### PR TITLE
Make successful donation creates respond with HTTP 201 as documented

### DIFF
--- a/src/Application/Actions/Action.php
+++ b/src/Application/Actions/Action.php
@@ -94,9 +94,9 @@ abstract class Action
      * @param  array|object|null $data
      * @return Response
      */
-    protected function respondWithData($data = null): Response
+    protected function respondWithData($data = null, int $statusCode = 200): Response
     {
-        $payload = new ActionPayload(200, $data);
+        $payload = new ActionPayload($statusCode, $data);
         return $this->respond($payload);
     }
 

--- a/src/Application/Actions/Donations/Create.php
+++ b/src/Application/Actions/Donations/Create.php
@@ -189,7 +189,7 @@ class Create extends Action
         // Attempt immediate sync. Buffered for a future batch sync if the SF call fails.
         $this->donationRepository->push($donation, true);
 
-        return $this->respondWithData($response);
+        return $this->respondWithData($response, 201);
     }
 
     private function getStatementDescriptor(Charity $charity): string

--- a/src/Client/Donation.php
+++ b/src/Client/Donation.php
@@ -48,7 +48,8 @@ class Donation extends Common
             throw new BadRequestException('Donation not created');
         }
 
-        if ($response->getStatusCode() !== 200) {
+        // For now, support created response codes of 200 (behaviour as of 3/5/22) or 201 (as documented).
+        if ($response->getStatusCode() > 201 || $response->getStatusCode() < 200) {
             $this->logger->error('Donation create got non-success code ' . $response->getStatusCode());
             throw new BadRequestException('Donation not created');
         }

--- a/tests/Application/Actions/Donations/CreateTest.php
+++ b/tests/Application/Actions/Donations/CreateTest.php
@@ -379,7 +379,7 @@ class CreateTest extends TestCase
         $payload = (string) $response->getBody();
 
         $this->assertJson($payload);
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(201, $response->getStatusCode());
 
         $payloadArray = json_decode($payload, true);
 
@@ -490,7 +490,7 @@ class CreateTest extends TestCase
         $payload = (string) $response->getBody();
 
         $this->assertJson($payload);
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(201, $response->getStatusCode());
 
         $payloadArray = json_decode($payload, true);
 
@@ -605,7 +605,7 @@ class CreateTest extends TestCase
         $payload = (string) $response->getBody();
 
         $this->assertJson($payload);
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(201, $response->getStatusCode());
 
         $payloadArray = json_decode($payload, true);
 
@@ -709,7 +709,7 @@ class CreateTest extends TestCase
         $payload = (string) $response->getBody();
 
         $this->assertJson($payload);
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(201, $response->getStatusCode());
 
         $payloadArray = json_decode($payload, true);
 
@@ -813,7 +813,7 @@ class CreateTest extends TestCase
         $payload = (string) $response->getBody();
 
         $this->assertJson($payload);
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(201, $response->getStatusCode());
 
         $payloadArray = json_decode($payload, true);
 


### PR DESCRIPTION
Spotted while testing with Dom today that HTTP 200 isn't what the
current API contract says will be returned.