### PR TITLE
Only include non-user-error-HTTP exceptions for logging as `.ERROR`

### DIFF
--- a/src/Application/Handlers/HttpErrorHandler.php
+++ b/src/Application/Handlers/HttpErrorHandler.php
@@ -65,9 +65,11 @@ class HttpErrorHandler extends SlimErrorHandler
         $response = $this->responseFactory->createResponse($statusCode);
         $response->getBody()->write($encodedPayload);
 
-        $this->logError(
-            get_class($this->exception) . ": {$this->exception->getMessage()} - {$this->exception->getTraceAsString()}"
-        );
+        if (!($this->exception instanceof HttpException)) {
+            $this->logError(
+                get_class($this->exception) . ": {$this->exception->getMessage()} - {$this->exception->getTraceAsString()}"
+            );
+        }
 
         return $response->withHeader('Content-Type', 'application/json');
     }


### PR DESCRIPTION
Now we are passing in the correct service, Staging is logging every not found request with a high severity log. We definitely need to exclude simple 404s and so far it looks reasonable for all `HttpException` to be excluded from logging at this level.