### PR TITLE
MAT-260 – pessimistic lock all database donations

### DIFF
--- a/src/Application/Actions/Donations/Update.php
+++ b/src/Application/Actions/Donations/Update.php
@@ -51,7 +51,7 @@ class Update extends Action
         }
 
         /** @var Donation $donation */
-        $donation = $this->donationRepository->findOneBy(['uuid' => $this->args['donationId']]);
+        $donation = $this->donationRepository->findForUpdateByUuid($this->args['donationId']);
 
         if (!$donation) {
             throw new DomainRecordNotFoundException('Donation not found');

--- a/src/Application/Actions/Donations/Update.php
+++ b/src/Application/Actions/Donations/Update.php
@@ -51,9 +51,13 @@ class Update extends Action
         }
 
         /** @var Donation $donation */
-        $donation = $this->donationRepository->findForUpdateByUuid($this->args['donationId']);
+        $this->entityManager->beginTransaction();
+
+        $donation = $this->donationRepository->findOneBy(['uuid' => $this->args['donationId']]);
 
         if (!$donation) {
+            $this->entityManager->rollback();
+
             throw new DomainRecordNotFoundException('Donation not found');
         }
 
@@ -73,6 +77,8 @@ class Update extends Action
             $message = 'Donation Update data deserialise error';
             $exceptionType = get_class($exception);
 
+            $this->entityManager->rollback();
+
             return $this->validationError(
                 "$message: $exceptionType - {$exception->getMessage()}",
                 $message,
@@ -81,6 +87,8 @@ class Update extends Action
         }
 
         if (!isset($donationData->status)) {
+            $this->entityManager->rollback();
+
             return $this->validationError(
                 "Donation ID {$this->args['donationId']} could not be updated with missing status",
                 'New status is required'
@@ -92,20 +100,29 @@ class Update extends Action
         }
 
         if ($donationData->status !== $donation->getDonationStatus()) {
+            $this->entityManager->rollback();
+
             return $this->validationError(
                 "Donation ID {$this->args['donationId']} could not be set to status {$donationData->status}",
                 'Status update is only supported for cancellation'
             );
         }
 
-        return $this->addData($donation, $donationData);
+        $response = $this->addData($donation, $donationData);
+
+        return $response;
     }
 
