### PR TITLE
Develop -> master - MAT-16 - move `doctrine:ensure-prod` later

### DIFF
--- a/deploy/secrets_entrypoint_tasks.sh
+++ b/deploy/secrets_entrypoint_tasks.sh
@@ -12,11 +12,10 @@ fi
 # Load the S3 secrets file contents into the environment variables
 export $(aws s3 cp s3://${SECRETS_BUCKET_NAME}/secrets - | grep -v '^#' | xargs)
 
-composer doctrine:ensure-prod
-
 echo "Running migrations before start if necessary..."
 composer doctrine:migrate
 composer doctrine:generate-proxies
+composer doctrine:ensure-prod
 
 echo "Starting task..."
 # Call the normal CLI entry-point script, passing on script name and any other arguments

--- a/deploy/secrets_entrypoint_web.sh
+++ b/deploy/secrets_entrypoint_web.sh
@@ -12,8 +12,6 @@ fi
 # Load the S3 secrets file contents into the environment variables
 export $(aws s3 cp s3://${SECRETS_BUCKET_NAME}/secrets - | grep -v '^#' | xargs)
 
-composer doctrine:ensure-prod
-
 # This is a bit hack-y because on a deploy that includes a new migration, several containers may be in
 # a race to try to run it. However because migrations are versioned and run transactionally, and we
 # call Doctrine with `--allow-no-migration`, it *should* be safe and subsequent instances' attempts to
@@ -21,6 +19,7 @@ composer doctrine:ensure-prod
 echo "Running migrations before start if necessary..."
 composer doctrine:migrate
 composer doctrine:generate-proxies
+composer doctrine:ensure-prod
 
 echo "Starting Apache..."
 # Call the normal web server entry-point script


### PR DESCRIPTION
In its original position it seemed to be unhappy in the case where the DB was not yet bootstrapped
from the first migrate run