### PR TITLE
MAT-36 - fix Salesforce-pushed donation data

### DIFF
--- a/src/Application/Commands/ExpireMatchFunds.php
+++ b/src/Application/Commands/ExpireMatchFunds.php
@@ -37,7 +37,6 @@ class ExpireMatchFunds extends LockingCommand
 
         foreach ($toRelease as $donation) {
             $this->donationRepository->releaseMatchFunds($donation);
-            $this->donationRepository->push($donation, false);
         }
 
         $numberExpired = count($toRelease);

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -424,6 +424,10 @@ class Donation extends SalesforceWriteProxy
      */
     public function getConfirmedChampionWithdrawalTotal(): string
     {
+        if (!$this->isSuccessful()) {
+            return '0.0';
+        }
+
         $withdrawalTotal = '0.0';
         foreach ($this->fundingWithdrawals as $fundingWithdrawal) {
             // Rely on Doctrine `SINGLE_TABLE` inheritance structure to derive the type from the concrete class.


### PR DESCRIPTION
* Fix champion match amounts being sent to Salesforce in reserved contexts instead of only when confirmed
* Don't push Pending donations to Salesforce after expiry, as this provides no new information and currently crashes the webhook receiver