### PR TITLE
Return 0 OK and log a warning if a command runs twice

### DIFF
--- a/matchbot-cli.php
+++ b/matchbot-cli.php
@@ -67,6 +67,7 @@ $commands = [
 foreach ($commands as $command) {
     if ($command instanceof LockingCommand) { // i.e. not Symfony Messenger's built-in consumer.
         $command->setLockFactory($psr11App->get(LockFactory::class));
+        $command->setLogger($psr11App->get(LoggerInterface::class));
     }
 
     $cliApp->add($command);

--- a/src/Application/Commands/UpdateCampaigns.php
+++ b/src/Application/Commands/UpdateCampaigns.php
@@ -29,7 +29,7 @@ class UpdateCampaigns extends LockingCommand
         private FundRepository $fundRepository,
         private LoggerInterface $logger
     ) {
-        parent::__construct();
+        parent::__construct(static::$defaultName);
     }
 
     protected function configure(): void

--- a/tests/Application/Commands/ClaimGiftAidTest.php
+++ b/tests/Application/Commands/ClaimGiftAidTest.php
@@ -12,6 +12,7 @@ use MatchBot\Tests\Application\DonationTestDataTrait;
 use MatchBot\Tests\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Log\NullLogger;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Messenger\Envelope;
@@ -103,6 +104,7 @@ class ClaimGiftAidTest extends TestCase
             $routableBusProphecy->reveal(),
         );
         $command->setLockFactory(new LockFactory(new AlwaysAvailableLockStore()));
+        $command->setLogger(new NullLogger());
 
         return $command;
     }

--- a/tests/Application/Commands/ExpireMatchFundsTest.php
+++ b/tests/Application/Commands/ExpireMatchFundsTest.php
@@ -10,6 +10,7 @@ use MatchBot\Domain\DonationRepository;
 use MatchBot\Tests\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Log\NullLogger;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Lock\LockFactory;
 
@@ -61,6 +62,7 @@ class ExpireMatchFundsTest extends TestCase
     {
         $command = new ExpireMatchFunds($donationRepoProphecy->reveal());
         $command->setLockFactory(new LockFactory(new AlwaysAvailableLockStore()));
+        $command->setLogger(new NullLogger());
 
         return $command;
     }

--- a/tests/Application/Commands/HandleOutOfSyncFundsTest.php
+++ b/tests/Application/Commands/HandleOutOfSyncFundsTest.php
@@ -12,6 +12,7 @@ use MatchBot\Domain\FundingWithdrawalRepository;
 use MatchBot\Tests\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Log\NullLogger;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Lock\LockFactory;
@@ -26,6 +27,7 @@ class HandleOutOfSyncFundsTest extends TestCase
             $this->getMatchingAdapterProphecy(false)->reveal(),
         );
         $command->setLockFactory(new LockFactory(new AlwaysAvailableLockStore()));
+        $command->setLogger(new NullLogger());
 
         $commandTester = new CommandTester($command);
         $commandTester->execute(['mode' => 'check']);
@@ -50,6 +52,7 @@ class HandleOutOfSyncFundsTest extends TestCase
             $this->getMatchingAdapterProphecy(true)->reveal(),
         );
         $command->setLockFactory(new LockFactory(new AlwaysAvailableLockStore()));
+        $command->setLogger(new NullLogger());
 
         $commandTester = new CommandTester($command);
         $commandTester->execute(['mode' => 'fix']);
@@ -81,6 +84,7 @@ class HandleOutOfSyncFundsTest extends TestCase
             $this->prophesize(Adapter::class)->reveal(),
         );
         $command->setLockFactory(new LockFactory(new AlwaysAvailableLockStore()));
+        $command->setLogger(new NullLogger());
 
         $commandTester = new CommandTester($command);
         $commandTester->execute([]);
@@ -94,6 +98,7 @@ class HandleOutOfSyncFundsTest extends TestCase
             $this->prophesize(Adapter::class)->reveal(),
         );
         $command->setLockFactory(new LockFactory(new AlwaysAvailableLockStore()));
+        $command->setLogger(new NullLogger());
 
         $commandTester = new CommandTester($command);
         $commandTester->execute(['mode' => 'fixx']);

--- a/tests/Application/Commands/PushDonationsTest.php
+++ b/tests/Application/Commands/PushDonationsTest.php
@@ -7,6 +7,7 @@ namespace MatchBot\Tests\Application\Commands;
 use MatchBot\Application\Commands\PushDonations;
 use MatchBot\Domain\DonationRepository;
 use MatchBot\Tests\TestCase;
+use Psr\Log\NullLogger;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Lock\LockFactory;
 
@@ -24,6 +25,7 @@ class PushDonationsTest extends TestCase
 
         $command = new PushDonations($donationRepoProphecy->reveal());
         $command->setLockFactory(new LockFactory(new AlwaysAvailableLockStore()));
