### PR TITLE
 MAT-125 - unqueue old donations in sandboxes + related

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,7 @@ BASE_URI=http://localhost:30030
 WEBHOOK_DONATION_SECRET=myLocalHookSecret
 JWT_DONATION_SECRET=myLocalJwtSecret
 
-SALESFORCE_CLIENT_TIMEOUT=5
+SALESFORCE_CLIENT_TIMEOUT=15
 SALESFORCE_CAMPAIGN_API=https://sf-api-staging.thebiggivetest.org.uk/campaigns/services/apexrest/v1.0/campaigns
 SALESFORCE_DONATION_API=https://sf-api-staging.thebiggivetest.org.uk/donations/services/apexrest/v1.0/donations
 SALESFORCE_FUND_API=https://sf-api-staging.thebiggivetest.org.uk/funds/services/apexrest/v1.0/funds

--- a/src/Client/Donation.php
+++ b/src/Client/Donation.php
@@ -73,6 +73,15 @@ class Donation extends Common
         } catch (RequestException $ex) {
             $this->logger->error('Donation update exception ' . get_class($ex) . ": {$ex->getMessage()}");
 
+            // Sandboxes that 404 on PUT have probably just been refreshed. In this case we want to
+            // update the local state of play to stop them getting pushed, instead of treating this
+            // as an error. So throw this for appropriate handling in the caller without an error level
+            // log. In production, 404s should not happen and so we continue to `return false` which
+            // will lead the caller to log an error.
+            if ($ex->getCode() === 404 && getenv('APP_ENV') !== 'production') {
+                throw new NotFoundException();
+            }
+
             return false;
         }
 

--- a/src/Domain/DonationRepository.php
+++ b/src/Domain/DonationRepository.php
@@ -57,7 +57,9 @@ class DonationRepository extends SalesforceWriteProxyRepository
             $result = $this->getClient()->put($donation);
         } catch (NotFoundException $ex) {
             // Thrown only for *sandbox* 404s -> quietly stop trying to push the removed donation.
-            $this->logInfo("Marking old Salesforce donation {$donation->getId()} as removed; will not try to push again.");
+            $this->logInfo(
+                "Marking old Salesforce donation {$donation->getId()} as removed; will not try to push again."
+            );
             $donation->setSalesforcePushStatus('removed');
             $this->getEntityManager()->persist($donation);
 

--- a/src/Domain/SalesforceWriteProxy.php
+++ b/src/Domain/SalesforceWriteProxy.php
@@ -26,7 +26,7 @@ abstract class SalesforceWriteProxy extends SalesforceProxy
 
     /**
      * @ORM\Column(type="string")
-     * @var string  One of 'not-sent', 'pending-create', 'pending-update' or 'complete'
+     * @var string  One of 'not-sent', 'pending-create', 'pending-update', 'complete' or 'removed'.
      */
     protected string $salesforcePushStatus = 'not-sent';
 

--- a/tests/Domain/DonationRepositoryTest.php
+++ b/tests/Domain/DonationRepositoryTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Tests\Domain;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use MatchBot\Client;
+use MatchBot\Domain\Donation;
+use MatchBot\Domain\DonationRepository;
+use MatchBot\Tests\Application\Actions\DonationTestDataTrait;
+use MatchBot\Tests\TestCase;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Log\NullLogger;
+
+class DonationRepositoryTest extends TestCase
+{
+    use DonationTestDataTrait;
+
+    public function testExistingPushOK(): void
+    {
+        $donationClientProphecy = $this->prophesize(Client\Donation::class);
+        $donationClientProphecy
+            ->put(Argument::type(Donation::class))
+            ->shouldBeCalledOnce()
+            ->willReturn(true);
+
+        $success = $this->getRepo($donationClientProphecy)->push($this->getTestDonation(), false);
+
+        $this->assertTrue($success);
+    }
+
+    public function testExistingPush404InSandbox(): void
+    {
+        $donationClientProphecy = $this->prophesize(Client\Donation::class);
+        $donationClientProphecy
+            ->put(Argument::type(Donation::class))
+            ->shouldBeCalledOnce()
+            ->willThrow(Client\NotFoundException::class);
+
+        $success = $this->getRepo($donationClientProphecy)->push($this->getTestDonation(), false);
+
+        $this->assertTrue($success);
+    }
+
+    public function testError(): void
+    {
+        $donationClientProphecy = $this->prophesize(Client\Donation::class);
+        $donationClientProphecy
+            ->put(Argument::type(Donation::class))
+            ->shouldBeCalledOnce()
+            ->willReturn(false);
+
+        $success = $this->getRepo($donationClientProphecy)->push($this->getTestDonation(), false);
+
+        $this->assertFalse($success);
+    }
+
+    /**
+     * @param ObjectProphecy|Client\Donation $donationClientProphecy
+     * @return DonationRepository
+     */
+    private function getRepo(ObjectProphecy $donationClientProphecy): DonationRepository
+    {
+        $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
+        $repo = new DonationRepository($entityManagerProphecy->reveal(), new ClassMetadata(Donation::class));
+        $repo->setClient($donationClientProphecy->reveal());
+        $repo->setLogger(new NullLogger());
+
+        return $repo;
+    }
+}


### PR DESCRIPTION
* MAT-125 - unqueue old donations in sandboxes
* MAT-125 - test the 3 update push scenarios
* MAT-125 - reduce cases where we double-push to Salesforce
* MAT-126 - update local example SF timeout