### PR TITLE
MAT-227 - handle overseas donations correctly

### DIFF
--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -1019,7 +1019,12 @@ class Donation extends SalesforceWriteProxy
         if ($this->donorHomeAddressLine1 !== null) {
             $donationMessage->house_no = preg_replace('/^([0-9a-z-]+).*$/i', '$1', $this->donorHomeAddressLine1);
         }
-        $donationMessage->postcode = $this->donorHomePostcode;
+
+        $donationMessage->postcode = ($this->donorHomePostcode === 'OVERSEAS')
+            ? ''
+            : ($this->donorHomePostcode ?? '');
+        $donationMessage->overseas = $this->donorHomePostcode === 'OVERSEAS';
+
         $donationMessage->amount = (float) $this->amount;
 
         $donationMessage->org_hmrc_ref = $this->getCampaign()->getCharity()->getHmrcReferenceNumber() ?? '';

--- a/tests/Domain/DonationTest.php
+++ b/tests/Domain/DonationTest.php
@@ -94,7 +94,7 @@ class DonationTest extends TestCase
         $this->assertEquals('1.23', $donation->getOriginalPspFee());
     }
 
-    public function testToClaimBotModel(): void
+    public function testToClaimBotModelUK(): void
     {
         $donation = $this->getTestDonation();
 
@@ -116,5 +116,22 @@ class DonationTest extends TestCase
         $this->assertEquals(123.45, $claimBotMessage->amount);
         $this->assertEquals('AB12345', $claimBotMessage->org_hmrc_ref);
         $this->assertEquals('Test charity', $claimBotMessage->org_name);
+        $this->assertEquals(false, $claimBotMessage->overseas);
+    }
+
+    public function testToClaimBotModelOverseas(): void
+    {
+        $donation = $this->getTestDonation();
+
+        $donation->setDonorHomePostcode('OVERSEAS');
+        $donation->getCampaign()->getCharity()->setTbgClaimingGiftAid(true);
+        $donation->getCampaign()->getCharity()->setHmrcReferenceNumber('AB12345');
+        $donation->setTbgShouldProcessGiftAid(true);
+
+        $claimBotMessage = $donation->toClaimBotModel();
+
+        $this->assertEquals('1', $claimBotMessage->house_no);
+        $this->assertEquals('', $claimBotMessage->postcode);
+        $this->assertEquals(true, $claimBotMessage->overseas);
     }
 }


### PR DESCRIPTION
Also fall back to blank string to avoid a type crash should home postcode be `null`.