### PR TITLE
MAT-170 - hopefully fix create-then-update logic for good!

### DIFF
--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -21,8 +21,6 @@ use Ramsey\Uuid\UuidInterface;
  */
 class Donation extends SalesforceWriteProxy
 {
-    use TimestampsTrait;
-
     /**
      * @var int
      * @see Donation::$currencyCode

--- a/src/Domain/SalesforceProxy.php
+++ b/src/Domain/SalesforceProxy.php
@@ -29,7 +29,7 @@ abstract class SalesforceProxy extends Model
     /**
      * @param string $salesforceId
      */
-    public function setSalesforceId(?string $salesforceId): void
+    public function setSalesforceId(string $salesforceId): void
     {
         $this->salesforceId = $salesforceId;
     }

--- a/src/Domain/SalesforceWriteProxy.php
+++ b/src/Domain/SalesforceWriteProxy.php
@@ -14,6 +14,8 @@ use Doctrine\ORM\Mapping as ORM;
  */
 abstract class SalesforceWriteProxy extends SalesforceProxy
 {
+    use TimestampsTrait;
+
     /** @var string Object has not yet been sent to Salesforce or queued to be so. */
     public const PUSH_STATUS_NOT_SENT = 'not-sent';
     /** @var string Object should be created in Salesforce. This might be imminent or queued. */
@@ -93,5 +95,17 @@ abstract class SalesforceWriteProxy extends SalesforceProxy
     public function setSalesforcePushStatus(string $salesforcePushStatus): void
     {
         $this->salesforcePushStatus = $salesforcePushStatus;
+    }
+
+    /**
+     * Indicates whether the proxy's local object was created & persisted at least 30 seconds
+     * ago, and so is deemed old enough to be likely stable enough for us to e.g. assume that
+     * another thread is not still trying to do a first push up to Salesforce.
+     *
+     * @return bool Whether object is stable/old enough.
+     */
+    public function isStable(): bool
+    {
+        return $this->createdAt !== null && $this->createdAt < (new DateTime('-30 seconds'));
     }
 }


### PR DESCRIPTION
* for post-error records over 30 seconds old, create-then-update in one go
* for newer ones, log an error but leave them ready to pick up next time