### PR TITLE
MAT-177 - error log instead of re-throwing exception when trying to update a 'missing' campaign in Production

### DIFF
--- a/matchbot-cli.php
+++ b/matchbot-cli.php
@@ -54,6 +54,7 @@ $commands = [
         $psr11App->get(CampaignRepository::class),
         $psr11App->get(EntityManagerInterface::class),
         $psr11App->get(FundRepository::class),
+        $psr11App->get(LoggerInterface::class),
     ),
 ];
 

--- a/tests/Application/Commands/UpdateCampaignsTest.php
+++ b/tests/Application/Commands/UpdateCampaignsTest.php
@@ -12,6 +12,7 @@ use MatchBot\Domain\CampaignRepository;
 use MatchBot\Domain\FundRepository;
 use Prophecy\PhpUnit\ProphecyTrait;
 use MatchBot\Tests\TestCase;
+use Psr\Log\NullLogger;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Lock\LockFactory;
 
@@ -36,6 +37,7 @@ class UpdateCampaignsTest extends TestCase
             $campaignRepoProphecy->reveal(),
             $this->getAppInstance()->getContainer()->get(EntityManagerInterface::class),
             $fundRepoProphecy->reveal(),
+            new NullLogger(),
         );
         $command->setLockFactory(new LockFactory(new AlwaysAvailableLockStore()));
 
@@ -70,6 +72,7 @@ class UpdateCampaignsTest extends TestCase
             $campaignRepoProphecy->reveal(),
             $this->getAppInstance()->getContainer()->get(EntityManagerInterface::class),
             $fundRepoProphecy->reveal(),
+            new NullLogger(),
         );
         $command->setLockFactory(new LockFactory(new AlwaysAvailableLockStore()));
 
@@ -102,6 +105,7 @@ class UpdateCampaignsTest extends TestCase
             $campaignRepoProphecy->reveal(),
             $this->getAppInstance()->getContainer()->get(EntityManagerInterface::class),
             $fundRepoProphecy->reveal(),
+            new NullLogger(),
         );
         $command->setLockFactory(new LockFactory(new AlwaysAvailableLockStore()));
 


### PR DESCRIPTION
Handle scenario where a charity with a previously approved campaign is no
longer in a state where they should be allowed to receive donations.