### PR TITLE
Give Redis / ElastiCache a full 15s for connection

### DIFF
--- a/app/dependencies.php
+++ b/app/dependencies.php
@@ -162,7 +162,7 @@ return function (ContainerBuilder $containerBuilder) {
             // on construct.
             $redis = new Redis();
             try {
-                $redis->connect($c->get('settings')['redis']['host']);
+                $redis->connect($c->get('settings')['redis']['host'], 6379, 15);
                 $cache = new RedisCache();
                 $cache->setRedis($redis);
                 $cache->setNamespace("matchbot-{$settings['appEnv']}");


### PR DESCRIPTION
It's not totally clear what the default/ previous effective value was but some tasks
seem to give up with timeouts after only a few seconds at most, so this seems a reasonable
step to help isolate issues and perhaps fix slow task startups.