### PR TITLE
Develop -> master - Revert "MAT-16 - move `doctrine:ensure-prod` later"

### DIFF
--- a/deploy/secrets_entrypoint_tasks.sh
+++ b/deploy/secrets_entrypoint_tasks.sh
@@ -12,10 +12,11 @@ fi
 # Load the S3 secrets file contents into the environment variables
 export $(aws s3 cp s3://${SECRETS_BUCKET_NAME}/secrets - | grep -v '^#' | xargs)
 
+composer doctrine:ensure-prod
+
 echo "Running migrations before start if necessary..."
 composer doctrine:migrate
 composer doctrine:generate-proxies
-composer doctrine:ensure-prod
 
 echo "Starting task..."
 # Call the normal CLI entry-point script, passing on script name and any other arguments

--- a/deploy/secrets_entrypoint_web.sh
+++ b/deploy/secrets_entrypoint_web.sh
@@ -12,6 +12,8 @@ fi
 # Load the S3 secrets file contents into the environment variables
 export $(aws s3 cp s3://${SECRETS_BUCKET_NAME}/secrets - | grep -v '^#' | xargs)
 
+composer doctrine:ensure-prod
+
 # This is a bit hack-y because on a deploy that includes a new migration, several containers may be in
 # a race to try to run it. However because migrations are versioned and run transactionally, and we
 # call Doctrine with `--allow-no-migration`, it *should* be safe and subsequent instances' attempts to
@@ -19,7 +21,6 @@ export $(aws s3 cp s3://${SECRETS_BUCKET_NAME}/secrets - | grep -v '^#' | xargs)
 echo "Running migrations before start if necessary..."
 composer doctrine:migrate
 composer doctrine:generate-proxies
-composer doctrine:ensure-prod
 
 echo "Starting Apache..."
 # Call the normal web server entry-point script


### PR DESCRIPTION
This reverts commit 888d7a05

This was a red herring - the issue was a missing piece of config allowing ECS containers to read the
configuration secrets. Putting this back where it was should mean we catch any misconfigurations
earlier.