### PR TITLE
MAT-218 - improve payout processing efficiency slightly; increase max payout handler runtime to 2 hours

### DIFF
--- a/app/dependencies.php
+++ b/app/dependencies.php
@@ -27,7 +27,6 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\UidProcessor;
 use Psr\Container\ContainerInterface;
-use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Log\LoggerInterface;
 use Psr\SimpleCache\CacheInterface;
 use Slim\Psr7\Factory\ResponseFactory;

--- a/composer.json
+++ b/composer.json
@@ -126,7 +126,7 @@
         ],
         "messenger:consume": [
             "Composer\\Config::disableProcessTimeout",
-            "php matchbot-cli.php messenger:consume -vv --time-limit=1800"
+            "php matchbot-cli.php messenger:consume -vv --time-limit=7200"
         ],
         "start": "php -S localhost:8080 -t public",
         "test": "phpunit",

--- a/tests/Application/Messenger/Handler/StripePayoutHandlerTest.php
+++ b/tests/Application/Messenger/Handler/StripePayoutHandlerTest.php
@@ -62,7 +62,7 @@ class StripePayoutHandlerTest extends TestCase
 
         $stripeTransferProphecy = $this->prophesize(TransferService::class);
         $stripeTransferProphecy
-            ->all($this->getCommonCalloutArgs())
+            ->all($this->getTransferCalloutArgs())
             ->shouldBeCalledOnce()
             ->willReturn(json_decode($transferResponse));
 
@@ -157,7 +157,7 @@ class StripePayoutHandlerTest extends TestCase
 
         $stripeTransferProphecy = $this->prophesize(TransferService::class);
         $stripeTransferProphecy
-            ->all($this->getCommonCalloutArgs())
+            ->all($this->getTransferCalloutArgs())
             ->shouldBeCalledOnce()
             ->willReturn(json_decode($transferResponse));
 
@@ -227,7 +227,7 @@ class StripePayoutHandlerTest extends TestCase
 
         $stripeTransferProphecy = $this->prophesize(TransferService::class);
         $stripeTransferProphecy
-            ->all($this->getCommonCalloutArgs())
+            ->all($this->getTransferCalloutArgs())
             ->shouldBeCalledOnce()
             ->willReturn(json_decode($transferResponse));
 
@@ -330,11 +330,11 @@ class StripePayoutHandlerTest extends TestCase
 
         $stripeTransferProphecy = $this->prophesize(TransferService::class);
         $stripeTransferProphecy
-            ->all($this->getCommonCalloutArgs())
+            ->all($this->getTransferCalloutArgs())
             ->shouldBeCalledOnce()
             ->willReturn(json_decode($transferResponse1));
         $stripeTransferProphecy
-            ->all(array_merge($this->getCommonCalloutArgs(), ['starting_after' => 'tr_externalId_124']))
+            ->all(array_merge($this->getTransferCalloutArgs(), ['starting_after' => 'tr_externalId_124']))
             ->shouldBeCalledOnce()
             ->willReturn(json_decode($transferResponse2));
 
@@ -413,6 +413,17 @@ class StripePayoutHandlerTest extends TestCase
             'created' => [ // Based on the date range from our standard test data payout (-22D, +1D).
                 'gt' => 1596634856,
                 'lt' => 1598622056
+            ],
+            'limit' => 100
+        ];
+    }
+
+    private function getTransferCalloutArgs(): array
+    {
+        return [
+            'created' => [ // Based on the Connected Account charges min + max times +/- 10s.
+                'gt' => 1594646313,
+                'lt' => 1594646333
             ],
             'limit' => 100
         ];

--- a/tests/TestData/StripeWebhook/ApiResponse/ch_list_with_invalid.json
+++ b/tests/TestData/StripeWebhook/ApiResponse/ch_list_with_invalid.json
@@ -26,7 +26,7 @@
       },
       "calculated_statement_descriptor": null,
       "captured": true,
-      "created": 1606149442,
+      "created": 1594646323,
       "currency": "gbp",
       "customer": null,
       "description": null,


### PR DESCRIPTION
Reduce the date range window for parent Stripe account Transfer checks
from the original 22 days to +/- 10 seconds from the actual earliest and
latest charge created times associated with the payout