### PR TITLE
 MAT-143 - fix the order of operations during donation cancellation and hook updates

### DIFF
--- a/src/Application/Actions/Donations/Update.php
+++ b/src/Application/Actions/Donations/Update.php
@@ -198,6 +198,14 @@ class Update extends Action
         $this->logger->info("Donor cancelled ID {$this->args['donationId']}");
 
         $donation->setDonationStatus('Cancelled');
+
+        // We need donation status to be persisted *immediately* and before the match
+        // funds release, to eliminate the possibility of a race condition leading a duplicate
+        // valid cancellation HTTP request causing the same match funds to be released twice.
+        // We saw this happen twice on 1 December 2020 (CC20 launch day) from double-cancellations
+        // within 0.005 seconds of each other (MAT-143).
+        $this->save($donation);
+
         if ($donation->getCampaign()->isMatched()) {
             $this->donationRepository->releaseMatchFunds($donation);
         }
@@ -214,8 +222,6 @@ class Update extends Action
                 return $this->respond(new ActionPayload(500, null, $error));
             }
         }
-
-        $this->save($donation);
 
         return $this->respondWithData($donation->toApiModel());
     }

--- a/src/Application/Actions/Hooks/DonationUpdate.php
+++ b/src/Application/Actions/Hooks/DonationUpdate.php
@@ -90,13 +90,14 @@ class DonationUpdate extends Action
             $donation->setTipAmount((string) $donationData->tipAmount);
         }
 
+        $this->entityManager->persist($donation);
+        $this->entityManager->flush();
+
         // Enthuse are now sending hooks with a few statuses that represent something 'refund-like'. All known
         // statuses that should act like this appear in `Donation::$reversedStatuses`.
         if ($donation->isReversed() && $donation->getCampaign()->isMatched()) {
             $this->donationRepository->releaseMatchFunds($donation);
         }
-
-        $this->entityManager->persist($donation);
 
         // We log if this fails but don't worry the webhook-sending payment client
         // about it. We'll re-try sending the updated status to Salesforce in a future

--- a/src/Application/Actions/Hooks/StripeChargeUpdate.php
+++ b/src/Application/Actions/Hooks/StripeChargeUpdate.php
@@ -65,10 +65,6 @@ class StripeChargeUpdate extends Stripe
             return $this->validationError(sprintf('Unsupported Status "%s"', $event->data->object->status));
         }
 
-        if ($donation->isReversed() && $event->data->object->metadata->matchedAmount > 0) {
-            $this->donationRepository->releaseMatchFunds($donation);
-        }
-
         $this->entityManager->persist($donation);
 
         // We log if this fails but don't worry the webhook-sending payment client

--- a/src/Domain/DonationRepository.php
+++ b/src/Domain/DonationRepository.php
@@ -223,6 +223,18 @@ class DonationRepository extends SalesforceWriteProxyRepository
         return $amountNewlyMatched;
     }
 
+    /**
+     * If calling this just after changing a specific donation instead of as a batch process,
+     * be careful to update donation status, persist and flush before invoking this.
+     * In particular, for the case where a donation has just entered a reversed status,
+     * if a second process decides to call this method based on funding allocations in place
+     * when it started, in rare edge cases you can double-release the same match funds
+     * when the funding withdrawals were already deleted in the first request.
+     *
+     * @param Donation $donation
+     * @throws DomainLockContentionException
+     * @throws Matching\TerminalLockException
+     */
     public function releaseMatchFunds(Donation $donation): void
     {
         $releaseTries = 0;

--- a/tests/Application/Actions/Hooks/DonationUpdateTest.php
+++ b/tests/Application/Actions/Hooks/DonationUpdateTest.php
@@ -173,6 +173,7 @@ class DonationUpdateTest extends TestCase
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
         $entityManagerProphecy->persist(Argument::type(Donation::class))->shouldBeCalledOnce();
+        $entityManagerProphecy->flush()->shouldBeCalledOnce();
 
         $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
         $container->set(EntityManagerInterface::class, $entityManagerProphecy->reveal());
@@ -228,6 +229,7 @@ class DonationUpdateTest extends TestCase
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
         $entityManagerProphecy->persist(Argument::type(Donation::class))->shouldBeCalledOnce();
+        $entityManagerProphecy->flush()->shouldBeCalledOnce();
 
         $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
         $container->set(EntityManagerInterface::class, $entityManagerProphecy->reveal());


### PR DESCRIPTION
Should eliminate a rare edge case where the same match funds can be released twice.

Also remove a nonsensical match release after success clause in the Stripe hook.