### PR TITLE
MAT-124, MAT-132 – Stripe webhook updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@ REDIS_HOST=redis
 
 STRIPE_SECRET_KEY=sk_test_yourKeyHere
 STRIPE_WEBHOOK_SIGNING_SECRET=whsec_test_yourKeyHere
+STRIPE_CONNECT_WEBHOOK_SIGNING_SECRET=whsec_test_yourPayoutKeyHere
 
 BASE_URI=http://localhost:30030
 # Must match the Salesforce secret for the corresponding environment

--- a/app/routes.php
+++ b/app/routes.php
@@ -30,7 +30,8 @@ return function (App $app) {
         ->add(DonationHookAuthMiddleware::class);
 
     // Authenticated through Stripes SDK signature verification
-    $app->post('/hooks/stripe', Hooks\StripeUpdate::class);
+    $app->post('/hooks/stripe', Hooks\StripeChargeUpdate::class);
+    $app->post('/hooks/stripe-connect', Hooks\StripePayoutUpdate::class);
 
     $app->options('/{routes:.+}', function ($request, $response, $args) {
         return $response;

--- a/app/settings.php
+++ b/app/settings.php
@@ -71,7 +71,8 @@ return function (ContainerBuilder $containerBuilder) {
             'stripe' => [
                 'apiKey' => getenv('STRIPE_SECRET_KEY'),
                 'apiVersion' => '2020-03-02',
-                'webhookSecret' => getenv('STRIPE_WEBHOOK_SIGNING_SECRET')
+                'accountWebhookSecret' => getenv('STRIPE_WEBHOOK_SIGNING_SECRET'),
+                'connectAppWebhookSecret' => getenv('STRIPE_CONNECT_WEBHOOK_SIGNING_SECRET'),
             ],
         ],
     ]);

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -34,6 +34,7 @@
         <env name="REDIS_HOST" value="dummy-redis-hostname" force="true" />
         <env name="STRIPE_SECRET_KEY" value="sk_test_unitTestFakeKey" force="true" />
         <env name="STRIPE_WEBHOOK_SIGNING_SECRET" value="whsec_test_unitTestFakeKey" force="true" />
+        <env name="STRIPE_CONNECT_WEBHOOK_SIGNING_SECRET" value="whsec_test_unitTestFakeConnectKey" force="true" />
         <env name="WEBHOOK_DONATION_SECRET" value="unitTestCchSecret" force="true" />
     </php>
 </phpunit>

--- a/src/Application/Actions/Hooks/Stripe.php
+++ b/src/Application/Actions/Hooks/Stripe.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Application\Actions\Hooks;
+
+use Doctrine\ORM\EntityManagerInterface;
+use MatchBot\Application\Actions\Action;
+use MatchBot\Application\Actions\ActionPayload;
+use MatchBot\Domain\DonationRepository;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\LoggerInterface;
+use Stripe\Event;
+use Stripe\StripeClient;
+
+/**
+ * Handle charge.succeeded and charge.refunded events from a Stripe account webhook.
+ *
+ * @return Response
+ */
+abstract class Stripe extends Action
+{
+    protected DonationRepository $donationRepository;
+    protected EntityManagerInterface $entityManager;
+    protected Event $event;
+    protected StripeClient $stripeClient;
+    protected array $stripeSettings;
+
+    public function __construct(
+        ContainerInterface $container,
+        DonationRepository $donationRepository,
+        EntityManagerInterface $entityManager,
+        LoggerInterface $logger,
+        StripeClient $stripeClient
+    ) {
+        $this->donationRepository = $donationRepository;
+        $this->entityManager = $entityManager;
+        $this->stripeClient = $stripeClient;
+        $this->stripeSettings = $container->get('settings')['stripe'];
+
+        parent::__construct($logger);
+    }
+
+    /**
+     * @param ServerRequestInterface $request
+     * @param string $webhookSecret
+     * @return Response|null    Validation error, or null if $this->event was set up OK.
+     */
+    protected function prepareEvent(ServerRequestInterface $request, string $webhookSecret): ?ResponseInterface
+    {
+        try {
+            $this->event = \Stripe\Webhook::constructEvent(
+                $request->getBody(),
+                $request->getHeaderLine('stripe-signature'),
+                $webhookSecret
+            );
+        } catch (\UnexpectedValueException $e) {
+            return $this->validationError("Invalid Payload: {$e->getMessage()}", 'Invalid Payload');
+        } catch (\Stripe\Exception\SignatureVerificationException $e) {
+            return $this->validationError('Invalid Signature');
+        }
+
+        if (!($this->event instanceof Event)) {
+            return $this->validationError('Invalid event');
+        }
+
+        if (!$this->event->livemode && getenv('APP_ENV') === 'production') {
+            $this->logger->warning(sprintf('Skipping non-live %s webhook in Production', $this->event->type));
+            return $this->respond(new ActionPayload(204));
+        }
+
+        return null;
+    }
+}

--- a/src/Application/Actions/Hooks/StripeChargeUpdate.php
+++ b/src/Application/Actions/Hooks/StripeChargeUpdate.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Application\Actions\Hooks;
+
+use Doctrine\ORM\EntityManagerInterface;
+use MatchBot\Application\Actions\Action;
+use MatchBot\Application\Actions\ActionPayload;
+use MatchBot\Domain\Donation;
+use MatchBot\Domain\DonationRepository;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Log\LoggerInterface;
+use Stripe\Event;
+use Stripe\StripeClient;
+
+/**
+ * Handle charge.succeeded and charge.refunded events from a Stripe account webhook.
+ *
+ * @return Response
+ */
+class StripeChargeUpdate extends Action
+{
+    private DonationRepository $donationRepository;
+    private EntityManagerInterface $entityManager;
+    private StripeClient $stripeClient;
+    private string $accountWebhookSecret;
+
+    public function __construct(
+        ContainerInterface $container,
+        DonationRepository $donationRepository,
+        EntityManagerInterface $entityManager,
+        LoggerInterface $logger,
+        StripeClient $stripeClient
+    ) {
+        $this->donationRepository = $donationRepository;
+        $this->entityManager = $entityManager;
+        $this->stripeClient = $stripeClient;
+        // As `settings` is just an array for now, I think we have to inject Container to do this.
+        $this->apiKey = $container->get('settings')['stripe']['apiKey'];
+        $this->accountWebhookSecret = $container->get('settings')['stripe']['accountWebhookSecret'];
+
+        parent::__construct($logger);
+    }
+
+    /**
+     * @return Response
+     */
+    protected function action(): Response
+    {
+        try {
+            $event = \Stripe\Webhook::constructEvent(
+                $this->request->getBody(),
+                $this->request->getHeaderLine('stripe-signature'),
+                $this->accountWebhookSecret
+            );
+        } catch (\UnexpectedValueException $e) {
+            return $this->validationError("Invalid Payload: {$e->getMessage()}", 'Invalid Payload');
+        } catch (\Stripe\Exception\SignatureVerificationException $e) {
+            return $this->validationError('Invalid Signature');
+        }
+
+        if (!($event instanceof Event)) {
+            return $this->validationError('Invalid event');
+        }
+
+        $this->logger->info(sprintf('Received Stripe account event type "%s"', $event->type));
+
+        if (!$event->livemode && getenv('APP_ENV') === 'production') {
+            $this->logger->warning(sprintf('Skipping non-live %s webhook in Production', $event->type));
+            return $this->respond(new ActionPayload(204));
+        }
+
+        switch ($event->type) {
+            case 'charge.refunded':
+                return $this->handleChargeRefunded($event);
+            case 'charge.succeeded':
+                return $this->handleChargeSucceeded($event);
+            default:
+                $this->logger->warning(sprintf('Unsupported event type "%s"', $event->type));
+                return $this->respond(new ActionPayload(204));
+        }
+    }
+
+    private function handleChargeSucceeded(Event $event): Response
+    {
+        $intentId = $event->data->object->payment_intent;
+
+        /** @var Donation $donation */
+        $donation = $this->donationRepository->findOneBy(['transactionId' => $intentId]);
+
+        if (!$donation) {
+            $this->logger->info(sprintf('Donation not found with Payment Intent ID %s', $intentId));
+            return $this->respond(new ActionPayload(204));
+        }
+
+        // For now we support the happy success path,
+        // as this is the only event type we're handling right now,
+        // convert status to the one SF uses.
+        if ($event->data->object->status === 'succeeded') {
+            $donation->setChargeId($event->data->object->id);
+            $donation->setDonationStatus('Collected');
+        } else {
+            return $this->validationError(sprintf('Unsupported Status "%s"', $event->data->object->status));
+        }
+
+        if ($donation->isReversed() && $event->data->object->metadata->matchedAmount > 0) {
+            $this->donationRepository->releaseMatchFunds($donation);
+        }
+
+        $this->entityManager->persist($donation);
+
+        // We log if this fails but don't worry the webhook-sending payment client
+        // about it. We'll re-try sending the updated status to Salesforce in a future
+        // batch sync.
+        $this->donationRepository->push($donation, false); // Attempt immediate sync to Salesforce
+
+        return $this->respondWithData($event->data->object);
+    }
+
+    private function handleChargeRefunded(Event $event): Response
+    {
+        $chargeId = $event->data->object->id;
+        $amountRefunded = $event->data->object->amount_refunded;
+
+        /** @var Donation $donation */
+        $donation = $this->donationRepository->findOneBy(['chargeId' => $chargeId]);
+
+        if (!$donation) {
+            $this->logger->info(sprintf('Donation not found with Charge ID %s', $chargeId));
+            return $this->respond(new ActionPayload(204));
+        }
+
+        // Available status' (pending, succeeded, failed, canceled),
+        // see: https://stripe.com/docs/api/refunds/object.
+        // For now we support the happy success path,
+        // convert status to the one SF uses.
+        if ($event->data->object->status === 'succeeded') {
+            $donation->setChargeId($event->data->object->id);
+            $donation->setDonationStatus('Refunded');
+        } else {
+            return $this->validationError(sprintf('Unsupported Status "%s"', $event->data->object->status));
+        }
+
+        // Release match funds only if the donation was matched and
+        // the refunded amount is equal to the local txn amount.
+        // We multiply local donation amount by 100 to match Stripes calculations.
+        if (
+            $donation->isReversed()
+            && $donation->getAmountInPenceIncTip() === $amountRefunded
+            && $donation->getCampaign()->isMatched()
+        ) {
+            $this->donationRepository->releaseMatchFunds($donation);
+        }
+
+        $this->entityManager->persist($donation);
+
+        $this->donationRepository->push($donation, false); // Attempt immediate sync to Salesforce
+
+        return $this->respondWithData($event->data->object);
+    }
+}

--- a/src/Migrations/Version20201119205321.php
+++ b/src/Migrations/Version20201119205321.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Update 3 Mousetrap Theatre missed donations to Paid status and mark for re-pushing to Salesforce.
+ */
+final class Version20201119205321 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return 'Update 3 Mousetrap Theatre missed donations to Paid status and mark for re-pushing to Salesforce.';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $updateSql = <<<EOT
+UPDATE Donation
+SET salesforcePushStatus = 'pending-update', donationStatus = 'Paid'
+WHERE salesforceId IN ('a066900001kFNkrAAG', 'a066900001kFNuSAAW', 'a066900001kFOgNAAW')
+LIMIT 3
+EOT;
+        $this->addSql($updateSql);
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        // No safe un-fix -> no-op.
+    }
+}

