### PR TITLE
MAT-243 – better validation and tighter currency code requirements

### DIFF
--- a/src/Application/HttpModels/Donation.php
+++ b/src/Application/HttpModels/Donation.php
@@ -14,7 +14,7 @@ class Donation
     public string $charityId;
     /** @var string|null Used only on creates; not persisted. */
     public ?string $creationRecaptchaCode = null;
-    public ?string $currencyCode = 'GBP';
+    public ?string $currencyCode = null;
     public float $donationAmount;
     public ?float $feeCoverAmount = null;
     public ?bool $giftAid;

--- a/src/Domain/DonationRepository.php
+++ b/src/Domain/DonationRepository.php
@@ -138,10 +138,6 @@ class DonationRepository extends SalesforceWriteProxyRepository
             $cacheDriver->deleteAll();
         }
 
-        if (empty($donationData->currencyCode)) {
-            $donationData->currencyCode = 'GBP';
-        }
-
         if ($donationData->currencyCode !== $campaign->getCurrencyCode()) {
             throw new \UnexpectedValueException(sprintf(
                 'Currency %s is invalid for campaign',

--- a/src/Domain/DonationRepository.php
+++ b/src/Domain/DonationRepository.php
@@ -107,8 +107,16 @@ class DonationRepository extends SalesforceWriteProxyRepository
      */
     public function buildFromApiRequest(DonationCreate $donationData): Donation
     {
-        if (empty($donationData->projectId)) {
-            throw new \UnexpectedValueException('Required field "projectId" not set');
+        // Fields where we've historically seen blanks and/or there is zero chance
+        // of success without them.
+        $checkEarlyFields = ['currencyCode', 'donationAmount', 'projectId'];
+        foreach ($checkEarlyFields as $checkEarlyField) {
+            if (empty($donationData->$checkEarlyField)) {
+                throw new \UnexpectedValueException(sprintf(
+                    'Required field "%s" not set',
+                    $checkEarlyField
+                ));
+            }
         }
 
         /** @var Campaign $campaign */


### PR DESCRIPTION
* [MAT-243 – catch missing amounts + currencies early](https://github.com/thebiggive/matchbot/commit/0c537ec3d18caaf7d34a484d8c73619cb34e9e81)
* Test `DonationRepository::buildFromApiRequest()` success and additional failure mode
* [MAT-243 – drop missing currency fallback support from `DonationRepository::buildFromApiRequest()` and donation HTTP model](https://github.com/thebiggive/matchbot/commit/f64a2e1256c57e02977d737e3029886fe49dfdf9)