### PR TITLE
MAT-249 – Revert "Give Redis / ElastiCache a full 15s for connection"

### DIFF
--- a/app/dependencies.php
+++ b/app/dependencies.php
@@ -162,7 +162,7 @@ return function (ContainerBuilder $containerBuilder) {
             // on construct.
             $redis = new Redis();
             try {
-                $redis->connect($c->get('settings')['redis']['host'], 6379, 15);
+                $redis->connect($c->get('settings')['redis']['host']);
                 $cache = new RedisCache();
                 $cache->setRedis($redis);
                 $cache->setNamespace("matchbot-{$settings['appEnv']}");


### PR DESCRIPTION
This reverts commit 35af02863ad80e3bbf1a02e82de08f7e00a8fc98.

Reversing the change to reduce the risk of unnecessarily adding a regression or a shorter timeout, and instead move things back to what we did back in April when this was last stable.