### PR TITLE
MAT-84 - add Stripe Payment Intent setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,8 @@ MYSQL_PORT=3306
 
 REDIS_HOST=redis
 
+STRIPE_SECRET_KEY=sk_test_yourKeyHere
+
 BASE_URI=http://localhost:30030
 # Must match the Salesforce secret for the corresponding environment
 WEBHOOK_DONATION_SECRET=myLocalHookSecret

--- a/app/dependencies.php
+++ b/app/dependencies.php
@@ -19,6 +19,7 @@ use Monolog\Logger;
 use Monolog\Processor\UidProcessor;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use Stripe\StripeClient;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\Store\PdoStore;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
@@ -156,6 +157,13 @@ return function (ContainerBuilder $containerBuilder) {
             $normalizers = [new ObjectNormalizer()];
 
             return new Serializer($normalizers, $encoders);
-        }
+        },
+
+        StripeClient::class => static function (ContainerInterface $c): StripeClient {
+            return new StripeClient([
+                'api_key' => $c->get('settings')['stripe']['apiKey'],
+                'stripe_version' => $c->get('settings')['stripe']['apiVersion'],
+            ]);
+        },
     ]);
 };

--- a/app/routes.php
+++ b/app/routes.php
@@ -16,7 +16,8 @@ return function (App $app) {
     $app->get('/ping', Status::class);
 
     $app->group('/v1', function (RouteCollectorProxy $versionGroup) {
-        // Currently the only unauthenticated endpoint besides `/ping`, and the only one in the `/v1` group.
+        // Currently the only unauthenticated endpoint besides `/ping` app-wide,
+        // and the only unauthenticated endpoint in the `/v1` group.
         $versionGroup->post('/donations', Donations\Create::class);
 
         $versionGroup->group('/donations/{donationId:[a-z0-9-]{36}}', function (RouteCollectorProxy $group) {

--- a/app/settings.php
+++ b/app/settings.php
@@ -66,7 +66,12 @@ return function (ContainerBuilder $containerBuilder) {
 
             'redis' => [
                 'host' => getenv('REDIS_HOST'),
-            ]
+            ],
+
+            'stripe' => [
+                'apiKey' => getenv('STRIPE_SECRET_KEY'),
+                'apiVersion' => '2020-03-02',
+            ],
         ],
     ]);
 };

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "ramsey/uuid-doctrine": "^1.6",
         "slim/psr7": "^1.0",
         "slim/slim": "^4.5",
+        "stripe/stripe-php": "^7.40",
         "symfony/console": "^5.0",
         "symfony/lock": "^5.0",
         "symfony/property-access": "^5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "670d92412c17dc14a0e814261db65697",
+    "content-hash": "704b8c7b9d2624d14c8b79e3ee557c33",
     "packages": [
         {
             "name": "brick/math",
@@ -2852,6 +2852,63 @@
                 }
             ],
             "time": "2020-04-14T20:49:48+00:00"
+        },
+        {
+            "name": "stripe/stripe-php",
+            "version": "v7.40.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/stripe/stripe-php.git",
+                "reference": "04aedea5ad95b9722aa394a41787751b2b478310"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/04aedea5ad95b9722aa394a41787751b2b478310",
+                "reference": "04aedea5ad95b9722aa394a41787751b2b478310",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "2.16.1",
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5.7",
+                "squizlabs/php_codesniffer": "^3.3",
+                "symfony/process": "~3.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Stripe\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Stripe and contributors",
+                    "homepage": "https://github.com/stripe/stripe-php/contributors"
+                }
+            ],
+            "description": "Stripe PHP Library",
+            "homepage": "https://stripe.com/",
+            "keywords": [
+                "api",
+                "payment processing",
+                "stripe"
+            ],
+            "time": "2020-07-06T17:51:30+00:00"
         },
         {
             "name": "symfony/console",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.4/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
     backupGlobals="false"
     backupStaticAttributes="false"
     beStrictAboutTestsThatDoNotTestAnything="true"
@@ -21,7 +21,10 @@
     </testsuites>
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src/</directory>
+            <directory suffix=".php">./src</directory>
+            <exclude>
+                <directory suffix=".php">./src/Migrations</directory>
+            </exclude>
         </whitelist>
     </filter>
     <php>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -29,6 +29,7 @@
         <env name="JWT_DONATION_SECRET" value="unitTestJWTSecret" force="true" />
         <env name="MYSQL_HOST" value="dummy-mysql-hostname" force="true" />
         <env name="REDIS_HOST" value="dummy-redis-hostname" force="true" />
+        <env name="STRIPE_SECRET_KEY" value="sk_test_unitTestFakeKey" force="true" />
         <env name="WEBHOOK_DONATION_SECRET" value="unitTestCchSecret" force="true" />
     </php>
 </phpunit>

--- a/src/Application/Actions/Donations/Create.php
+++ b/src/Application/Actions/Donations/Create.php
@@ -93,7 +93,10 @@ class Create extends Action
                     'currency' => 'gbp',
                 ]);
             } catch (ApiErrorException $exception) {
-                $this->logger->error('Stripe Payment Intent create error: ' . get_class($exception) . ': ' . $exception->getMessage());
+                $this->logger->error(
+                    'Stripe Payment Intent create error: ' .
+                    get_class($exception) . ': ' . $exception->getMessage()
+                );
                 $error = new ActionError(ActionError::SERVER_ERROR, 'Could not make Stripe Payment Intent');
                 return $this->respond(new ActionPayload(500, null, $error));
             }

