### PR TITLE
MAT-121 – matching stability & script enhancements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,8 @@ APP_ENV=local
 # Turn off sending proxy updates to Salesforce
 DISABLE_CLIENT_PUSH=0
 
+KNOWN_OVERMATCHED_FUNDING_IDS="[]"
+
 # Remember to never let any personal data into your local DB!
 MYSQL_HOST=db
 MYSQL_USER=root

--- a/src/Application/Commands/ExpireMatchFunds.php
+++ b/src/Application/Commands/ExpireMatchFunds.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Expire match funding allocations, by hard-deleting `FundingWithdrawals` for donations that have been
- * Pending for more than the reservation time.
+ * Pending for more than the reservation time and releasing funds with the real-time adapter.
  *
  * Donations may still be completed after the expiry time but will not receive match funds.
  */

--- a/src/Application/Commands/HandleOutOfSyncFunds.php
+++ b/src/Application/Commands/HandleOutOfSyncFunds.php
@@ -69,14 +69,22 @@ class HandleOutOfSyncFunds extends LockingCommand
             return 1;
         }
 
+        $excludedFundingIds = [];
+        if ($excludeJson = getenv('KNOWN_OVERMATCHED_FUNDING_IDS')) {
+            $excludedFundingIds = json_decode($excludeJson, true, 512, JSON_THROW_ON_ERROR);
+        }
+
         $numFundingsCorrect = 0;
         $numFundingsOvermatched = 0;
         $numFundingsUndermatched = 0;
+        /** @var CampaignFunding[] $fundings */
         $fundings = $this->campaignFundingRepository->findAll();
         $numFundings = count($fundings);
 
         foreach ($fundings as $funding) {
-            /** @var CampaignFunding $funding */
+            if (in_array($funding->getId(), $excludedFundingIds, true)) {
+                continue;
+            }
 
             // Amount allocated from the CampaignFunding
             $fundingAvailable = $this->matchingAdapter->getAmountAvailable($funding);

--- a/src/Domain/FundingWithdrawalRepository.php
+++ b/src/Domain/FundingWithdrawalRepository.php
@@ -20,6 +20,12 @@ class FundingWithdrawalRepository extends EntityRepository
             ->where('fw.campaignFunding = :campaignFunding')
             ->setParameter('campaignFunding', $campaignFunding->getId());
 
-        return (string) $qb->getQuery()->getSingleScalarResult();
+        $amount = (string) $qb->getQuery()->getSingleScalarResult();
+
+        if ($amount === '') {
+            return '0.00';
+        }
+
+        return $amount;
     }
 }


### PR DESCRIPTION
* try to fix adapter's `getAmountAvailable()` used by the check command in cases where campaigns are not being frequently accessed – should resolve numerous spurious reported under-matches
* support excluding known historic mismatches from the same command – will let us assess new data without the 1 known CC19 discrepancy confusing monitoring
* replace all non-integer casts with bcmath functions – should resolve rare out-by-£0.01 bug
* show zeroes clearly in out of sync fund check command