### PR TITLE
MAT-262 – expand `Status` to test Doctrine ORM proxies' presence

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,9 @@ orbs:
 
 jobs:
   test: # Also lints first
+    # Working directory must match docker-compose mount / Docker `COPY` for real Doctrine proxy
+    # generation-dependent tests to work.
+    working_directory: /var/www/html
     docker:
       - image: thebiggive/php:dev-8.1
         auth:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,11 +32,6 @@ jobs:
             - vendor
           key: composer-v1-{{ checksum "composer.lock" }}
 
-      - run:
-            name: List Domain directory (temporary)
-            command: |
-                ls -la /var/www/html/src/Domain
-
       - run: composer run lint:check
 
       - run: composer run test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,11 @@ jobs:
             - vendor
           key: composer-v1-{{ checksum "composer.lock" }}
 
+      - run:
+            name: List Domain directory (temporary)
+            command: |
+                ls -la /var/www/html/src/Domain
+
       - run: composer run lint:check
 
       - run: composer run test

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN echo 'opcache.validate_timestamps = 0' >> /usr/local/etc/php/conf.d/opcache-
 RUN apt-get update -qq && apt-get install -y awscli && \
     rm -rf /var/lib/apt/lists/* /var/cache/apk/*
 
-ADD . /var/www/html
+COPY . /var/www/html
 
 # Ensure Apache can run as www-data and still write to these when the Docker build creates them as root.
 RUN chmod 777 /var/www/html/var/cache /var/www/html/var/doctrine /var/www/html/var/doctrine/proxies

--- a/src/Application/Actions/Status.php
+++ b/src/Application/Actions/Status.php
@@ -4,9 +4,17 @@ declare(strict_types=1);
 
 namespace MatchBot\Application\Actions;
 
+use Doctrine\Common\Proxy\ProxyGenerator;
 use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\ORM\EntityManagerInterface;
 use JetBrains\PhpStorm\Pure;
+use MatchBot\Domain\Campaign;
+use MatchBot\Domain\CampaignFunding;
+use MatchBot\Domain\ChampionFund;
+use MatchBot\Domain\Charity;
+use MatchBot\Domain\Donation;
+use MatchBot\Domain\FundingWithdrawal;
+use MatchBot\Domain\Pledge;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Log\LoggerInterface;
 use Redis;
@@ -46,6 +54,10 @@ class Status extends Action
             $errorMessage = 'Database connection failed';
         }
 
+        if (!$this->checkCriticalModelDoctrineProxies()) {
+            $errorMessage = 'Doctrine proxies not built';
+        }
+
         if ($errorMessage === null) {
             return $this->respondWithData(['status' => 'OK']);
         }
@@ -53,5 +65,38 @@ class Status extends Action
         $error = new ActionError(ActionError::SERVER_ERROR, $errorMessage);
 
         return $this->respond(new ActionPayload(500, ['error' => $errorMessage], $error));
+    }
+
+    /**
+     * @return bool Whether all needed proxies are present.
+     */
+    private function checkCriticalModelDoctrineProxies(): bool
+    {
+        // Concrete, core mapped app models only.
+        $criticalModelClasses = [
+            Campaign::class,
+            CampaignFunding::class,
+            ChampionFund::class,
+            Charity::class,
+            Donation::class,
+            FundingWithdrawal::class,
+            Pledge::class,
+        ];
+
+        // A separate ProxyGenerator with the same proxy dir and proxy namespace should produce the paths we need to
+        // test for. We can't call the one inside the EM's ProxyFactory because it's private and we don't want to
+        // call the public method that regenerates proxies, since in deployed ECS envs we set files to be immutable
+        // and expect to generate things only in the `deploy/` entrypoints.
+        $emConfig = $this->entityManager->getConfiguration();
+        $proxyGenerator = new ProxyGenerator($emConfig->getProxyDir(), $emConfig->getProxyNamespace());
+        foreach ($criticalModelClasses as $modelClass) {
+            $expectedFile = $proxyGenerator->getProxyFileName($modelClass);
+
+            if (!file_exists($expectedFile)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/tests/Application/Actions/StatusTest.php
+++ b/tests/Application/Actions/StatusTest.php
@@ -4,11 +4,35 @@ declare(strict_types=1);
 
 namespace MatchBot\Tests\Application\Actions;
 
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+use Doctrine\ORM\Tools\Setup;
 use MatchBot\Application\Actions\ActionPayload;
 use MatchBot\Tests\TestCase;
 
 class StatusTest extends TestCase
 {
+    public function testOK(): void
+    {
+        $app = $this->getAppInstance();
+
+        $entityManager = $this->getConnectedMockEntityManager('/var/www/html/var/doctrine/proxies');
+        $app->getContainer()->set(EntityManagerInterface::class, $entityManager);
+
+        $request = $this->createRequest('GET', '/ping');
+        $response = $app->handle($request);
+        $payload = (string) $response->getBody();
+
+        $expectedPayload = new ActionPayload(200, ['status' => 'OK']);
+        $expectedSerialised = json_encode($expectedPayload, JSON_PRETTY_PRINT);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals($expectedSerialised, $payload);
+    }
+
     public function testRedisErrorWithDummyHostname(): void
     {
         $app = $this->getAppInstance(true); // Use real Redis for this test
@@ -22,5 +46,59 @@ class StatusTest extends TestCase
 
         $this->assertEquals(500, $response->getStatusCode());
         $this->assertEquals($expectedSerialised, $payload);
+    }
+
+    public function testMissingDoctrineORMProxy(): void
+    {
+        $app = $this->getAppInstance();
+
+        // Use a deliberately wrong path so proxies are absent.
+        $entityManager = $this->getConnectedMockEntityManager('/tmp/not/this/dir/proxies');
+
+        $app->getContainer()->set(EntityManagerInterface::class, $entityManager);
+
+        $request = $this->createRequest('GET', '/ping');
+        $response = $app->handle($request);
+        $payload = (string) $response->getBody();
+
+        $expectedPayload = new ActionPayload(500, ['error' => 'Doctrine proxies not built']);
+        $expectedSerialised = json_encode($expectedPayload, JSON_PRETTY_PRINT);
+
+        $this->assertEquals(500, $response->getStatusCode());
+        $this->assertEquals($expectedSerialised, $payload);
+    }
+
+    private function getConnectedMockEntityManager(string $proxyPath): EntityManagerInterface
+    {
+        $cache = new ArrayCache();
+        $ormConfigWithNonStandardProxyVars = Setup::createAnnotationMetadataConfiguration(
+            ['/var/www/html/src/Domain'],
+            false, // Simulate live mode for these tests.
+            $proxyPath,
+            $cache,
+        );
+
+        // No auto-generation – like live mode – for these tests.
+        $ormConfigWithNonStandardProxyVars->setAutoGenerateProxyClasses(false);
+        $ormConfigWithNonStandardProxyVars->setMetadataDriverImpl(
+            new AnnotationDriver(new AnnotationReader(), ['/var/www/html/src/Domain']),
+        );
+        $ormConfigWithNonStandardProxyVars->setMetadataCacheImpl($cache);
+
+        $connectionProphecy = $this->prophesize(Connection::class);
+        $connectionProphecy->isConnected()
+            ->shouldBeCalledOnce()
+            ->willReturn(true);
+
+        $emProphecy = $this->prophesize(EntityManagerInterface::class);
+        $emProphecy->getConfiguration()
+            ->shouldBeCalledOnce()
+            ->willReturn($ormConfigWithNonStandardProxyVars);
+
+        $emProphecy->getConnection()
+            ->shouldBeCalledOnce()
+            ->willReturn($connectionProphecy->reveal());
+
+        return $emProphecy->reveal();
     }
 }

--- a/tests/Application/Actions/StatusTest.php
+++ b/tests/Application/Actions/StatusTest.php
@@ -70,8 +70,9 @@ class StatusTest extends TestCase
         $this->assertEquals($expectedSerialised, $payload);
     }
 
-    private function getConnectedMockEntityManager(string $proxyPath = '/var/www/html/var/doctrine/proxies'): EntityManagerInterface
-    {
+    private function getConnectedMockEntityManager(
+        string $proxyPath = '/var/www/html/var/doctrine/proxies',
+    ): EntityManagerInterface {
         $cache = new ArrayCache();
         $ormConfigWithNonStandardProxyVars = Setup::createAnnotationMetadataConfiguration(
             ['/var/www/html/src/Domain'],


### PR DESCRIPTION
Also expand unit tests to cover the healthy case