### PR TITLE
Sync command tweaks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,11 +71,11 @@
         ],
         "matchbot:check-out-of-sync-funds": [
           "Composer\\Config::disableProcessTimeout",
-          "php matchbot-cli.php matchbot:matchbot:handle-out-of-sync-funds check"
+          "php matchbot-cli.php matchbot:handle-out-of-sync-funds check"
         ],
         "matchbot:fix-out-of-sync-funds": [
             "Composer\\Config::disableProcessTimeout",
-            "php matchbot-cli.php matchbot:matchbot:handle-out-of-sync-funds fix"
+            "php matchbot-cli.php matchbot:handle-out-of-sync-funds fix"
         ],
         "matchbot:push-donations": "php matchbot-cli.php matchbot:push-donations",
         "matchbot:retrospectively-match": [

--- a/src/Application/Commands/HandleOutOfSyncFunds.php
+++ b/src/Application/Commands/HandleOutOfSyncFunds.php
@@ -84,7 +84,8 @@ class HandleOutOfSyncFunds extends LockingCommand
             /** @var CampaignFunding $funding */
 
             // Amount allocated from the CampaignFunding
-            $campaignFundingAllocated = bcsub($funding->getAmount(), $funding->getAmountAvailable(), 2);
+            $fundingAvailable = $this->matchingAdapter->getAmountAvailable($funding);
+            $campaignFundingAllocated = bcsub($funding->getAmount(), $fundingAvailable, 2);
 
             // Get the sum of all FundingWithdrawals for donations, whether complete or active reservations.
             $fundingWithdrawalTotal = $this->fundingWithdrawalRepository->getWithdrawalsTotal($funding);

--- a/src/Application/Matching/Adapter.php
+++ b/src/Application/Matching/Adapter.php
@@ -12,6 +12,18 @@ abstract class Adapter
     private $inTransaction = false;
 
     /**
+     * Get a snapshot of the amount of match funds available in the given `$funding`. This should not be used to start
+     * allocation maths except in emergencies where things appear to have got out of sync, because there is no
+     * guarantee with this function that another thread will not reserve or release funds before you have finished
+     * your work. You should instead use `addAmount()` and `subtractAmount()` which are built to work atomically or
+     * transactionally so that they are safe for high-volume, multi-thread use.
+     *
+     * @param CampaignFunding $funding
+     * @return string Amount available as bcmath-ready decimal string
+     */
+    abstract public function getAmountAvailable(CampaignFunding $funding): string;
+
+    /**
      * @param callable $function
      * @return mixed The given `$function`'s return value
      */

--- a/src/Application/Matching/LockingRedisAdapter.php
+++ b/src/Application/Matching/LockingRedisAdapter.php
@@ -47,6 +47,13 @@ class LockingRedisAdapter extends Adapter
         return $result;
     }
 
+    public function getAmountAvailable(CampaignFunding $funding): string
+    {
+        $fundBalanceInPence = $this->redis->get($this->buildKey($funding)) ?: 0;
+
+        return (string) ($fundBalanceInPence / 100);
+    }
+
     private function setAmount(CampaignFunding $funding, string $amount): bool
     {
         $setResult = $this->redis->set($this->buildKey($funding), $amount);

--- a/src/Application/Matching/OptimisticRedisAdapter.php
+++ b/src/Application/Matching/OptimisticRedisAdapter.php
@@ -40,6 +40,13 @@ class OptimisticRedisAdapter extends Adapter
         return $result;
     }
 
+    public function getAmountAvailable(CampaignFunding $funding): string
+    {
+        $fundBalanceInPence = $this->redis->get($this->buildKey($funding)) ?: 0;
+
+        return (string) ($fundBalanceInPence / 100);
+    }
+
     protected function doSubtractAmount(CampaignFunding $funding, string $amount): string
     {
         $decrementInPence = (int) (((float) $amount) * 100);


### PR DESCRIPTION
* `getAmountAvailable()` based on the live matching adapter, not always the DB copy: When using either Redis adapter, this should reduce the frequency with which the sync commands report spurious mis-matches because new data hasn't finished being persisted to the database.
* Fix typo in updated sync Composer commands