### PR TITLE
Make more HTTP Donation model properties optional

### DIFF
--- a/src/Application/HttpModels/Donation.php
+++ b/src/Application/HttpModels/Donation.php
@@ -13,7 +13,7 @@ class Donation
     public string $status;
     public string $charityId;
     public float $donationAmount;
-    public bool $giftAid;
+    public ?bool $giftAid;
     public bool $donationMatched;
     public ?string $firstName = null;
     public ?string $lastName = null;
@@ -22,7 +22,7 @@ class Donation
     public ?string $countryCode = null;
     public ?string $homeAddress = null;
     public ?string $homePostcode = null;
-    public bool $optInTbgEmail;
+    public ?bool $optInTbgEmail;
     public ?bool $optInCharityEmail = null;
     public string $projectId;
     public ?float $tipAmount = null;

--- a/src/Client/Donation.php
+++ b/src/Client/Donation.php
@@ -42,7 +42,7 @@ class Donation extends Common
     }
 
     /**
-     * For now, cancellations with Salesforce use the webhook receiver and not the Donations API
+     * For now, updates with Salesforce use the webhook receiver and not the Donations API
      * with JWT auth. As a server app there's no huge downside to using a fixed key, and getting
      * the Salesforce certificate's private part in the right format to use for RS256 JWT signature
      * creation was pretty involved. By sticking with this we can use the faster HS256 algorithm


### PR DESCRIPTION
This should fix e.g. cancellations in cases where these values
were never set but the Action still returns the updated Donation
object using this model