--- a/src/Application/HttpModels/DonationCreate.php
+++ b/src/Application/HttpModels/DonationCreate.php
@@ -9,9 +9,11 @@ namespace MatchBot\Application\HttpModels;
  */
 class DonationCreate
 {
+    /** @var string In full pounds GBP */
     public string $donationAmount;
     public bool $giftAid;
     public bool $optInCharityEmail;
     public bool $optInTbgEmail;
     public string $projectId;
+    public string $psp;
 }

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -218,6 +218,7 @@ class Donation extends SalesforceWriteProxy
             'optInCharityEmail' => $this->getCharityComms(),
             'optInTbgEmail' => $this->getTbgComms(),
             'projectId' => $this->getCampaign()->getSalesforceId(),
+            'psp' => $this->getPsp(),
             'status' => $this->getDonationStatus(),
         ];
 

--- a/src/Domain/DonationRepository.php
+++ b/src/Domain/DonationRepository.php
@@ -98,6 +98,7 @@ class DonationRepository extends SalesforceWriteProxyRepository
         }
 
         $donation = new Donation();
+        $donation->setPsp($donationData->psp);
         $donation->setDonationStatus('Pending');
         $donation->setUuid((new UuidGenerator())->generate($this->getEntityManager(), $donation));
         $donation->setCampaign($campaign); // Charity & match expectation determined implicitly from this

--- a/src/Migrations/Version20200713104818.php
+++ b/src/Migrations/Version20200713104818.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Add fields to support multiple PSPs and Stripe PaymentIntent client secrets
+ */
+final class Version20200713104818 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return 'Add fields to support multiple PSPs and Stripe PaymentIntent client secrets';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        // Migration modified to first set up existing donations with
+        // psp = 'enthuse'
+        $this->addSql("ALTER TABLE Donation ADD psp VARCHAR(20) DEFAULT 'enthuse', ADD clientSecret VARCHAR(255) DEFAULT NULL");
+
+        // Once this change is done, remove the psp default and make psp
+        // non-nullable going forward.
+        $this->addSql('ALTER TABLE Donation CHANGE psp psp VARCHAR(20) NOT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE Donation DROP psp, DROP clientSecret');
+    }
+}

--- a/tests/Application/Actions/DonationTestDataTrait.php
+++ b/tests/Application/Actions/DonationTestDataTrait.php
@@ -33,6 +33,7 @@ trait DonationTestDataTrait
         $donation->setDonorLastName('Doe');
         $donation->setDonorPostalAddress('1 Main St, London N1 1AA');
         $donation->setGiftAid(true);
+        $donation->setPsp('enthuse');
         $donation->setTbgComms(false);
         $donation->setTransactionId('some-external-txn-id');
         $donation->setUuid(Uuid::fromString('12345678-1234-1234-1234-1234567890ab'));

--- a/tests/Application/Actions/Donations/CreateTest.php
+++ b/tests/Application/Actions/Donations/CreateTest.php
@@ -259,6 +259,7 @@ class CreateTest extends TestCase
         $donation->setCampaign($campaign);
         $donation->setCharityComms(false);
         $donation->setGiftAid(false);
+        $donation->setPsp('enthuse');
         $donation->setTbgComms(false);
         $donation->setUuid(Uuid::fromString('12345678-1234-1234-1234-1234567890ab'));
 

--- a/tests/Application/Actions/Donations/CreateTest.php
+++ b/tests/Application/Actions/Donations/CreateTest.php
@@ -17,6 +17,8 @@ use MatchBot\Domain\FundingWithdrawal;
 use MatchBot\Tests\TestCase;
 use Prophecy\Argument;
 use Ramsey\Uuid\Uuid;
+use Stripe\Service\PaymentIntentService;
+use Stripe\StripeClient;
 use UnexpectedValueException;
 
 class CreateTest extends TestCase
@@ -142,7 +144,7 @@ class CreateTest extends TestCase
         $this->assertEquals(503, $response->getStatusCode());
     }
 
