### PR TITLE
MAT-50, MAT-46 - validation fixes

### DIFF
--- a/src/Application/Actions/Donations/Create.php
+++ b/src/Application/Actions/Donations/Create.php
@@ -42,6 +42,7 @@ class Create extends Action
 
     /**
      * @return Response
+     * @throws \MatchBot\Application\Matching\TerminalLockException if the matching adapter can't allocate funds
      */
     protected function action(): Response
     {
@@ -67,7 +68,8 @@ class Create extends Action
         } catch (\UnexpectedValueException $exception) {
             $message = 'Donation Create data initial model load';
             $this->logger->warning($message . ': ' . $exception->getMessage());
-            $error = new ActionError(ActionError::BAD_REQUEST, $message);
+            $this->logger->info("Donation Create model load failure payload was: {$this->request->getBody()}");
+            $error = new ActionError(ActionError::BAD_REQUEST, $exception->getMessage());
 
             return $this->respond(new ActionPayload(400, null, $error));
         }

--- a/src/Application/Actions/Donations/Create.php
+++ b/src/Application/Actions/Donations/Create.php
@@ -85,15 +85,14 @@ class Create extends Action
         $this->entityManager->persist($donation);
         $this->entityManager->flush();
 
-        try {
-            if ($donation->getCampaign()->isMatched()) {
-                // This implicitly calls @prePersist on the Donation, so is part of the try{...}
+        if ($donation->getCampaign()->isMatched()) {
+            try {
                 $this->donationRepository->allocateMatchFunds($donation);
-            }
-        } catch (DomainLockContentionException $exception) {
-            $error = new ActionError(ActionError::SERVER_ERROR, 'Fund resource locked');
+            } catch (DomainLockContentionException $exception) {
+                $error = new ActionError(ActionError::SERVER_ERROR, 'Fund resource locked');
 
-            return $this->respond(new ActionPayload(503, null, $error));
+                return $this->respond(new ActionPayload(503, null, $error));
+            }
         }
 
         $response = new DonationCreatedResponse();

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -146,20 +146,6 @@ class Donation extends SalesforceWriteProxy
     }
 
     /**
-     * @ORM\PrePersist Check that the amount is in the permitted range
-     */
-    public function prePersist(): void
-    {
-        // Decimal-safe check that amount if in the allowed range
-        if (
-            bccomp($this->amount, (string) $this->minimumAmount, 2) === -1 ||
-            bccomp($this->amount, (string) $this->maximumAmount, 2) === 1
-        ) {
-            throw new \UnexpectedValueException("Amount must be £{$this->minimumAmount}-{$this->maximumAmount}");
-        }
-    }
-
-    /**
      * @ORM\PreUpdate Check that the amount is never changed
      * @param PreUpdateEventArgs $args
      * @throws \LogicException if amount is changed
@@ -390,6 +376,13 @@ class Donation extends SalesforceWriteProxy
      */
     public function setAmount(string $amount): void
     {
+        if (
+            bccomp($amount, (string) $this->minimumAmount, 2) === -1 ||
+            bccomp($amount, (string) $this->maximumAmount, 2) === 1
+        ) {
+            throw new \UnexpectedValueException("Amount must be £{$this->minimumAmount}-{$this->maximumAmount}");
+        }
+
         $this->amount = $amount;
     }
 

--- a/src/Domain/DonationRepository.php
+++ b/src/Domain/DonationRepository.php
@@ -58,8 +58,17 @@ class DonationRepository extends SalesforceWriteProxyRepository
         return $this->getClient()->put($donation);
     }
 
+    /**
+     * @param DonationCreate $donationData
+     * @return Donation
+     * @throws \UnexpectedValueException if inputs invalid, including projectId being unrecognised
+     */
     public function buildFromApiRequest(DonationCreate $donationData): Donation
     {
+        if (!isset($donationData->giftAid, $donationData->optInCharityEmail, $donationData->optInTbgEmail)) {
+            throw new \UnexpectedValueException('Required boolean fields not set');
+        }
+
         /** @var Campaign $campaign */
         $campaign = $this->campaignRepository->findOneBy(['salesforceId' => $donationData->projectId]);
 

--- a/tests/Domain/DonationTest.php
+++ b/tests/Domain/DonationTest.php
@@ -23,12 +23,8 @@ class DonationTest extends TestCase
     {
         $donation = new Donation();
         $donation->setAmount('100.00');
-        // Invoking real Doctrine events but with a fake driver, for isolated unit testing, is
-        // both complex and not very valuable, so for now we just manually pretend the object is
-        // about to be persisted rather than bootstrapping a whole fake EntityManager.
-        $donation->prePersist();
 
-        $this->addToAssertionCount(1); // Just check persist doesn't hit lifecycle hook exceptions
+        $this->addToAssertionCount(1); // Just check setAmount() doesn't hit an exception
     }
 
     public function testAmountTooLowNotPersisted(): void
@@ -38,7 +34,6 @@ class DonationTest extends TestCase
 
         $donation = new Donation();
         $donation->setAmount('4.99');
-        $donation->prePersist();
     }
 
     public function testAmountTooHighNotPersisted(): void
@@ -48,6 +43,5 @@ class DonationTest extends TestCase
 
         $donation = new Donation();
         $donation->setAmount('25000.01');
-        $donation->prePersist();
     }
 }


### PR DESCRIPTION
* MAT-50 - only allocate match funds after a Donation is persisted successfully - this should fix edge cases where funds' totals can get out of sync with donation allocations
* MAT-50 - do amount validation inside `setAmount()` and simplify surrounding validation logic
* MAT-50 - add logs; make validation error output more helpful
* MAT-46 - return 400 Bad Request if any of the 3 donation init boolean fields are missing or null