### PR TITLE
MAT-77 – fix result cache handling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,11 @@
         }
     },
     "scripts": {
-        "doctrine:cache:clear": "doctrine orm:clear-cache:metadata",
+        "doctrine:cache:clear": [
+            "doctrine orm:clear-cache:metadata",
+            "doctrine orm:clear-cache:query",
+            "doctrine orm:clear-cache:result"
+        ],
         "doctrine:delete-and-recreate": [
             "doctrine orm:schema-tool:drop --force",
             "doctrine orm:schema-tool:create",

--- a/matchbot-cli.php
+++ b/matchbot-cli.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 $psr11App = require __DIR__ . '/bootstrap.php';
 
+use Doctrine\ORM\EntityManagerInterface;
 use MatchBot\Application\Commands\ExpireMatchFunds;
 use MatchBot\Application\Commands\HandleOutOfSyncFunds;
 use MatchBot\Application\Commands\PushDonations;
@@ -29,7 +30,11 @@ $commands = [
     ),
     new PushDonations($psr11App->get(DonationRepository::class)),
     new RetrospectivelyMatch($psr11App->get(DonationRepository::class)),
-    new UpdateCampaigns($psr11App->get(CampaignRepository::class), $psr11App->get(FundRepository::class)),
+    new UpdateCampaigns(
+        $psr11App->get(CampaignRepository::class),
+        $psr11App->get(EntityManagerInterface::class),
+        $psr11App->get(FundRepository::class),
+    ),
 ];
 foreach ($commands as $command) {
     $command->setLockFactory($psr11App->get(LockFactory::class));

--- a/src/Application/Commands/UpdateCampaigns.php
+++ b/src/Application/Commands/UpdateCampaigns.php
@@ -27,8 +27,7 @@ class UpdateCampaigns extends LockingCommand
         CampaignRepository $campaignRepository,
         EntityManagerInterface $entityManager,
         FundRepository $fundRepository
-    )
-    {
+    ) {
         $this->campaignRepository = $campaignRepository;
         $this->entityManager = $entityManager;
         $this->fundRepository = $fundRepository;

--- a/src/Domain/DonationRepository.php
+++ b/src/Domain/DonationRepository.php
@@ -282,7 +282,13 @@ class DonationRepository extends SalesforceWriteProxyRepository
             ->setParameter('expireWithStatus', 'Pending')
             ->setParameter('expireBefore', $cutoff);
 
-        return $qb->getQuery()->getResult();
+        // As this is used by the only regular task working with donations,
+        // `ExpireMatchFunds`, it makes more sense to opt it out of query caching
+        // here rather than take the performance hit of a full query cache clear
+        // after every single persisted donation.
+        return $qb->getQuery()
+            ->disableResultCache()
+            ->getResult();
     }
 
     /**
@@ -304,7 +310,12 @@ class DonationRepository extends SalesforceWriteProxyRepository
             ->setParameter('campaignMatched', true)
             ->setParameter('checkAfter', $sinceDate);
 
-        return $qb->getQuery()->getResult();
+        // Result caching rationale as per `findWithExpiredMatching()`, except this is
+        // currently used only in the rarer case of manually invoking
+        // `RetrospectivelyMatch`.
+        return $qb->getQuery()
+            ->disableResultCache()
+            ->getResult();
     }
 
     /**

--- a/tests/Application/Commands/UpdateCampaignsTest.php
+++ b/tests/Application/Commands/UpdateCampaignsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MatchBot\Tests\Application\Commands;
 
+use Doctrine\ORM\EntityManagerInterface;
 use MatchBot\Application\Commands\UpdateCampaigns;
 use MatchBot\Client\NotFoundException;
 use MatchBot\Domain\Campaign;
@@ -28,7 +29,11 @@ class UpdateCampaignsTest extends TestCase
         $fundRepoProphecy = $this->prophesize(FundRepository::class);
         $fundRepoProphecy->pullForCampaign($campaign)->shouldbeCalledOnce();
 
-        $command = new UpdateCampaigns($campaignRepoPropehcy->reveal(), $fundRepoProphecy->reveal());
+        $command = new UpdateCampaigns(
+            $campaignRepoPropehcy->reveal(),
+            $this->getAppInstance()->getContainer()->get(EntityManagerInterface::class),
+            $fundRepoProphecy->reveal(),
+        );
         $command->setLockFactory(new LockFactory(new AlwaysAvailableLockStore()));
 
         $commandTester = new CommandTester($command);
@@ -58,7 +63,11 @@ class UpdateCampaignsTest extends TestCase
         $fundRepoProphecy = $this->prophesize(FundRepository::class);
         $fundRepoProphecy->pullForCampaign($campaign)->shouldNotBeCalled(); // Exception reached before this call
 
-        $command = new UpdateCampaigns($campaignRepoPropehcy->reveal(), $fundRepoProphecy->reveal());
+        $command = new UpdateCampaigns(
+            $campaignRepoPropehcy->reveal(),
+            $this->getAppInstance()->getContainer()->get(EntityManagerInterface::class),
+            $fundRepoProphecy->reveal(),
+        );
         $command->setLockFactory(new LockFactory(new AlwaysAvailableLockStore()));
 
         $commandTester = new CommandTester($command);


### PR DESCRIPTION
* clear result cache after creating/updating campaigns, en masse or individually
* skip the result cache for multi-donation lookups
* clear all 3 Doctrine caches on startup