-    public function testSuccessWithMatchedCampaign(): void
+    public function testSuccessWithMatchedCampaignUsingEnthuse(): void
     {
         $donation = $this->getTestDonation(true, true);
 
@@ -192,6 +194,85 @@ class CreateTest extends TestCase
         $this->assertEquals('567CharitySFID', $payloadArray['donation']['charityId']);
         $this->assertEquals('123CampaignId', $payloadArray['donation']['projectId']);
         $this->assertEquals('Pending', $payloadArray['donation']['status']);
+    }
+
+    public function testSuccessWithMatchedCampaignUsingStripe(): void
+    {
+        $donation = $this->getTestDonation(true, true);
+        $donation->setPsp('stripe');
+
+        $fundingWithdrawalForMatch = new FundingWithdrawal();
+        $fundingWithdrawalForMatch->setAmount('8.00'); // Partial match
+        $fundingWithdrawalForMatch->setDonation($donation);
+
+        $donationToReturn = $donation;
+        $donationToReturn->setDonationStatus('Pending');
+        $donationToReturn->addFundingWithdrawal($fundingWithdrawalForMatch);
+
+        $app = $this->getAppInstance();
+        /** @var Container $container */
+        $container = $app->getContainer();
+        $donationRepoProphecy = $this->prophesize(DonationRepository::class);
+        $donationRepoProphecy
+            ->buildFromApiRequest(Argument::type(DonationCreate::class))
+            ->willReturn($donationToReturn);
+        $donationRepoProphecy->push(Argument::type(Donation::class), true)->willReturn(true)->shouldBeCalledOnce();
+        $donationRepoProphecy->allocateMatchFunds(Argument::type(Donation::class))->shouldBeCalledOnce();
+
+        $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
+        $entityManagerProphecy->persist(Argument::type(Donation::class))->shouldBeCalledOnce();
+        $entityManagerProphecy->flush()->shouldBeCalledOnce();
+
+        $expectedPaymentIntentArgs = [
+            'amount' => 1200,
+            'currency' => 'gbp'
+        ];
+        // Most properites we don't use omitted.
+        // See https://stripe.com/docs/api/payment_intents/object
+        $paymentIntentMockResult = (object) [
+            'id' => 'pi_dummyIntent_id',
+            'object' => 'payment_intent',
+            'amount' => 1200,
+            'client_secret' => 'pi_dummySecret_123',
+            'confirmation_method' => 'automatic',
+            'currency' => 'gbp',
+        ];
+
+        $stripePaymentIntentsProphecy = $this->prophesize(PaymentIntentService::class);
+        $stripePaymentIntentsProphecy->create($expectedPaymentIntentArgs)
+            ->willReturn($paymentIntentMockResult)
+            ->shouldBeCalledOnce();
+
+        $stripeClientProphecy = $this->prophesize(StripeClient::class);
+        $stripeClientProphecy->paymentIntents = $stripePaymentIntentsProphecy->reveal();
+
+        $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
+        $container->set(EntityManagerInterface::class, $entityManagerProphecy->reveal());
+        $container->set(StripeClient::class, $stripeClientProphecy->reveal());
+
+        $data = json_encode($donation->toApiModel(true));
+        $request = $this->createRequest('POST', '/v1/donations', $data);
+        $response = $app->handle($request);
+
+        $payload = (string) $response->getBody();
+
+        $this->assertJson($payload);
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $payloadArray = json_decode($payload, true);
+
+        $this->assertIsString($payloadArray['jwt']);
+        $this->assertNotEmpty($payloadArray['jwt']);
+        $this->assertIsArray($payloadArray['donation']);
+        $this->assertFalse($payloadArray['donation']['giftAid']);
+        $this->assertEquals(12, $payloadArray['donation']['donationAmount']);
+        $this->assertEquals('12345678-1234-1234-1234-1234567890ab', $payloadArray['donation']['donationId']);
+        $this->assertEquals(8, $payloadArray['donation']['matchReservedAmount']);
+        $this->assertEquals('567CharitySFID', $payloadArray['donation']['charityId']);
+        $this->assertEquals('123CampaignId', $payloadArray['donation']['projectId']);
+        $this->assertEquals('Pending', $payloadArray['donation']['status']);
+        $this->assertEquals('stripe', $payloadArray['donation']['psp']);
+        $this->assertEquals('pi_dummySecret_123', $payloadArray['donation']['clientSecret']);
     }
 
     public function testSuccessWithUnmatchedCampaign(): void

--- a/tests/Domain/DonationTest.php
+++ b/tests/Domain/DonationTest.php
@@ -17,6 +17,7 @@ class DonationTest extends TestCase
         $this->assertEquals('not-sent', $donation->getSalesforcePushStatus());
         $this->assertNull($donation->getSalesforceLastPush());
         $this->assertNull($donation->getSalesforceId());
+        $this->assertNull($donation->getClientSecret());
     }
 
     public function testValidDataPersisted(): void
@@ -43,5 +44,22 @@ class DonationTest extends TestCase
 
         $donation = new Donation();
         $donation->setAmount('25000.01');
+    }
+
+    public function testInvalidPspRejected()
+    {
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage("Unexpected PSP 'paypal'");
+
+        $donation = new Donation();
+        $donation->setPsp('paypal');
+    }
+
+    public function testValidPspAccepted()
+    {
+        $donation = new Donation();
+        $donation->setPsp('enthuse');
+
+        $this->addToAssertionCount(1); // Just check setPsp() doesn't hit an exception
     }
 }


### PR DESCRIPTION
* set up Stripe library + service config
* introduce a required `psp` field for Donations and populate existing Donations' with 'enthuse'
* for 'stripe' Donations just created, make a Payment Intent, storing and returning the associated client secret