### PR TITLE
Set order of donations to evaluate for possible matching explicitly

### DIFF
--- a/src/Application/Commands/RetrospectivelyMatch.php
+++ b/src/Application/Commands/RetrospectivelyMatch.php
@@ -29,7 +29,7 @@ class RetrospectivelyMatch extends LockingCommand
     protected function configure(): void
     {
         $this->setDescription(
-            "Allocates matching from the last N days' donations if they missed it due to pending reservations"
+            "Allocates matching from the last N days' donations if they missed it due to pending reservations, refunds etc."
         );
         $this->addArgument(
             'days-back',

--- a/src/Application/Commands/RetrospectivelyMatch.php
+++ b/src/Application/Commands/RetrospectivelyMatch.php
@@ -29,7 +29,7 @@ class RetrospectivelyMatch extends LockingCommand
     protected function configure(): void
     {
         $this->setDescription(
-            "Allocates matching from the last N days' donations if they missed it due to pending reservations, refunds etc."
+            "Allocates matching from the last N days' donations if missed due to pending reservations, refunds etc."
         );
         $this->addArgument(
             'days-back',

--- a/src/Domain/DonationRepository.php
+++ b/src/Domain/DonationRepository.php
@@ -332,6 +332,7 @@ class DonationRepository extends SalesforceWriteProxyRepository
             ->andWhere('d.createdAt >= :checkAfter')
             ->groupBy('d')
             ->having('(SUM(fw.amount) IS NULL OR SUM(fw.amount) < d.amount)') // No withdrawals *or* less than donation
+            ->orderBy('d.createdAt', 'ASC')
             ->setParameter('completeStatuses', Donation::getSuccessStatuses())
             ->setParameter('campaignMatched', true)
             ->setParameter('checkAfter', $sinceDate);


### PR DESCRIPTION
So we can:
* assess how close the retrospective match command is to finishing, and
* ensure matching is allocated more intuitively within the given date range