### PR TITLE
MAT-15 - error resilience + smarter Salesforce push options

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 APP_DEBUG=1
 APP_ENV=local
 
+# Turn off sending proxy updates to Salesforce
+DISABLE_CLIENT_PUSH=0
+
 # Remember to never let any personal data into your local DB!
 MYSQL_HOST=db
 MYSQL_USER=root

--- a/src/Client/Common.php
+++ b/src/Client/Common.php
@@ -14,6 +14,7 @@ abstract class Common
 
     /** @var Client */
     private $httpClient;
+
     /** @var LoggerInterface */
     protected $logger;
 

--- a/src/Client/Donation.php
+++ b/src/Client/Donation.php
@@ -16,6 +16,11 @@ class Donation extends Common
      */
     public function create(DonationModel $donation): string
     {
+        if (getenv('DISABLE_CLIENT_PUSH')) {
+            $this->logger->info("Client push off: Skipping create of donation {$donation->getUUid()}");
+            throw new BadRequestException('Client push is off');
+        }
+
         try {
             $response = $this->getHttpClient()->post(
                 $this->getSetting('donation', 'baseUri'),
@@ -48,6 +53,12 @@ class Donation extends Common
      */
     public function put(DonationModel $donation): bool
     {
+        if (getenv('DISABLE_CLIENT_PUSH')) {
+            $this->logger->info("Client push off: Skipping update of donation {$donation->getUUid()}");
+
+            return false;
+        }
+
         try {
             $response = $this->getHttpClient()->put(
                 $this->getSetting('webhook', 'baseUri') . "/donation/{$donation->getSalesforceId()}",

--- a/src/Domain/DonationRepository.php
+++ b/src/Domain/DonationRepository.php
@@ -342,6 +342,10 @@ class DonationRepository extends SalesforceWriteProxyRepository
                 $done = true;
             } catch (RetryableException $exception) {
                 $this->getEntityManager()->rollback();
+                $this->logInfo(
+                    "Doctrine flush got a retryable error on attempt #$tries - " .
+                    get_class($exception) . " {$exception->getMessage()}"
+                );
                 usleep(random_int(0, 200000)); // Wait between 0 and 0.2 seconds before retrying
                 // Carry on to next loop cycle if retryable, unless we're out of tries
             } // Any other exception is left uncaught


### PR DESCRIPTION
* Implement Doctrine retries for non-realtime pieces: The 2 failures in the most recent load test were 1 on each of the two `flush()` calls migrated here. With this happening in rare edge cases it should be safe - and prudent - to retry after this type of error.
* Rationalise attempts to update push proxies not yet created successfully
* Add a feature flag to skip pushing donations to Salesforce