### PR TITLE
MAT-59 - add validation for missing `status` on cancellation

### DIFF
--- a/src/Application/Actions/Donations/Cancel.php
+++ b/src/Application/Actions/Donations/Cancel.php
@@ -55,6 +55,15 @@ class Cancel extends Action
             'json'
         );
 
+        if (!isset($donationData->status)) {
+            $this->logger->warning(
+                "Donation ID {$this->args['donationId']} could not be updated with missing status"
+            );
+            $error = new ActionError(ActionError::BAD_REQUEST, 'New status is required');
+
+            return $this->respond(new ActionPayload(400, null, $error));
+        }
+
         if ($donationData->status !== 'Cancelled') {
             $this->logger->warning(
                 "Donation ID {$this->args['donationId']} could not be set to status {$donationData->status}"


### PR DESCRIPTION
Stricter handling at the Action level should fix this crashing with the new HTTP model type constraints.
This PR also adds a unit test for this invalid data case and adds a much better, more realistic happy path
test case for valid cancellations.