### PR TITLE
MAT-43 - add a task to retrospectively match donations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,7 @@
         "lint:fix": "phpcbf --standard=phpcs.xml -s .",
         "matchbot:expire-match-funds": "php matchbot-cli.php matchbot:expire-match-funds",
         "matchbot:push-donations": "php matchbot-cli.php matchbot:push-donations",
+        "matchbot:retrospectively-match": "php matchbot-cli.php matchbot:retrospectively-match",
         "matchbot:update-campaigns": "php matchbot-cli.php matchbot:update-campaigns",
         "start": "php -S localhost:8080 -t public",
         "test": "phpunit"

--- a/matchbot-cli.php
+++ b/matchbot-cli.php
@@ -6,6 +6,7 @@ $psr11App = require __DIR__ . '/bootstrap.php';
 
 use MatchBot\Application\Commands\ExpireMatchFunds;
 use MatchBot\Application\Commands\PushDonations;
+use MatchBot\Application\Commands\RetrospectivelyMatch;
 use MatchBot\Application\Commands\UpdateCampaigns;
 use MatchBot\Domain\CampaignRepository;
 use MatchBot\Domain\DonationRepository;
@@ -18,6 +19,7 @@ $cliApp = new Application();
 $commands = [
     new ExpireMatchFunds($psr11App->get(DonationRepository::class)),
     new PushDonations($psr11App->get(DonationRepository::class)),
+    new RetrospectivelyMatch($psr11App->get(DonationRepository::class)),
     new UpdateCampaigns($psr11App->get(CampaignRepository::class), $psr11App->get(FundRepository::class)),
 ];
 foreach ($commands as $command) {

--- a/src/Application/Commands/RetrospectivelyMatch.php
+++ b/src/Application/Commands/RetrospectivelyMatch.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Application\Commands;
+
+use MatchBot\Domain\DonationRepository;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Find complete donations to matched campaigns with less matching than their full value, from the past 48 hours,
+ * and allocate any newly-available match funds to them.
+ */
+class RetrospectivelyMatch extends LockingCommand
+{
+    protected static $defaultName = 'matchbot:retrospectively-match';
+
+    /** @var DonationRepository */
+    private $donationRepository;
+
+    public function __construct(DonationRepository $donationRepository)
+    {
+        $this->donationRepository = $donationRepository;
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription(
+            "Allocates matching from the last 48 hours' donations if they missed it due to pending reservations"
+        );
+    }
+
+    protected function doExecute(OutputInterface $output)
+    {
+        $toCheckForMatching = $this->donationRepository->findRecentNotFullyMatchedToMatchCampaigns();
+        $numChecked = count($toCheckForMatching);
+        $distinctCampaignIds = [];
+        $numWithMatchingAllocated = 0;
+        $totalNewMatching = '0.00';
+
+        foreach ($toCheckForMatching as $donation) {
+            $amountAllocated = $this->donationRepository->allocateMatchFunds($donation);
+
+            if (bccomp($amountAllocated, '0.00', 2) === 1) {
+                $this->donationRepository->push($donation, false);
+                $numWithMatchingAllocated++;
+                $totalNewMatching = bcadd($totalNewMatching, $amountAllocated, 2);
+
+                if (!in_array($donation->getCampaign()->getId(), $distinctCampaignIds, true)) {
+                    $distinctCampaignIds[] = $donation->getCampaign()->getId();
+                }
+            }
+        }
+
+        $numDistinctCampaigns = count($distinctCampaignIds);
+
+        $output->writeln(
+            "Retrospectively matched $numWithMatchingAllocated of $numChecked donations. " .
+            "£$totalNewMatching total new matching, across $numDistinctCampaigns campaigns."
+        );
+    }
+}

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -42,7 +42,7 @@ class Donation extends SalesforceWriteProxy
 
     private $newStatuses = ['NotSet', 'Pending'];
 
-    private $successStatuses = ['Collected', 'Paid'];
+    private static $successStatuses = ['Collected', 'Paid'];
 
     /**
      * The donation ID for Charity Checkout and public APIs. Not the same as the internal auto-increment $id used
@@ -238,7 +238,7 @@ class Donation extends SalesforceWriteProxy
      */
     public function isSuccessful(): bool
     {
-        return in_array($this->donationStatus, $this->successStatuses, true);
+        return in_array($this->donationStatus, self::$successStatuses, true);
     }
 
     /**
@@ -524,5 +524,13 @@ class Donation extends SalesforceWriteProxy
     public function hasPostCreateUpdates(): bool
     {
         return !in_array($this->getDonationStatus(), $this->newStatuses, true);
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getSuccessStatuses(): array
+    {
+        return self::$successStatuses;
     }
 }


### PR DESCRIPTION
Looks for:
* any donation in the past 48 hours when the task runs
* to a matched campaign
* with no funding withdrawals or a total less than the donation total

And then attempts matching allocation following the standard logic, which now accounts for any existing withdrawals for the donation.