### PR TITLE
MAT-30 - fund update fixes + inline docs

### DIFF
--- a/src/Domain/CampaignFundingRepository.php
+++ b/src/Domain/CampaignFundingRepository.php
@@ -13,6 +13,15 @@ class CampaignFundingRepository extends EntityRepository
     /**
      * Get available-for-allocation `CampaignFunding`s, without a lock.
      *
+     * Ordering is well-defined as far being champion funds first (currently given allocationOrder=100) then pledges
+     * (given allocationOrder=200). The more specific ordering is arbitrary, determined by the order funds were first
+     * read from the Salesforce implementation's API. This doesn't matter in effect because the allocations can't
+     * mirror the reality of what happens after a campaign if not all pledges are used, which varies per charity. In
+     * the case of pro-rata'ing the amount from each pledger, MatchBot's allocations cannot accurately reflect the
+     * amount due at the end. It would not be feasible to track these proportional amounts during the allocation phase
+     * because we would have to split amounts up constantly and it would break the decimal strings,
+     * no-floating-point-maths approach we've taken to ensure accuracy.
+     *
      * @param Campaign $campaign
      * @return CampaignFunding[]    Sorted in the order funds should be allocated
      * @throws \Doctrine\ORM\TransactionRequiredException if called this outside a surrounding transaction


### PR DESCRIPTION
* MAT-30 - fix unexpected CampaignFunding available amount resets
* MAT-30 - fix crashes if we get unexpected `null` fund amounts
* Explain what's going on with defined and arbitrary allocation orders