### PR TITLE
MAT-22 - add tip support

### DIFF
--- a/src/Application/Actions/Hooks/DonationUpdate.php
+++ b/src/Application/Actions/Hooks/DonationUpdate.php
@@ -92,6 +92,10 @@ class DonationUpdate extends Action
         $donation->setTbgComms($donationData->optInTbgEmail);
         $donation->setTransactionId($donationData->transactionId);
 
+        if ($donationData->tipAmount > 0) {
+            $donation->setTipAmount((string) $donationData->tipAmount);
+        }
+
         $this->entityManager->persist($donation);
 
         // We log if this fails but don't worry the webhook-sending payment client

--- a/src/Application/HttpModels/Donation.php
+++ b/src/Application/HttpModels/Donation.php
@@ -47,4 +47,7 @@ class Donation
 
     /** @var string */
     public $projectId;
+
+    /** @var float */
+    public $tipAmount;
 }

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -127,6 +127,12 @@ class Donation extends SalesforceWriteProxy
     protected $donorPostalAddress;
 
     /**
+     * @ORM\Column(type="decimal", precision=18, scale=2, options={"default": "0.00"})
+     * @var string  Amount donor chose to tip. Precision numeric string. Set on Charity Checkout callback
+     */
+    protected $tipAmount = '0.00';
+
+    /**
      * @ORM\OneToMany(targetEntity="FundingWithdrawal", mappedBy="donation", fetch="EAGER")
      * @var ArrayCollection|FundingWithdrawal[]
      */
@@ -215,6 +221,7 @@ class Donation extends SalesforceWriteProxy
             $data['lastName'] = $this->getDonorLastName();
             $data['transactionId'] = $this->getTransactionId();
             $data['matchedAmount'] = $this->isSuccessful() ? (float) $this->getFundingWithdrawalTotal() : 0;
+            $data['tipAmount'] = (float) $this->getTipAmount();
         }
 
         return $data;
@@ -448,5 +455,21 @@ class Donation extends SalesforceWriteProxy
     public function setDonorCountryCode(string $donorCountryCode): void
     {
         $this->donorCountryCode = $donorCountryCode;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTipAmount(): string
+    {
+        return $this->tipAmount;
+    }
+
+    /**
+     * @param string $tipAmount
+     */
+    public function setTipAmount(string $tipAmount): void
+    {
+        $this->tipAmount = $tipAmount;
     }
 }

--- a/src/Migrations/Version20191119154404.php
+++ b/src/Migrations/Version20191119154404.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Add Donation.tipAmount
+ */
+final class Version20191119154404 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return 'Add Donation.tipAmount';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql("ALTER TABLE Donation ADD tipAmount NUMERIC(18, 2) DEFAULT '0.00' NOT NULL");
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE Donation DROP tipAmount');
+    }
+}


### PR DESCRIPTION
* MAT-23 - add field to the Donation domain model and migrate the schema
* MAT-24 - support receiving the value in webhook and persist it
* MAT-25 - return field in GETs by including it in `Donation::toApiModel()`
* MAT-26 - send field from Salesforce client due to same change, as `toHookModel()` starts with the API model