--- a/tests/Application/Actions/DonationTestDataTrait.php
+++ b/tests/Application/Actions/DonationTestDataTrait.php
@@ -9,7 +9,7 @@ use Ramsey\Uuid\Uuid;
 
 trait DonationTestDataTrait
 {
-    private function getTestDonation(): Donation
+    protected function getTestDonation(): Donation
     {
         $charity = new Charity();
         $charity->setDonateLinkId('123CharityId');
@@ -46,7 +46,7 @@ trait DonationTestDataTrait
         return $donation;
     }
 
-    private function getAnonymousPendingTestDonation(): Donation
+    protected function getAnonymousPendingTestDonation(): Donation
     {
         $charity = new Charity();
         $charity->setDonateLinkId('123CharityId');

--- a/tests/Application/Actions/Hooks/StripeChargeUpdateTest.php
+++ b/tests/Application/Actions/Hooks/StripeChargeUpdateTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Tests\Application\Actions\Hooks;
+
+use DI\Container;
+use Doctrine\ORM\EntityManagerInterface;
+use MatchBot\Application\Actions\ActionPayload;
+use MatchBot\Domain\Donation;
+use MatchBot\Domain\DonationRepository;
+use Prophecy\Argument;
+
+class StripeChargeUpdateTest extends StripeTest
+{
+    public function testUnsupportedAction(): void
+    {
+        $app = $this->getAppInstance();
+        /** @var Container $container */
+        $container = $app->getContainer();
+
+        // Payment Intent events, including cancellations, return a 204 No Content no-op for now.
+        $body = file_get_contents(dirname(__DIR__, 3) . '/TestData/StripeWebhook/pi_canceled.json');
+        $webhookSecret = $container->get('settings')['stripe']['accountWebhookSecret'];
+        $time = (string) time();
+
+        $donationRepoProphecy = $this->prophesize(DonationRepository::class);
+        $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
+
+        $request = $this->createRequest('POST', '/hooks/stripe', $body)
+            ->withHeader('Stripe-Signature', $this->generateSignature($time, $body, $webhookSecret));
+
+        $response = $app->handle($request);
+
+        $this->assertEquals(204, $response->getStatusCode());
+    }
+
+    public function testUnrecognisedTransactionId(): void
+    {
+        $app = $this->getAppInstance();
+        /** @var Container $container */
+        $container = $app->getContainer();
+
+        $body = file_get_contents(dirname(__DIR__, 3) . '/TestData/StripeWebhook/ch_invalid_id.json');
+        $webhookSecret = $container->get('settings')['stripe']['accountWebhookSecret'];
+        $time = (string) time();
+
+        $donationRepoProphecy = $this->prophesize(DonationRepository::class);
+        $donationRepoProphecy
+            ->findOneBy(['transactionId' => 'pi_invalidId_123'])
+            ->willReturn(null)
+            ->shouldBeCalledOnce();
+
+        $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
+
+        $container->set(EntityManagerInterface::class, $entityManagerProphecy->reveal());
+        $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
+
+        $request = $this->createRequest('POST', '/hooks/stripe', $body)
+            ->withHeader('Stripe-Signature', $this->generateSignature($time, $body, $webhookSecret));
+
+        $response = $app->handle($request);
+
+        $this->assertEquals(204, $response->getStatusCode());
+    }
+
+    public function testMissingSignature(): void
+    {
+        $app = $this->getAppInstance();
+        /** @var Container $container */
+        $container = $app->getContainer();
+
+        $body = file_get_contents(dirname(__DIR__, 3) . '/TestData/StripeWebhook/ch_succeeded.json');
+
+        $donationRepoProphecy = $this->prophesize(DonationRepository::class);
+        $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
+
+        $container->set(EntityManagerInterface::class, $entityManagerProphecy->reveal());
+        $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
+
+        $request = $this->createRequest('POST', '/hooks/stripe', $body)
+            ->withHeader('Stripe-Signature', '');
+
+        $response = $app->handle($request);
+
+        $expectedPayload = new ActionPayload(400, ['error' => [
+            'type' => 'BAD_REQUEST',
+            'description' => 'Invalid Signature',
+        ]]);
+        $expectedSerialised = json_encode($expectedPayload, JSON_PRETTY_PRINT);
+
+        $payload = (string) $response->getBody();
+
+        $this->assertEquals($expectedSerialised, $payload);
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    public function testSuccessfulPayment(): void
+    {
+        $app = $this->getAppInstance();
+        /** @var Container $container */
+        $container = $app->getContainer();
+
+        $body = file_get_contents(dirname(__DIR__, 3) . '/TestData/StripeWebhook/ch_succeeded.json');
+        $donation = $this->getTestDonation();
+        $webhookSecret = $container->get('settings')['stripe']['accountWebhookSecret'];
+        $time = (string) time();
+
+        $donationRepoProphecy = $this->prophesize(DonationRepository::class);
+        $donationRepoProphecy
+            ->findOneBy(['transactionId' => 'pi_externalId_123'])
+            ->willReturn($donation)
+            ->shouldBeCalledOnce();
+
+        $donationRepoProphecy
+            ->push(Argument::type(Donation::class), false)
+            ->willReturn(true)
+            ->shouldBeCalledOnce();
+
+        $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
+
+        $container->set(EntityManagerInterface::class, $entityManagerProphecy->reveal());
+        $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
+
+        $request = $this->createRequest('POST', '/hooks/stripe', $body)
+            ->withHeader('Stripe-Signature', $this->generateSignature($time, $body, $webhookSecret));
+
+        $response = $app->handle($request);
+
+        $this->assertEquals('ch_externalId_123', $donation->getChargeId());
+        $this->assertEquals('Collected', $donation->getDonationStatus());
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testSuccessfulRefund(): void
+    {
+        $app = $this->getAppInstance();
+        /** @var Container $container */
+        $container = $app->getContainer();
+
+        $body = file_get_contents(dirname(__DIR__, 3) . '/TestData/StripeWebhook/ch_refunded.json');
+        $donation = $this->getTestDonation();
+        $webhookSecret = $container->get('settings')['stripe']['accountWebhookSecret'];
+        $time = (string) time();
+
+        $donationRepoProphecy = $this->prophesize(DonationRepository::class);
+        $donationRepoProphecy
+            ->findOneBy(['chargeId' => 'ch_externalId_123'])
+            ->willReturn($donation)
+            ->shouldBeCalledOnce();
+
+        $donationRepoProphecy
+            ->releaseMatchFunds($donation)
+            ->shouldBeCalledOnce();
+
+        $donationRepoProphecy
+            ->push(Argument::type(Donation::class), false)
+            ->willReturn(true)
+            ->shouldBeCalledOnce();
+
+        $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
+
+        $container->set(EntityManagerInterface::class, $entityManagerProphecy->reveal());
+        $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
+
+        $request = $this->createRequest('POST', '/hooks/stripe', $body)
+            ->withHeader('Stripe-Signature', $this->generateSignature($time, $body, $webhookSecret));
+
+        $response = $app->handle($request);
+
+        $this->assertEquals('ch_externalId_123', $donation->getChargeId());
+        $this->assertEquals('Refunded', $donation->getDonationStatus());
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+}

--- a/tests/Application/Actions/Hooks/StripePayoutUpdateTest.php
+++ b/tests/Application/Actions/Hooks/StripePayoutUpdateTest.php
@@ -9,16 +9,12 @@ use Doctrine\ORM\EntityManagerInterface;
 use MatchBot\Application\Actions\ActionPayload;
 use MatchBot\Domain\Donation;
 use MatchBot\Domain\DonationRepository;
-use MatchBot\Tests\Application\Actions\DonationTestDataTrait;
-use MatchBot\Tests\TestCase;
 use Prophecy\Argument;
 use Stripe\Service\BalanceTransactionService;
 use Stripe\StripeClient;
 
-class StripeUpdateTest extends TestCase
+class StripePayoutUpdateTest extends StripeTest
 {
-    use DonationTestDataTrait;
-
     public function testUnsupportedAction(): void
     {
         $app = $this->getAppInstance();
@@ -27,42 +23,13 @@ class StripeUpdateTest extends TestCase
 
         // Payment Intent events, including cancellations, return a 204 No Content no-op for now.
         $body = file_get_contents(dirname(__DIR__, 3) . '/TestData/StripeWebhook/pi_canceled.json');
-        $webhookSecret = $container->get('settings')['stripe']['webhookSecret'];
+        $webhookSecret = $container->get('settings')['stripe']['connectAppWebhookSecret'];
         $time = (string) time();
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
 
-        $request = $this->createRequest('POST', '/hooks/stripe', $body)
-            ->withHeader('Stripe-Signature', $this->generateSignature($time, $body, $webhookSecret));
-
-        $response = $app->handle($request);
-
-        $this->assertEquals(204, $response->getStatusCode());
-    }
-
-    public function testUnrecognisedTransactionId(): void
-    {
-        $app = $this->getAppInstance();
-        /** @var Container $container */
-        $container = $app->getContainer();
-
-        $body = file_get_contents(dirname(__DIR__, 3) . '/TestData/StripeWebhook/ch_invalid_id.json');
-        $webhookSecret = $container->get('settings')['stripe']['webhookSecret'];
-        $time = (string) time();
-
-        $donationRepoProphecy = $this->prophesize(DonationRepository::class);
-        $donationRepoProphecy
-            ->findOneBy(['transactionId' => 'pi_invalidId_123'])
-            ->willReturn(null)
-            ->shouldBeCalledOnce();
-
-        $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
-
-        $container->set(EntityManagerInterface::class, $entityManagerProphecy->reveal());
-        $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
-
-        $request = $this->createRequest('POST', '/hooks/stripe', $body)
+        $request = $this->createRequest('POST', '/hooks/stripe-connect', $body)
             ->withHeader('Stripe-Signature', $this->generateSignature($time, $body, $webhookSecret));
 
         $response = $app->handle($request);
@@ -84,7 +51,7 @@ class StripeUpdateTest extends TestCase
         $container->set(EntityManagerInterface::class, $entityManagerProphecy->reveal());
         $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
 
-        $request = $this->createRequest('POST', '/hooks/stripe', $body)
+        $request = $this->createRequest('POST', '/hooks/stripe-connect', $body)
             ->withHeader('Stripe-Signature', '');
 
         $response = $app->handle($request);
@@ -101,43 +68,6 @@ class StripeUpdateTest extends TestCase
         $this->assertEquals(400, $response->getStatusCode());
     }
 
-    public function testSuccessfulPayment(): void
-    {
-        $app = $this->getAppInstance();
-        /** @var Container $container */
-        $container = $app->getContainer();
-
-        $body = file_get_contents(dirname(__DIR__, 3) . '/TestData/StripeWebhook/ch_succeeded.json');
-        $donation = $this->getTestDonation();
-        $webhookSecret = $container->get('settings')['stripe']['webhookSecret'];
-        $time = (string) time();
-
-        $donationRepoProphecy = $this->prophesize(DonationRepository::class);
-        $donationRepoProphecy
-            ->findOneBy(['transactionId' => 'pi_externalId_123'])
-            ->willReturn($donation)
-            ->shouldBeCalledOnce();
-
-        $donationRepoProphecy
-            ->push(Argument::type(Donation::class), false)
-            ->willReturn(true)
-            ->shouldBeCalledOnce();
-
-        $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
-
-        $container->set(EntityManagerInterface::class, $entityManagerProphecy->reveal());
-        $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
-
-        $request = $this->createRequest('POST', '/hooks/stripe', $body)
-            ->withHeader('Stripe-Signature', $this->generateSignature($time, $body, $webhookSecret));
-
-        $response = $app->handle($request);
-
-        $this->assertEquals('ch_externalId_123', $donation->getChargeId());
-        $this->assertEquals('Collected', $donation->getDonationStatus());
-        $this->assertEquals(200, $response->getStatusCode());
-    }
-
     public function testUnrecognisedChargeIdPayout(): void
     {
         $app = $this->getAppInstance();
@@ -148,7 +78,7 @@ class StripeUpdateTest extends TestCase
         $balanceTxnResponse = file_get_contents(
             dirname(__DIR__, 3) . '/TestData/StripeWebhook/ApiResponse/bt_invalid.json'
         );
-        $webhookSecret = $container->get('settings')['stripe']['webhookSecret'];
+        $webhookSecret = $container->get('settings')['stripe']['connectAppWebhookSecret'];
         $time = (string) time();
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
@@ -175,7 +105,7 @@ class StripeUpdateTest extends TestCase
         $container->set(EntityManagerInterface::class, $entityManagerProphecy->reveal());
         $container->set(StripeClient::class, $stripeClientProphecy->reveal());
 
-        $request = $this->createRequest('POST', '/hooks/stripe', $body)
+        $request = $this->createRequest('POST', '/hooks/stripe-connect', $body)
             ->withHeader('Stripe-Signature', $this->generateSignature($time, $body, $webhookSecret));
 
         $response = $app->handle($request);
@@ -194,7 +124,7 @@ class StripeUpdateTest extends TestCase
             dirname(__DIR__, 3) . '/TestData/StripeWebhook/ApiResponse/bt_success.json'
         );
         $donation = $this->getTestDonation();
-        $webhookSecret = $container->get('settings')['stripe']['webhookSecret'];
+        $webhookSecret = $container->get('settings')['stripe']['connectAppWebhookSecret'];
         $time = (string) time();
 
         $donation->setDonationStatus('Failed');
@@ -223,7 +153,7 @@ class StripeUpdateTest extends TestCase
         $container->set(EntityManagerInterface::class, $entityManagerProphecy->reveal());
         $container->set(StripeClient::class, $stripeClientProphecy->reveal());
 
-        $request = $this->createRequest('POST', '/hooks/stripe', $body)
+        $request = $this->createRequest('POST', '/hooks/stripe-connect', $body)
             ->withHeader('Stripe-Signature', $this->generateSignature($time, $body, $webhookSecret));
 
         $response = $app->handle($request);
@@ -245,7 +175,7 @@ class StripeUpdateTest extends TestCase
             dirname(__DIR__, 3) . '/TestData/StripeWebhook/ApiResponse/bt_success.json'
         );
         $donation = $this->getTestDonation();
-        $webhookSecret = $container->get('settings')['stripe']['webhookSecret'];
+        $webhookSecret = $container->get('settings')['stripe']['connectAppWebhookSecret'];
         $time = (string) time();
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
@@ -277,69 +207,12 @@ class StripeUpdateTest extends TestCase
         $container->set(EntityManagerInterface::class, $entityManagerProphecy->reveal());
         $container->set(StripeClient::class, $stripeClientProphecy->reveal());
 
-        $request = $this->createRequest('POST', '/hooks/stripe', $body)
+        $request = $this->createRequest('POST', '/hooks/stripe-connect', $body)
             ->withHeader('Stripe-Signature', $this->generateSignature($time, $body, $webhookSecret));
 
         $response = $app->handle($request);
 
         $this->assertEquals('Paid', $donation->getDonationStatus());
         $this->assertEquals(200, $response->getStatusCode());
-    }
-
-    public function testSuccessfulRefund(): void
-    {
-        $app = $this->getAppInstance();
-        /** @var Container $container */
-        $container = $app->getContainer();
-
-        $body = file_get_contents(dirname(__DIR__, 3) . '/TestData/StripeWebhook/ch_refunded.json');
-        $donation = $this->getTestDonation();
-        $webhookSecret = $container->get('settings')['stripe']['webhookSecret'];
-        $time = (string) time();
-
-        $donationRepoProphecy = $this->prophesize(DonationRepository::class);
-        $donationRepoProphecy
-            ->findOneBy(['chargeId' => 'ch_externalId_123'])
-            ->willReturn($donation)
-            ->shouldBeCalledOnce();
-
-        $donationRepoProphecy
-            ->releaseMatchFunds($donation)
-            ->shouldBeCalledOnce();
-
-        $donationRepoProphecy
-            ->push(Argument::type(Donation::class), false)
-            ->willReturn(true)
-            ->shouldBeCalledOnce();
-
-        $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
-
-        $container->set(EntityManagerInterface::class, $entityManagerProphecy->reveal());
-        $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
-
-        $request = $this->createRequest('POST', '/hooks/stripe', $body)
-            ->withHeader('Stripe-Signature', $this->generateSignature($time, $body, $webhookSecret));
-
-        $response = $app->handle($request);
-
-        $this->assertEquals('ch_externalId_123', $donation->getChargeId());
-        $this->assertEquals('Refunded', $donation->getDonationStatus());
-        $this->assertEquals(200, $response->getStatusCode());
-    }
-
-    private function generateSignature(string $time, string $body, string $webhookSecret): string
-    {
-        return 't=' . $time . ',' . 'v1=' . $this->getValidAuth($this->getSignedPayload($time, $body), $webhookSecret);
-    }
-
-    private function getSignedPayload(string $time, string $body): string
-    {
-        $time = (string) time();
-        return $time . '.' . $body;
-    }
-
-    private function getValidAuth(string $signedPayload, string $webhookSecret): string
-    {
-        return hash_hmac('sha256', $signedPayload, $webhookSecret);
     }
 }

--- a/tests/Application/Actions/Hooks/StripeTest.php
+++ b/tests/Application/Actions/Hooks/StripeTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Tests\Application\Actions\Hooks;
+
+use MatchBot\Tests\Application\Actions\DonationTestDataTrait;
+use MatchBot\Tests\TestCase;
+
+abstract class StripeTest extends TestCase
+{
+    use DonationTestDataTrait;
+
+    protected function generateSignature(string $time, string $body, string $webhookSecret): string
+    {
+        return 't=' . $time . ',' . 'v1=' . $this->getValidAuth($this->getSignedPayload($time, $body), $webhookSecret);
+    }
+
+    private function getSignedPayload(string $time, string $body): string
+    {
+        return "$time.$body";
+    }
+
+    private function getValidAuth(string $signedPayload, string $webhookSecret): string
+    {
+        return hash_hmac('sha256', $signedPayload, $webhookSecret);
+    }
+}


### PR DESCRIPTION
* split webhook types into separate endpoints
* log error on `payout.failed`
* skip non-livemode events in Production
* update 3 Mousetrap Theatre missed donations to Paid status and mark for re-pushing to Salesforce

