### PR TITLE
MAT-234 – temporarily silently strip out ';;' from email addresses

### DIFF
--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -313,9 +313,9 @@ class Donation extends SalesforceWriteProxy
     {
         $data = $this->toApiModel();
 
-        // MAT-168 - truncate dubious, long postcodes for now so records can save in SF.
-        if ($data['homePostcode'] !== null) {
-            $data['homePostcode'] = mb_substr($data['homePostcode'], 0, 8);
+        // MAT-234 - remove dubious patterns from email for now so records can save in SF.
+        if (str_contains($data['emailAddress'], ';;')) {
+            $data['emailAddress'] = str_replace(';;', '', $data['emailAddress']);
         }
 
         $data['createdTime'] = $this->getCreatedDate()->format(DateTimeInterface::ATOM);

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -314,7 +314,7 @@ class Donation extends SalesforceWriteProxy
         $data = $this->toApiModel();
 
         // MAT-234 - remove dubious patterns from email for now so records can save in SF.
-        if (str_contains($data['emailAddress'], ';;')) {
+        if ($data['emailAddress'] !== null && str_contains($data['emailAddress'], ';;')) {
             $data['emailAddress'] = str_replace(';;', '', $data['emailAddress']);
         }
 

--- a/tests/Application/Actions/Donations/CreateTest.php
+++ b/tests/Application/Actions/Donations/CreateTest.php
@@ -732,14 +732,6 @@ class CreateTest extends TestCase
         $this->assertEquals('123CampaignId', $payloadArray['donation']['projectId']);
     }
 
-    public function encodeWithDummyCaptcha(Donation $donation): string
-    {
-        $donationArray = $donation->toApiModel();
-        $donationArray['creationRecaptchaCode'] = 'good response';
-
-        return json_encode($donationArray);
-    }
-
     /**
      * Use unmatched campaign in previous test but also omit all donor-supplied
      * detail except donation and tip amount, to test new 2-step Create setup.
@@ -842,6 +834,14 @@ class CreateTest extends TestCase
         $this->assertEquals('1.11', $payloadArray['donation']['tipAmount']);
         $this->assertEquals('567CharitySFID', $payloadArray['donation']['charityId']);
         $this->assertEquals('123CampaignId', $payloadArray['donation']['projectId']);
+    }
+
+    private function encodeWithDummyCaptcha(Donation $donation): string
+    {
+        $donationArray = $donation->toApiModel();
+        $donationArray['creationRecaptchaCode'] = 'good response';
+
+        return json_encode($donationArray);
     }
 
     private function getTestDonation(

--- a/tests/Domain/DonationTest.php
+++ b/tests/Domain/DonationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MatchBot\Tests\Domain;
 
 use MatchBot\Domain\Donation;
+use MatchBot\Domain\FundingWithdrawal;
 use MatchBot\Tests\Application\DonationTestDataTrait;
 use MatchBot\Tests\TestCase;
 
@@ -92,6 +93,48 @@ class DonationTest extends TestCase
         $donation->setOriginalPspFeeFractional(123);
 
         $this->assertEquals('1.23', $donation->getOriginalPspFee());
+    }
+
+    public function testToApiModel(): void
+    {
+        $fundingWithdrawal = new FundingWithdrawal();
+        $fundingWithdrawal->setAmount('1.23');
+        $donation = $this->getTestDonation();
+        $donation->addFundingWithdrawal($fundingWithdrawal);
+
+        $donationData = $donation->toApiModel();
+
+        $this->assertEquals('john.doe@example.com', $donationData['emailAddress']);
+        $this->assertEquals('1.23', $donationData['matchedAmount']);
+    }
+
+    public function testToApiModelTemporaryHackHasNoImpact(): void
+    {
+        $donation = $this->getTestDonation();
+        $donation->setDonorEmailAddress('noel;;@thebiggive.org.uk');
+
+        $donationData = $donation->toApiModel();
+
+        $this->assertEquals('noel;;@thebiggive.org.uk', $donationData['emailAddress']);
+    }
+
+    public function testToHookModel(): void
+    {
+        $donation = $this->getTestDonation();
+
+        $donationData = $donation->toHookModel();
+
+        $this->assertEquals('john.doe@example.com', $donationData['emailAddress']);
+    }
+
+    public function testToHookModelTemporaryHack(): void
+    {
+        $donation = $this->getTestDonation();
+        $donation->setDonorEmailAddress('noel;;@thebiggive.org.uk');
+
+        $donationData = $donation->toHookModel();
+
+        $this->assertEquals('noel@thebiggive.org.uk', $donationData['emailAddress']);
     }
 
     public function testToClaimBotModelUK(): void


### PR DESCRIPTION
Also remove workaround for previous data issue MAT-168