### PR TITLE
MAT-174 reset fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,8 +62,8 @@
             "doctrine orm:clear-cache:result"
         ],
         "doctrine:delete-and-recreate": [
+            "doctrine-migrations migrate first -n",
             "doctrine orm:schema-tool:drop --force",
-            "doctrine orm:schema-tool:create",
             "@doctrine:migrate"
         ],
         "doctrine:ensure-prod": "doctrine orm:ensure-production-settings",

--- a/tests/Application/Commands/ResetMatchingTest.php
+++ b/tests/Application/Commands/ResetMatchingTest.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace MatchBot\Tests\Application\Commands;
 
+use Doctrine\DBAL\Driver\PDOException;
+use Doctrine\DBAL\Exception\TableNotFoundException;
 use MatchBot\Application\Commands\ResetMatching;
 use MatchBot\Application\Matching;
 use MatchBot\Domain\CampaignFunding;
 use MatchBot\Domain\CampaignFundingRepository;
 use MatchBot\Domain\ChampionFund;
 use MatchBot\Tests\TestCase;
+use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Lock\LockFactory;
@@ -48,6 +51,37 @@ class ResetMatchingTest extends TestCase
 
         $expectedOutputLines = [
             'matchbot:reset-matching starting!',
+            'Completed matching reset for 1 fundings.',
+            'matchbot:reset-matching complete!',
+        ];
+        $this->assertEquals(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
+        $this->assertEquals(0, $commandTester->getStatusCode());
+    }
+
+    public function testBlankDb(): void
+    {
+        $matchingAdapterProphecy = $this->prophesize(Matching\Adapter::class);
+        $matchingAdapterProphecy->delete(Argument::type(CampaignFunding::class))->shouldNotBeCalled();
+
+        $campaignFundingRepoProphecy = $this->prophesize(CampaignFundingRepository::class);
+        $campaignFundingRepoProphecy->findAll()
+            ->willThrow(new TableNotFoundException(
+                'An exception occurred.. (unit test sample message)',
+                // Doctrine PDOException (a DriverException subclass) wraps native \PDOException.
+                new PDOException(
+                    new \PDOException("SQLSTATE[42S02]: Base table or view not found: 1146 Table 'matchbot.CampaignFunding' doesn't exist")
+                )))
+            ->shouldBeCalledOnce();
+
+        $command = new ResetMatching($campaignFundingRepoProphecy->reveal(), $matchingAdapterProphecy->reveal());
+        $command->setLockFactory(new LockFactory(new AlwaysAvailableLockStore()));
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([]);
+
+        $expectedOutputLines = [
+            'matchbot:reset-matching starting!',
+            'Skipping matching reset as database is empty.',
             'matchbot:reset-matching complete!',
         ];
         $this->assertEquals(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());

--- a/tests/Application/Commands/ResetMatchingTest.php
+++ b/tests/Application/Commands/ResetMatchingTest.php
@@ -69,8 +69,12 @@ class ResetMatchingTest extends TestCase
                 'An exception occurred.. (unit test sample message)',
                 // Doctrine PDOException (a DriverException subclass) wraps native \PDOException.
                 new PDOException(
-                    new \PDOException("SQLSTATE[42S02]: Base table or view not found: 1146 Table 'matchbot.CampaignFunding' doesn't exist")
-                )))
+                    new \PDOException(
+                        'SQLSTATE[42S02]: Base table or view not found: 1146 ' .
+                        "Table 'matchbot.CampaignFunding' doesn't exist"
+                    )
+                )
+            ))
             ->shouldBeCalledOnce();
 
         $command = new ResetMatching($campaignFundingRepoProphecy->reveal(), $matchingAdapterProphecy->reveal());


### PR DESCRIPTION
* rely just on migrations for schema structure rebuild; reset the migrations table to 'first' first so this can work
* make `ResetMatching` command handle empty database case