### PR TITLE
Rename & separate out Composer check/fix commands

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,9 +69,13 @@
             "Composer\\Config::disableProcessTimeout",
             "php matchbot-cli.php matchbot:expire-match-funds"
         ],
+        "matchbot:check-out-of-sync-funds": [
+          "Composer\\Config::disableProcessTimeout",
+          "php matchbot-cli.php matchbot:matchbot:handle-out-of-sync-funds check"
+        ],
         "matchbot:fix-out-of-sync-funds": [
             "Composer\\Config::disableProcessTimeout",
-            "php matchbot-cli.php matchbot:fix-out-of-sync-funds"
+            "php matchbot-cli.php matchbot:matchbot:handle-out-of-sync-funds fix"
         ],
         "matchbot:push-donations": "php matchbot-cli.php matchbot:push-donations",
         "matchbot:retrospectively-match": [

--- a/matchbot-cli.php
+++ b/matchbot-cli.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 $psr11App = require __DIR__ . '/bootstrap.php';
 
 use MatchBot\Application\Commands\ExpireMatchFunds;
-use MatchBot\Application\Commands\FixOutOfSyncFunds;
+use MatchBot\Application\Commands\HandleOutOfSyncFunds;
 use MatchBot\Application\Commands\PushDonations;
 use MatchBot\Application\Commands\RetrospectivelyMatch;
 use MatchBot\Application\Commands\UpdateCampaigns;
@@ -22,7 +22,7 @@ $cliApp = new Application();
 
 $commands = [
     new ExpireMatchFunds($psr11App->get(DonationRepository::class)),
-    new FixOutOfSyncFunds(
+    new HandleOutOfSyncFunds(
         $psr11App->get(CampaignFundingRepository::class),
         $psr11App->get(FundingWithdrawalRepository::class),
         $psr11App->get(Matching\Adapter::class)

--- a/src/Application/Commands/HandleOutOfSyncFunds.php
+++ b/src/Application/Commands/HandleOutOfSyncFunds.php
@@ -26,9 +26,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  *  3. you expect donations to be at a low volume when you run this, reducing the risk of things
  *     getting back out of sync because of donations coming in while it runs
  */
-class FixOutOfSyncFunds extends LockingCommand
+class HandleOutOfSyncFunds extends LockingCommand
 {
-    protected static $defaultName = 'matchbot:fix-out-of-sync-funds';
+    protected static $defaultName = 'matchbot:handle-out-of-sync-funds';
 
     /** @var CampaignFundingRepository */
     private $campaignFundingRepository;


### PR DESCRIPTION
Reduce risk of running the wrong one mistakenly