+        $command->setLogger(new NullLogger());
 
         $commandTester = new CommandTester($command);
         $commandTester->execute([]);
@@ -49,6 +51,7 @@ class PushDonationsTest extends TestCase
 
         $command = new PushDonations($donationRepoProphecy->reveal());
         $command->setLockFactory(new LockFactory(new AlwaysAvailableLockStore()));
+        $command->setLogger(new NullLogger());
 
         $commandTester = new CommandTester($command);
         $commandTester->execute([]);

--- a/tests/Application/Commands/ResetMatchingTest.php
+++ b/tests/Application/Commands/ResetMatchingTest.php
@@ -14,6 +14,7 @@ use MatchBot\Domain\CampaignFundingRepository;
 use MatchBot\Domain\ChampionFund;
 use MatchBot\Tests\TestCase;
 use Prophecy\Argument;
+use Psr\Log\NullLogger;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Lock\LockFactory;
 
@@ -43,6 +44,7 @@ class ResetMatchingTest extends TestCase
 
         $command = new ResetMatching($campaignFundingRepoProphecy->reveal(), $matchingAdapterProphecy->reveal());
         $command->setLockFactory(new LockFactory(new AlwaysAvailableLockStore()));
+        $command->setLogger(new NullLogger());
 
         $commandTester = new CommandTester($command);
         $commandTester->execute([]);
@@ -77,6 +79,7 @@ class ResetMatchingTest extends TestCase
 
         $command = new ResetMatching($campaignFundingRepoProphecy->reveal(), $matchingAdapterProphecy->reveal());
         $command->setLockFactory(new LockFactory(new AlwaysAvailableLockStore()));
+        $command->setLogger(new NullLogger());
 
         $commandTester = new CommandTester($command);
         $commandTester->execute([]);

--- a/tests/Application/Commands/RetrospectivelyMatchTest.php
+++ b/tests/Application/Commands/RetrospectivelyMatchTest.php
@@ -9,6 +9,7 @@ use MatchBot\Application\Commands\RetrospectivelyMatch;
 use MatchBot\Domain\DonationRepository;
 use MatchBot\Tests\TestCase;
 use Prophecy\Argument;
+use Psr\Log\NullLogger;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Lock\LockFactory;
@@ -29,6 +30,7 @@ class RetrospectivelyMatchTest extends TestCase
 
         $this->command = new RetrospectivelyMatch($donationRepo->reveal());
         $this->command->setLockFactory(new LockFactory(new AlwaysAvailableLockStore()));
+        $this->command->setLogger(new NullLogger());
     }
 
     public function testMissingDaysBackRefusesToRun(): void

--- a/tests/Application/Commands/UpdateCampaignsTest.php
+++ b/tests/Application/Commands/UpdateCampaignsTest.php
@@ -41,6 +41,7 @@ class UpdateCampaignsTest extends TestCase
             new NullLogger(),
         );
         $command->setLockFactory(new LockFactory(new AlwaysAvailableLockStore()));
+        $command->setLogger(new NullLogger());
 
         $commandTester = new CommandTester($command);
         $commandTester->execute([]);
@@ -76,6 +77,7 @@ class UpdateCampaignsTest extends TestCase
             new NullLogger(),
         );
         $command->setLockFactory(new LockFactory(new AlwaysAvailableLockStore()));
+        $command->setLogger(new NullLogger());
 
         $commandTester = new CommandTester($command);
         $commandTester->execute([]);
@@ -117,6 +119,7 @@ class UpdateCampaignsTest extends TestCase
             new NullLogger(),
         );
         $command->setLockFactory(new LockFactory(new AlwaysAvailableLockStore()));
+        $command->setLogger(new NullLogger());
 
         $commandTester = new CommandTester($command);
         $commandTester->execute([]);
@@ -173,6 +176,7 @@ class UpdateCampaignsTest extends TestCase
             new NullLogger(),
         );
         $command->setLockFactory(new LockFactory(new AlwaysAvailableLockStore()));
+        $command->setLogger(new NullLogger());
 
         $commandTester = new CommandTester($command);
         $commandTester->execute([]);
@@ -206,6 +210,7 @@ class UpdateCampaignsTest extends TestCase
             new NullLogger(),
         );
         $command->setLockFactory(new LockFactory(new AlwaysAvailableLockStore()));
+        $command->setLogger(new NullLogger());
 
         $commandTester = new CommandTester($command);
         $commandTester->execute(['--all' => null]);


### PR DESCRIPTION
CloudWatch Events run "at least once" (https://stackoverflow.com/a/39794141/2803757)
and we have observed the every-minute funds expiry process getting
invoked twice within a couple of seconds several times over late 2021/
early 2022.

If this happens regularly we should know about it, so a warning log that
shows up on dashboards is appropriate. But occasional overlaps are harmless
and we don't want the noise of *error* alarms from this. As we treat all
non-0 return codes from commands as errors, this update has locking commands
return 0 OK once they have logged their warning in this scenario.