### PR TITLE
MAT-93 - Stripe Account ID considerations

### DIFF
--- a/src/Application/Actions/Donations/Create.php
+++ b/src/Application/Actions/Donations/Create.php
@@ -85,6 +85,14 @@ class Create extends Action
         }
 
         if ($donation->getPsp() === 'stripe') {
+            if (empty($donation->getCampaign()->getCharity()->getStripeAccountId())) {
+                $this->logger->error(
+                    "Stripe Payment Intent create error: Stripe Account ID not set for {$donation->getCampaign()->getCharity()->getSalesforceId()}"
+                );
+                $error = new ActionError(ActionError::SERVER_ERROR, 'Could not make Stripe Payment Intent (A)');
+                return $this->respond(new ActionPayload(500, null, $error));
+            }
+
             try {
                 $intent = $this->stripeClient->paymentIntents->create([
                     // Stripe Payment Intent `amount` is in the smallest currency unit, e.g. pence.
@@ -102,7 +110,7 @@ class Create extends Action
                     'Stripe Payment Intent create error: ' .
                     get_class($exception) . ': ' . $exception->getMessage()
                 );
-                $error = new ActionError(ActionError::SERVER_ERROR, 'Could not make Stripe Payment Intent');
+                $error = new ActionError(ActionError::SERVER_ERROR, 'Could not make Stripe Payment Intent (B)');
                 return $this->respond(new ActionPayload(500, null, $error));
             }
 

--- a/src/Application/Actions/Donations/Create.php
+++ b/src/Application/Actions/Donations/Create.php
@@ -86,9 +86,10 @@ class Create extends Action
 
         if ($donation->getPsp() === 'stripe') {
             if (empty($donation->getCampaign()->getCharity()->getStripeAccountId())) {
-                $this->logger->error(
-                    "Stripe Payment Intent create error: Stripe Account ID not set for {$donation->getCampaign()->getCharity()->getSalesforceId()}"
-                );
+                $this->logger->error(sprintf(
+                    'Stripe Payment Intent create error: Stripe Account ID not set for Account %s',
+                    $donation->getCampaign()->getCharity()->getSalesforceId(),
+                ));
                 $error = new ActionError(ActionError::SERVER_ERROR, 'Could not make Stripe Payment Intent (A)');
                 return $this->respond(new ActionPayload(500, null, $error));
             }

--- a/src/Domain/Charity.php
+++ b/src/Domain/Charity.php
@@ -62,15 +62,15 @@ class Charity extends SalesforceReadProxy
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getStripeAccountId(): string
+    public function getStripeAccountId(): ?string
     {
         return $this->stripeAccountId;
     }
 
     /**
-     * @param string $stripeAccountId
+     * @param string|null $stripeAccountId
      */
     public function setStripeAccountId(?string $stripeAccountId): void
     {

--- a/tests/Application/Actions/Donations/CreateTest.php
+++ b/tests/Application/Actions/Donations/CreateTest.php
@@ -157,7 +157,12 @@ class CreateTest extends TestCase
         /** @var Container $container */
         $container = $app->getContainer();
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
-        $donationRepoProphecy->buildFromApiRequest(Argument::type(DonationCreate::class))->willReturn($donationToReturn);
+        $donationRepoProphecy
+            ->buildFromApiRequest(Argument::type(DonationCreate::class))
+            ->willReturn($donationToReturn);
+
+        // This and several subsequent Prophecy calls are defined in order to assert that they are *not* called in
+        // this error case, because we bail out before they would normally happen.
         $donationRepoProphecy->push(Argument::type(Donation::class), Argument::type('bool'))->shouldNotBeCalled();
         $donationRepoProphecy->allocateMatchFunds(Argument::type(Donation::class))->shouldNotBeCalled();
 
@@ -166,7 +171,7 @@ class CreateTest extends TestCase
         $entityManagerProphecy->flush()->shouldNotBeCalled();
 
         $stripePaymentIntentsProphecy = $this->prophesize(PaymentIntentService::class);
-        $stripePaymentIntentsProphecy->create(Argument::any())->shouldNotBeCalled(); // No PaymentIntent should be set up
+        $stripePaymentIntentsProphecy->create(Argument::any())->shouldNotBeCalled();
 
         $stripeClientProphecy = $this->prophesize(StripeClient::class);
         $stripeClientProphecy->paymentIntents = $stripePaymentIntentsProphecy->reveal();


### PR DESCRIPTION
* fix possible crash when checking for Stripe Account ID
* fail gracefully when a Donation Create is attempted in Stripe mode with no Stripe Account ID set