### PR TITLE
MAT-93 - calculate & send Stripe transfer data

### DIFF
--- a/src/Application/Actions/Donations/Create.php
+++ b/src/Application/Actions/Donations/Create.php
@@ -91,6 +91,11 @@ class Create extends Action
                     // See https://stripe.com/docs/api/payment_intents/object
                     'amount' => (100 * $donation->getAmount()),
                     'currency' => 'gbp',
+                    // See https://stripe.com/docs/connect/destination-charges
+                    'transfer_data' => [
+                        'amount' => (100 * $donation->getAmountForCharity()),
+                        'destination' => $donation->getCampaign()->getCharity()->getStripeAccountId(),
+                    ],
                 ]);
             } catch (ApiErrorException $exception) {
                 $this->logger->error(

--- a/tests/Application/Actions/Donations/CreateTest.php
+++ b/tests/Application/Actions/Donations/CreateTest.php
@@ -227,7 +227,11 @@ class CreateTest extends TestCase
 
         $expectedPaymentIntentArgs = [
             'amount' => 1200,
-            'currency' => 'gbp'
+            'currency' => 'gbp',
+            'transfer_data' => [
+                'amount' => 1166,
+                'destination' => 'unitTest_stripeAccount_123',
+            ],
         ];
         // Most properites we don't use omitted.
         // See https://stripe.com/docs/api/payment_intents/object
@@ -326,6 +330,7 @@ class CreateTest extends TestCase
         $charity = new Charity();
         $charity->setDonateLinkId('567CharitySFID');
         $charity->setName('Create test charity');
+        $charity->setStripeAccountId('unitTest_stripeAccount_123');
 
         $campaign = new Campaign();
         $campaign->setCharity($charity);

--- a/tests/Domain/DonationTest.php
+++ b/tests/Domain/DonationTest.php
@@ -62,4 +62,45 @@ class DonationTest extends TestCase
 
         $this->addToAssertionCount(1); // Just check setPsp() doesn't hit an exception
     }
+
+    public function testAmountForCharityWithTip()
+    {
+        // N.B. tip to TBG should not change the amount the charity receives, and the tip
+        // is not included in the core donation amount set by `setAmount()`.
+        $donation = new Donation();
+        $donation->setAmount('987.65');
+        $donation->setTipAmount('10.00');
+
+        // £987.65 * 1.2%   = £ 11.85 (to 2 d.p.)
+        // Fixed fee        = £  0.20
+        // Total fee        = £ 12.05
+        // Amount after fee = £975.60
+
+        $this->assertEquals('975.60', $donation->getAmountForCharity());
+    }
+
+    public function testAmountForCharityWithoutTip()
+    {
+        $donation = new Donation();
+        $donation->setAmount('987.65');
+
+        // £987.65 * 1.2%   = £ 11.85 (to 2 d.p.)
+        // Fixed fee        = £  0.20
+        // Total fee        = £ 12.05
+        // Amount after fee = £975.60
+
+        $this->assertEquals('975.60', $donation->getAmountForCharity());
+    }
+
+    public function testAmountForCharityWithoutTipRoundingOnPointFive()
+    {
+        $donation = new Donation();
+        $donation->setAmount('6.25');
+
+        // £1.25 * 1.2% = £ 0.08 (to 2 d.p. – following normal mathematical rounding from £0.075)
+        // Fixed fee    = £ 0.20
+        // Total fee    = £ 0.28
+        // After fee    = £ 5.97
+        $this->assertEquals('5.97', $donation->getAmountForCharity());
+    }
 }


### PR DESCRIPTION
* give Donation a method to calculate the amount for the charity
* send this amount and Connected Stripe Account ID during Payment Intent setup