+    /**
+     * Assumes it will be called only after starting a transaction pre-donation-select.
+     */
     private function addData(Donation $donation, HttpModels\Donation $donationData): Response
     {
         // If the app tries to PUT with a different amount, something has gone very wrong and we should
         // explicitly fail instead of ignoring that field.
         if (bccomp($donation->getAmount(), (string) $donationData->donationAmount) !== 0) {
+            $this->entityManager->rollback();
+
             return $this->validationError(
                 "Donation ID {$this->args['donationId']} amount did not match",
                 'Amount updates are not supported'
@@ -114,6 +131,8 @@ class Update extends Action
 
         foreach (['optInCharityEmail', 'optInTbgEmail'] as $requiredBoolean) {
             if (!isset($donationData->$requiredBoolean)) {
+                $this->entityManager->rollback();
+
                 return $this->validationError(sprintf(
                     "Required boolean field '%s' not set",
                     $requiredBoolean,
@@ -122,9 +141,9 @@ class Update extends Action
         }
 
         if ($donationData->currencyCode === 'GBP' && !isset($donationData->giftAid)) {
-            return $this->validationError(sprintf(
-                "Required boolean field 'giftAid' not set",
-            ), null, true);
+            $this->entityManager->rollback();
+
+            return $this->validationError("Required boolean field 'giftAid' not set", null, true);
         }
 
         // These 3 fields are currently set up early in the journey, but are harmless and more flexible
@@ -140,6 +159,8 @@ class Update extends Action
             try {
                 $donation->setTipAmount((string) $donationData->tipAmount);
             } catch (\UnexpectedValueException $exception) {
+                $this->entityManager->rollback();
+
                 return $this->validationError(
                     sprintf("Invalid tipAmount '%s'", $donationData->tipAmount),
                     $exception->getMessage(),
@@ -227,11 +248,13 @@ class Update extends Action
                             $exception->getStripeCode(),
                             $exception->getMessage(),
                         ));
-                        // Quickly distinuish fee change case with response message suffix.
+                        // Quickly distinguish fee change case with response message suffix.
                         $error = new ActionError(
                             ActionError::SERVER_ERROR,
                             'Could not update Stripe Payment Intent [A]',
                         );
+                        $this->entityManager->rollback();
+
                         return $this->respond(new ActionPayload(500, null, $error));
                     }
                 } else {
@@ -243,6 +266,8 @@ class Update extends Action
                         $exception->getMessage(),
                     ));
                     $error = new ActionError(ActionError::SERVER_ERROR, 'Could not update Stripe Payment Intent [B]');
+                    $this->entityManager->rollback();
+
                     return $this->respond(new ActionPayload(500, null, $error));
                 }
             }
@@ -257,12 +282,16 @@ class Update extends Action
     {
         if ($donation->getDonationStatus() === 'Cancelled') {
             $this->logger->info("Donation ID {$this->args['donationId']} was already Cancelled");
+            $this->entityManager->rollback();
+
             return $this->respondWithData($donation->toApiModel());
         }
 
         if ($donation->isSuccessful()) {
             // If a donor uses browser back before loading the thank you page, it is possible for them to get
             // a Cancel dialog and send a cancellation attempt to this endpoint after finishing the donation.
+            $this->entityManager->rollback();
+
             return $this->validationError(
                 "Donation ID {$this->args['donationId']} could not be cancelled as {$donation->getDonationStatus()}",
                 'Donation already finalised'
@@ -273,7 +302,7 @@ class Update extends Action
 
         $donation->setDonationStatus('Cancelled');
 
-        // Save & flush early to reduce the chance of another thread getting the old status.
+        // Save & flush early to reduce chance of lock conflicts.
         $this->save($donation);
 
         if ($donation->getCampaign()->isMatched()) {
@@ -308,6 +337,7 @@ class Update extends Action
 
                 if ($returnError) {
                     $error = new ActionError(ActionError::SERVER_ERROR, 'Could not cancel Stripe Payment Intent');
+
                     return $this->respond(new ActionPayload(500, null, $error));
                 } // Else likely double-send -> fall through to normal 200 OK response and return the donation as-is.
             }
@@ -320,6 +350,8 @@ class Update extends Action
      * Save donation in all cases. Also send updated donation data to Salesforce, *if* we know
      * enough to do so successfully.
      *
+     * Assumes it will be called only after starting a transaction pre-donation-select.
+     *
      * @param Donation $donation
      */
     private function save(Donation $donation): void
@@ -329,6 +361,7 @@ class Update extends Action
         // preferences, so to be safe we persist here first.
         $this->entityManager->persist($donation);
         $this->entityManager->flush();
+        $this->entityManager->commit();
 
         if (!$donation->hasEnoughDataForSalesforce()) {
             return;

--- a/src/Application/Handlers/HttpErrorHandler.php
+++ b/src/Application/Handlers/HttpErrorHandler.php
@@ -66,9 +66,12 @@ class HttpErrorHandler extends SlimErrorHandler
         $response->getBody()->write($encodedPayload);
 
         if (!($this->exception instanceof HttpException)) {
-            $this->logError(
-                get_class($this->exception) . ": {$this->exception->getMessage()} - {$this->exception->getTraceAsString()}"
-            );
+            $this->logError(sprintf(
+                '%s: %s - %s',
+                get_class($this->exception),
+                $this->exception->getMessage(),
+                $this->exception->getTraceAsString(),
+            ));
         }
 
         return $response->withHeader('Content-Type', 'application/json');

--- a/src/Domain/DonationRepository.php
+++ b/src/Domain/DonationRepository.php
@@ -7,8 +7,6 @@ namespace MatchBot\Domain;
 use DateTime;
 use Doctrine\Common\Cache\CacheProvider;
 use Doctrine\DBAL\Exception as DBALException;
-use Doctrine\DBAL\LockMode;
-use Doctrine\ORM\PessimisticLockException;
 use GuzzleHttp\Exception\ClientException;
 use MatchBot\Application\Fees\Calculator;
 use MatchBot\Application\HttpModels\DonationCreate;
@@ -380,52 +378,6 @@ class DonationRepository extends SalesforceWriteProxyRepository
         $this->logInfo('Deallocation took ' . round($lockEndTime - $lockStartTime, 6) . ' seconds');
 
         $fundsReleaseLock->release();
-    }
-
-    /**
-     * @param string $uuid
-     * @return Donation|null
-     * @throw PessimiticLockException If lock acquisition fails.
-     */
-    public function findForUpdateByUuid(string $uuid): ?Donation
-    {
-        $query = $this->getEntityManager()->createQuery('
-            SELECT d FROM MatchBot\Domain\Donation d
-            WHERE d.uuid = :uuid
-        ')
-            ->setParameter('uuid', $uuid)
-            ->setLockMode(LockMode::PESSIMISTIC_WRITE);
-
-        return $query->getOneOrNullResult(); // Leave lock exceptions as unhandled 500s.
-    }
-
-    /**
-     * @param string $transactionId
-     * @return Donation|null
-     * @throw PessimiticLockException If lock acquisition fails twice, 5s apart.
-     */
-    public function findForUpdateByTxnId(string $transactionId): ?Donation
-    {
-        $query = $this->getEntityManager()->createQuery('
-            SELECT d FROM MatchBot\Domain\Donation d
-            WHERE d.transactionId = :transactionId
-        ')
-            ->setParameter('transactionId', $transactionId)
-            ->setLockMode(LockMode::PESSIMISTIC_WRITE);
-
-        try {
-            $result = $query->getOneOrNullResult();
-        } catch (PessimisticLockException $exception) {
-            $this->logWarning(sprintf(
-                'Could not get a lock on donation with transaction ID %s, will try once more in 5s...',
-                $transactionId,
-            ));
-            sleep(5);
-
-            $result = $query->getOneOrNullResult();
-        }
-
-        return $result;
     }
 
     /**

--- a/src/Domain/SalesforceWriteProxyRepository.php
+++ b/src/Domain/SalesforceWriteProxyRepository.php
@@ -169,7 +169,11 @@ abstract class SalesforceWriteProxyRepository extends SalesforceProxyRepository
                     $this->logInfo('... plus interim updates for ' . get_class($proxy) . " {$proxy->getId()}");
                 } else {
                     $proxy->setSalesforcePushStatus(SalesforceWriteProxy::PUSH_STATUS_PENDING_UPDATE);
-                    $this->logError('... with error on interim updates for ' . get_class($proxy) . " {$proxy->getId()}");
+                    $this->logError(sprintf(
+                        '... with error on interim updates for %s %d',
+                        get_class($proxy),
+                        $proxy->getId(),
+                    ));
                 }
             }
         } else {

--- a/tests/Application/Actions/Donations/UpdateTest.php
+++ b/tests/Application/Actions/Donations/UpdateTest.php
@@ -45,7 +45,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
+            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
             ->shouldNotBeCalled();
         $donationRepoProphecy
             ->releaseMatchFunds(Argument::type(Donation::class))
@@ -73,7 +73,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
+            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
             ->shouldNotBeCalled();
         $donationRepoProphecy
             ->releaseMatchFunds(Argument::type(Donation::class))
@@ -104,7 +104,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
+            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
             ->shouldNotBeCalled();
         $donationRepoProphecy
             ->releaseMatchFunds(Argument::type(Donation::class))
@@ -135,7 +135,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findOneBy(['uuid' => '87654321-1234-1234-1234-ba0987654321'])
+            ->findForUpdateByUuid('87654321-1234-1234-1234-ba0987654321')
             ->willReturn(null)
             ->shouldBeCalledOnce();
         $donationRepoProphecy
@@ -168,7 +168,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
+            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
             ->willReturn($this->getTestDonation()) // Get a new mock object so it's 'Collected'.
             ->shouldBeCalledOnce();
         $donationRepoProphecy
@@ -212,7 +212,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
+            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
             ->willReturn($donation)
             ->shouldBeCalledOnce();
         $donationRepoProphecy
@@ -262,7 +262,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
+            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
             ->willReturn($donationResponse)
             ->shouldBeCalledOnce();
         $donationRepoProphecy
@@ -313,7 +313,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
+            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
             ->willReturn($responseDonation)
             ->shouldBeCalledOnce();
         // Cancel is a no-op -> no fund release or push to SF
@@ -373,7 +373,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
+            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
             ->willReturn($responseDonation)
             ->shouldBeCalledOnce();
         $donationRepoProphecy
@@ -447,7 +447,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
+            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
             ->willReturn($responseDonation)
             ->shouldBeCalledOnce();
         $donationRepoProphecy
@@ -514,7 +514,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
+            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
             ->willReturn($responseDonation)
             ->shouldBeCalledOnce();
         $donationRepoProphecy
@@ -577,7 +577,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ac'])
+            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ac')
             ->willReturn($responseDonation)
             ->shouldBeCalledOnce();
         $donationRepoProphecy
@@ -639,7 +639,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
+            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
             ->willReturn($this->getTestDonation()) // Get a new mock object so it's £123.45.
             ->shouldBeCalledOnce();
         $donationRepoProphecy
@@ -682,7 +682,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
+            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
             ->willReturn($donation)
             ->shouldBeCalledOnce();
         $donationRepoProphecy
@@ -732,7 +732,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
+            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
             ->willReturn($donation)
             ->shouldBeCalledOnce();
         $donationRepoProphecy
@@ -780,7 +780,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
+            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
             ->willReturn($donation)
             ->shouldBeCalledOnce();
         $donationRepoProphecy
@@ -829,7 +829,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
+            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
             ->willReturn($this->getTestDonation()) // Get a new mock object so it's £123.45.
             ->shouldBeCalledOnce();
         $donationRepoProphecy
@@ -887,7 +887,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
+            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
             ->willReturn($this->getTestDonation()) // Get a new mock object so DB has old values.
             ->shouldBeCalledOnce();
         $donationRepoProphecy
@@ -980,7 +980,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
+            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
             ->willReturn($this->getTestDonation()) // Get a new mock object so DB has old values.
             ->shouldBeCalledOnce();
         $donationRepoProphecy
@@ -1076,7 +1076,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
+            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
             ->willReturn($this->getTestDonation()) // Get a new mock object so DB has old values.
             ->shouldBeCalledOnce();
         $donationRepoProphecy
@@ -1179,7 +1179,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
+            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
             ->willReturn($this->getTestDonation()) // Get a new mock object so DB has old values.
             ->shouldBeCalledOnce();
         $donationRepoProphecy

--- a/tests/Application/Actions/Donations/UpdateTest.php
+++ b/tests/Application/Actions/Donations/UpdateTest.php
@@ -1368,8 +1368,10 @@ class UpdateTest extends TestCase
             ->shouldBeCalledOnce();
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
+        $entityManagerProphecy->beginTransaction()->shouldBeCalledOnce();
         $entityManagerProphecy->persist(Argument::type(Donation::class))->shouldBeCalledOnce();
         $entityManagerProphecy->flush()->shouldBeCalledOnce();
+        $entityManagerProphecy->commit()->shouldBeCalledOnce();
 
         $stripePaymentIntentsProphecy = $this->prophesize(PaymentIntentService::class);
         $stripePaymentIntentsProphecy->update('pi_externalId_123', [

--- a/tests/Application/Actions/Donations/UpdateTest.php
+++ b/tests/Application/Actions/Donations/UpdateTest.php
@@ -45,7 +45,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
+            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
             ->shouldNotBeCalled();
         $donationRepoProphecy
             ->releaseMatchFunds(Argument::type(Donation::class))
@@ -73,7 +73,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
+            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
             ->shouldNotBeCalled();
         $donationRepoProphecy
             ->releaseMatchFunds(Argument::type(Donation::class))
@@ -104,7 +104,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
+            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
             ->shouldNotBeCalled();
         $donationRepoProphecy
             ->releaseMatchFunds(Argument::type(Donation::class))
@@ -135,7 +135,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findForUpdateByUuid('87654321-1234-1234-1234-ba0987654321')
+            ->findOneBy(['uuid' => '87654321-1234-1234-1234-ba0987654321'])
             ->willReturn(null)
             ->shouldBeCalledOnce();
         $donationRepoProphecy
@@ -145,7 +145,12 @@ class UpdateTest extends TestCase
             ->push(Argument::type(Donation::class), false)
             ->shouldNotBeCalled();
 
+        $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
+        $entityManagerProphecy->beginTransaction()->shouldBeCalledOnce();
+        $entityManagerProphecy->rollback()->shouldBeCalledOnce();
+
         $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
+        $container->set(EntityManagerInterface::class, $entityManagerProphecy->reveal());
 
         $request = $this->createRequest('PUT', '/v1/donations/87654321-1234-1234-1234-ba0987654321')
             ->withHeader('x-tbg-auth', DonationToken::create('87654321-1234-1234-1234-ba0987654321'));
@@ -168,7 +173,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
+            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
             ->willReturn($this->getTestDonation()) // Get a new mock object so it's 'Collected'.
             ->shouldBeCalledOnce();
         $donationRepoProphecy
@@ -178,7 +183,12 @@ class UpdateTest extends TestCase
             ->push(Argument::type(Donation::class), false)
             ->shouldNotBeCalled();
 
+        $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
+        $entityManagerProphecy->beginTransaction()->shouldBeCalledOnce();
+        $entityManagerProphecy->rollback()->shouldBeCalledOnce();
+
         $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
+        $container->set(EntityManagerInterface::class, $entityManagerProphecy->reveal());
 
         $request = $this->createRequest(
             'PUT',
@@ -212,7 +222,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
+            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
             ->willReturn($donation)
             ->shouldBeCalledOnce();
         $donationRepoProphecy
@@ -222,7 +232,12 @@ class UpdateTest extends TestCase
             ->push(Argument::type(Donation::class), false)
             ->shouldNotBeCalled();
 
+        $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
+        $entityManagerProphecy->beginTransaction()->shouldBeCalledOnce();
+        $entityManagerProphecy->rollback()->shouldBeCalledOnce();
+
         $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
+        $container->set(EntityManagerInterface::class, $entityManagerProphecy->reveal());
 
         $donationData = $donation->toApiModel();
         unset($donationData['status']); // Simulate an API client omitting the status JSON field
@@ -262,7 +277,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
+            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
             ->willReturn($donationResponse)
             ->shouldBeCalledOnce();
         $donationRepoProphecy
@@ -272,7 +287,12 @@ class UpdateTest extends TestCase
             ->push(Argument::type(Donation::class), false)
             ->shouldNotBeCalled();
 
+        $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
+        $entityManagerProphecy->beginTransaction()->shouldBeCalledOnce();
+        $entityManagerProphecy->rollback()->shouldBeCalledOnce();
+
         $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
+        $container->set(EntityManagerInterface::class, $entityManagerProphecy->reveal());
 
         $request = $this->createRequest(
             'PUT',
@@ -313,7 +333,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
+            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
             ->willReturn($responseDonation)
             ->shouldBeCalledOnce();
         // Cancel is a no-op -> no fund release or push to SF
@@ -324,7 +344,12 @@ class UpdateTest extends TestCase
             ->push(Argument::type(Donation::class), false)
             ->shouldNotBeCalled();
 
+        $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
+        $entityManagerProphecy->beginTransaction()->shouldBeCalledOnce();
+        $entityManagerProphecy->rollback()->shouldBeCalledOnce();
+
         $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
+        $container->set(EntityManagerInterface::class, $entityManagerProphecy->reveal());
 
         $request = $this->createRequest(
             'PUT',
@@ -373,7 +398,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
+            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
             ->willReturn($responseDonation)
             ->shouldBeCalledOnce();
         $donationRepoProphecy
@@ -386,8 +411,10 @@ class UpdateTest extends TestCase
             ->shouldBeCalledOnce();
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
+        $entityManagerProphecy->beginTransaction()->shouldBeCalledOnce();
         $entityManagerProphecy->persist(Argument::type(Donation::class))->shouldBeCalledOnce();
         $entityManagerProphecy->flush()->shouldBeCalledOnce();
+        $entityManagerProphecy->commit()->shouldBeCalledOnce();
 
         $stripePaymentIntentsProphecy = $this->prophesize(PaymentIntentService::class);
         $stripePaymentIntentsProphecy->cancel('pi_externalId_123')
@@ -447,7 +474,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
+            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
             ->willReturn($responseDonation)
             ->shouldBeCalledOnce();
         $donationRepoProphecy
@@ -460,8 +487,10 @@ class UpdateTest extends TestCase
             ->shouldBeCalledOnce();
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
+        $entityManagerProphecy->beginTransaction()->shouldBeCalledOnce();
         $entityManagerProphecy->persist(Argument::type(Donation::class))->shouldBeCalledOnce();
         $entityManagerProphecy->flush()->shouldBeCalledOnce();
+        $entityManagerProphecy->commit()->shouldBeCalledOnce();
 
         $stripeErrorMessage = 'You cannot cancel this PaymentIntent because it has a status of ' .
             'succeeded. Only a PaymentIntent with one of the following statuses may be canceled: ' .
@@ -514,7 +543,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
+            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
             ->willReturn($responseDonation)
             ->shouldBeCalledOnce();
         $donationRepoProphecy
@@ -527,8 +556,10 @@ class UpdateTest extends TestCase
             ->shouldBeCalledOnce();
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
+        $entityManagerProphecy->beginTransaction()->shouldBeCalledOnce();
         $entityManagerProphecy->persist(Argument::type(Donation::class))->shouldBeCalledOnce();
         $entityManagerProphecy->flush()->shouldBeCalledOnce();
+        $entityManagerProphecy->commit()->shouldBeCalledOnce();
 
         $stripeErrorMessage = 'You cannot cancel this PaymentIntent because it has a status of ' .
             'canceled. Only a PaymentIntent with one of the following statuses may be canceled: ' .
@@ -577,7 +608,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ac')
+            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ac'])
             ->willReturn($responseDonation)
             ->shouldBeCalledOnce();
         $donationRepoProphecy
@@ -590,8 +621,10 @@ class UpdateTest extends TestCase
             ->shouldNotBeCalled();
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
+        $entityManagerProphecy->beginTransaction()->shouldBeCalledOnce();
         $entityManagerProphecy->persist(Argument::type(Donation::class))->shouldBeCalledOnce();
         $entityManagerProphecy->flush()->shouldBeCalledOnce();
+        $entityManagerProphecy->commit()->shouldBeCalledOnce();
 
         $stripePaymentIntentsProphecy = $this->prophesize(PaymentIntentService::class);
         $stripePaymentIntentsProphecy->cancel('pi_stripe_pending_123')
@@ -639,7 +672,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
+            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
             ->willReturn($this->getTestDonation()) // Get a new mock object so it's £123.45.
             ->shouldBeCalledOnce();
         $donationRepoProphecy
@@ -649,7 +682,12 @@ class UpdateTest extends TestCase
             ->push(Argument::type(Donation::class), false)
             ->shouldNotBeCalled();
 
+        $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
+        $entityManagerProphecy->beginTransaction()->shouldBeCalledOnce();
+        $entityManagerProphecy->rollback()->shouldBeCalledOnce();
+
         $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
+        $container->set(EntityManagerInterface::class, $entityManagerProphecy->reveal());
 
         $request = $this->createRequest(
             'PUT',
@@ -682,7 +720,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
+            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
             ->willReturn($donation)
             ->shouldBeCalledOnce();
         $donationRepoProphecy
@@ -692,7 +730,12 @@ class UpdateTest extends TestCase
             ->push(Argument::type(Donation::class), false)
             ->shouldNotBeCalled();
 
+        $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
+        $entityManagerProphecy->beginTransaction()->shouldBeCalledOnce();
+        $entityManagerProphecy->rollback()->shouldBeCalledOnce();
+
         $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
+        $container->set(EntityManagerInterface::class, $entityManagerProphecy->reveal());
 
         // Remove giftAid after converting to array, as it makes the internal HTTP model invalid.
         $donationData = $donation->toApiModel();
@@ -732,7 +775,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
+            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
             ->willReturn($donation)
             ->shouldBeCalledOnce();
         $donationRepoProphecy
@@ -742,7 +785,12 @@ class UpdateTest extends TestCase
             ->push(Argument::type(Donation::class), false)
             ->shouldNotBeCalled();
 
+        $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
+        $entityManagerProphecy->beginTransaction()->shouldBeCalledOnce();
+        $entityManagerProphecy->rollback()->shouldBeCalledOnce();
+
         $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
+        $container->set(EntityManagerInterface::class, $entityManagerProphecy->reveal());
 
         $bodyArray = $donation->toHookModel();
         $bodyArray['homeAddress'] = ['123', 'Main St']; // Invalid array type.
@@ -780,7 +828,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
+            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
             ->willReturn($donation)
             ->shouldBeCalledOnce();
         $donationRepoProphecy
@@ -790,7 +838,12 @@ class UpdateTest extends TestCase
             ->push(Argument::type(Donation::class), false)
             ->shouldNotBeCalled();
 
+        $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
+        $entityManagerProphecy->beginTransaction()->shouldBeCalledOnce();
+        $entityManagerProphecy->rollback()->shouldBeCalledOnce();
+
         $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
+        $container->set(EntityManagerInterface::class, $entityManagerProphecy->reveal());
 
         // Remove giftAid after converting to array, as it makes the internal HTTP model invalid.
         $donationData = $donation->toApiModel();
@@ -829,14 +882,19 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
+            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
             ->willReturn($this->getTestDonation()) // Get a new mock object so it's £123.45.
             ->shouldBeCalledOnce();
         $donationRepoProphecy
             ->push(Argument::type(Donation::class), false)
             ->shouldNotBeCalled();
 
+        $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
+        $entityManagerProphecy->beginTransaction()->shouldBeCalledOnce();
+        $entityManagerProphecy->rollback()->shouldBeCalledOnce();
+
         $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
+        $container->set(EntityManagerInterface::class, $entityManagerProphecy->reveal());
 
         $putArray = $donation->toApiModel();
         $putArray['tipAmount'] = '25000.01';
@@ -887,7 +945,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
+            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
             ->willReturn($this->getTestDonation()) // Get a new mock object so DB has old values.
             ->shouldBeCalledOnce();
         $donationRepoProphecy
@@ -902,8 +960,10 @@ class UpdateTest extends TestCase
             ->shouldBeCalledOnce();
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
+        $entityManagerProphecy->beginTransaction()->shouldBeCalledOnce();
         $entityManagerProphecy->persist(Argument::type(Donation::class))->shouldNotBeCalled();
         $entityManagerProphecy->flush()->shouldNotBeCalled();
+        $entityManagerProphecy->rollback()->shouldBeCalledOnce();
 
         $stripePaymentIntentsProphecy = $this->prophesize(PaymentIntentService::class);
         $stripePaymentIntentsProphecy->update('pi_externalId_123', [
@@ -980,7 +1040,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
+            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
             ->willReturn($this->getTestDonation()) // Get a new mock object so DB has old values.
             ->shouldBeCalledOnce();
         $donationRepoProphecy
@@ -993,8 +1053,10 @@ class UpdateTest extends TestCase
 
         // Persist as normal.
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
+        $entityManagerProphecy->beginTransaction()->shouldBeCalledOnce();
         $entityManagerProphecy->persist(Argument::type(Donation::class))->shouldBeCalledOnce();
         $entityManagerProphecy->flush()->shouldBeCalledOnce();
+        $entityManagerProphecy->commit()->shouldBeCalledOnce();
 
         $stripeErrorMessage = 'The parameter application_fee_amount cannot be updated on a PaymentIntent ' .
             'after a capture has already been made.';
@@ -1076,7 +1138,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
+            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
             ->willReturn($this->getTestDonation()) // Get a new mock object so DB has old values.
             ->shouldBeCalledOnce();
         $donationRepoProphecy
@@ -1090,9 +1152,10 @@ class UpdateTest extends TestCase
             ->willReturn($donation) // Actual fee calculation is tested elsewhere.
             ->shouldBeCalledOnce();
 
+        // Internal persist still goes ahead.
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
-        $entityManagerProphecy->persist(Argument::type(Donation::class))->shouldNotBeCalled();
-        $entityManagerProphecy->flush()->shouldNotBeCalled();
+        $entityManagerProphecy->beginTransaction()->shouldBeCalledOnce();
+        $entityManagerProphecy->rollback()->shouldBeCalledOnce();
 
         $stripeErrorMessage = 'The parameter application_fee_amount cannot be updated on a PaymentIntent ' .
             'after a capture has already been made.';
@@ -1179,7 +1242,7 @@ class UpdateTest extends TestCase
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findForUpdateByUuid('12345678-1234-1234-1234-1234567890ab')
+            ->findOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
             ->willReturn($this->getTestDonation()) // Get a new mock object so DB has old values.
             ->shouldBeCalledOnce();
         $donationRepoProphecy
@@ -1194,8 +1257,10 @@ class UpdateTest extends TestCase
             ->shouldBeCalledOnce();
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
+        $entityManagerProphecy->beginTransaction()->shouldBeCalledOnce();
         $entityManagerProphecy->persist(Argument::type(Donation::class))->shouldBeCalledOnce();
         $entityManagerProphecy->flush()->shouldBeCalledOnce();
+        $entityManagerProphecy->commit()->shouldBeCalledOnce();
 
         $stripePaymentIntentsProphecy = $this->prophesize(PaymentIntentService::class);
         $stripePaymentIntentsProphecy->update('pi_externalId_123', [

--- a/tests/Application/Actions/Hooks/StripeChargeUpdateTest.php
+++ b/tests/Application/Actions/Hooks/StripeChargeUpdateTest.php
@@ -49,7 +49,7 @@ class StripeChargeUpdateTest extends StripeTest
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findOneBy(['transactionId' => 'pi_invalidId_123'])
+            ->findForUpdateByTxnId('pi_invalidId_123')
             ->willReturn(null)
             ->shouldBeCalledOnce();
 
@@ -109,7 +109,7 @@ class StripeChargeUpdateTest extends StripeTest
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findOneBy(['transactionId' => 'pi_externalId_123'])
+            ->findForUpdateByTxnId('pi_externalId_123')
             ->willReturn($donation)
             ->shouldBeCalledOnce();
 
@@ -160,7 +160,7 @@ class StripeChargeUpdateTest extends StripeTest
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findOneBy(['transactionId' => 'pi_externalId_123'])
+            ->findForUpdateByTxnId('pi_externalId_123')
             ->willReturn($donation)
             ->shouldBeCalledOnce();
 
@@ -208,7 +208,7 @@ class StripeChargeUpdateTest extends StripeTest
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findOneBy(['transactionId' => 'pi_externalId_123'])
+            ->findForUpdateByTxnId('pi_externalId_123')
             ->willReturn($donation)
             ->shouldBeCalledOnce();
 
@@ -252,7 +252,7 @@ class StripeChargeUpdateTest extends StripeTest
         // never any data changes to make in the "won" case.
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findOneBy(['transactionId' => 'pi_externalId_123'])
+            ->findForUpdateByTxnId('pi_externalId_123')
             ->shouldNotBeCalled();
 
         $donationRepoProphecy
@@ -294,7 +294,7 @@ class StripeChargeUpdateTest extends StripeTest
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findOneBy(['transactionId' => 'pi_invalidId_123'])
+            ->findForUpdateByTxnId('pi_invalidId_123')
             ->willReturn(null)
             ->shouldBeCalledOnce();
 
@@ -324,7 +324,7 @@ class StripeChargeUpdateTest extends StripeTest
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findOneBy(['transactionId' => 'pi_externalId_123'])
+            ->findForUpdateByTxnId('pi_externalId_123')
             ->willReturn($donation)
             ->shouldBeCalledOnce();
 
@@ -368,7 +368,7 @@ class StripeChargeUpdateTest extends StripeTest
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findOneBy(['chargeId' => 'ch_externalId_123'])
+            ->findForUpdateByTxnId('pi_00000000000000')
             ->willReturn($donation)
             ->shouldBeCalledOnce();
 
@@ -410,7 +410,7 @@ class StripeChargeUpdateTest extends StripeTest
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findOneBy(['chargeId' => 'ch_externalId_123'])
+            ->findForUpdateByTxnId('pi_00000000000000')
             ->willReturn($donation)
             ->shouldBeCalledOnce();
 
@@ -439,7 +439,7 @@ class StripeChargeUpdateTest extends StripeTest
         $this->assertEquals(200, $response->getStatusCode());
     }
 
-    public function testUnsupportRefundAmount(): void
+    public function testUnsupportedRefundAmount(): void
     {
         $app = $this->getAppInstance();
         /** @var Container $container */
@@ -452,7 +452,7 @@ class StripeChargeUpdateTest extends StripeTest
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findOneBy(['chargeId' => 'ch_externalId_123'])
+            ->findForUpdateByTxnId('pi_00000000000000')
             ->willReturn($donation)
             ->shouldBeCalledOnce();
 

--- a/tests/Application/Actions/Hooks/StripeChargeUpdateTest.php
+++ b/tests/Application/Actions/Hooks/StripeChargeUpdateTest.php
@@ -49,7 +49,7 @@ class StripeChargeUpdateTest extends StripeTest
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findForUpdateByTxnId('pi_invalidId_123')
+            ->findOneBy(['transactionId' => 'pi_invalidId_123'])
             ->willReturn(null)
             ->shouldBeCalledOnce();
 
@@ -109,7 +109,7 @@ class StripeChargeUpdateTest extends StripeTest
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findForUpdateByTxnId('pi_externalId_123')
+            ->findOneBy(['transactionId' => 'pi_externalId_123'])
             ->willReturn($donation)
             ->shouldBeCalledOnce();
 
@@ -160,7 +160,7 @@ class StripeChargeUpdateTest extends StripeTest
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findForUpdateByTxnId('pi_externalId_123')
+            ->findOneBy(['transactionId' => 'pi_externalId_123'])
             ->willReturn($donation)
             ->shouldBeCalledOnce();
 
@@ -208,7 +208,7 @@ class StripeChargeUpdateTest extends StripeTest
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findForUpdateByTxnId('pi_externalId_123')
+            ->findOneBy(['transactionId' => 'pi_externalId_123'])
             ->willReturn($donation)
             ->shouldBeCalledOnce();
 
@@ -252,7 +252,7 @@ class StripeChargeUpdateTest extends StripeTest
         // never any data changes to make in the "won" case.
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findForUpdateByTxnId('pi_externalId_123')
+            ->findOneBy(['transactionId' => 'pi_externalId_123'])
             ->shouldNotBeCalled();
 
         $donationRepoProphecy
@@ -294,7 +294,7 @@ class StripeChargeUpdateTest extends StripeTest
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findForUpdateByTxnId('pi_invalidId_123')
+            ->findOneBy(['transactionId' => 'pi_invalidId_123'])
             ->willReturn(null)
             ->shouldBeCalledOnce();
 
@@ -324,7 +324,7 @@ class StripeChargeUpdateTest extends StripeTest
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findForUpdateByTxnId('pi_externalId_123')
+            ->findOneBy(['transactionId' => 'pi_externalId_123'])
             ->willReturn($donation)
             ->shouldBeCalledOnce();
 
@@ -368,7 +368,7 @@ class StripeChargeUpdateTest extends StripeTest
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findForUpdateByTxnId('pi_00000000000000')
+            ->findOneBy(['chargeId' => 'ch_externalId_123'])
             ->willReturn($donation)
             ->shouldBeCalledOnce();
 
@@ -410,7 +410,7 @@ class StripeChargeUpdateTest extends StripeTest
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findForUpdateByTxnId('pi_00000000000000')
+            ->findOneBy(['chargeId' => 'ch_externalId_123'])
             ->willReturn($donation)
             ->shouldBeCalledOnce();
 
@@ -424,6 +424,10 @@ class StripeChargeUpdateTest extends StripeTest
             ->shouldBeCalledOnce();
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
+        $entityManagerProphecy->beginTransaction()->shouldBeCalledOnce();
+        $entityManagerProphecy->persist(Argument::type(Donation::class))->shouldBeCalledOnce();
+        $entityManagerProphecy->flush()->shouldBeCalledOnce();
+        $entityManagerProphecy->commit()->shouldBeCalledOnce();
 
         $container->set(EntityManagerInterface::class, $entityManagerProphecy->reveal());
         $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
@@ -452,7 +456,7 @@ class StripeChargeUpdateTest extends StripeTest
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy
-            ->findForUpdateByTxnId('pi_00000000000000')
+            ->findOneBy(['chargeId' => 'ch_externalId_123'])
             ->willReturn($donation)
             ->shouldBeCalledOnce();
 


### PR DESCRIPTION
For both Stripe charge and donor initiated updates. Use pessimistic locks for both to start out.