### PR TITLE
MAT-267 – fix donations with no `paymentMethodType` pre-push and not in a migration

### DIFF
--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -401,7 +401,7 @@ class Donation extends SalesforceWriteProxy
             'projectId' => $this->getCampaign()->getSalesforceId(),
             'psp' => $this->getPsp(),
             'pspCustomerId' => $this->getPspCustomerId(),
-            'pspMethodType' => $this->paymentMethodType,
+            'pspMethodType' => $this->getPaymentMethodType(),
             'status' => $this->getDonationStatus(),
             'tipAmount' => (float) $this->getTipAmount(),
             'tipGiftAid' => $this->hasTipGiftAid(),
@@ -1079,6 +1079,11 @@ class Donation extends SalesforceWriteProxy
     public function setPspCustomerId(?string $pspCustomerId): void
     {
         $this->pspCustomerId = $pspCustomerId;
+    }
+
+    public function getPaymentMethodType(): ?string
+    {
+        return $this->paymentMethodType;
     }
 
     public function setPaymentMethodType(string $paymentMethodType): void

--- a/src/Domain/DonationRepository.php
+++ b/src/Domain/DonationRepository.php
@@ -67,6 +67,11 @@ class DonationRepository extends SalesforceWriteProxyRepository
      */
     public function doUpdate(SalesforceWriteProxy $donation): bool
     {
+        if ($donation->getPaymentMethodType() === null) {
+            $donation->setPaymentMethodType('card');
+            $this->getEntityManager()->persist($donation);
+        }
+
         try {
             if ($donation->isNew()) {
                 // A new status but an existing Salesforce ID suggests pushes might have ended up out

--- a/src/Migrations/Version20221025044553.php
+++ b/src/Migrations/Version20221025044553.php
@@ -23,7 +23,9 @@ final class Version20221025044553 extends AbstractMigration
             $this->addSql('ALTER TABLE Donation ADD paymentMethodType VARCHAR(255) DEFAULT NULL');
         }
 
-        $this->addSql("UPDATE Donation SET paymentMethodType = 'card' WHERE paymentMethodType IS NULL");
+        // Removed after the fact because Production seems unable to complete
+        // the transaction within the lock time.
+//        $this->addSql("UPDATE Donation SET paymentMethodType = 'card' WHERE paymentMethodType IS NULL");
     }
 
     public function down(Schema $schema): void

--- a/src/Migrations/Version20221030095831.php
+++ b/src/Migrations/Version20221030095831.php
@@ -19,7 +19,9 @@ final class Version20221030095831 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql("UPDATE Donation SET paymentMethodType = :card WHERE paymentMethodType IS NULL", ['card' => 'card']);
+        // Removed after the fact because Production seems unable to complete
+        // the transaction within the lock time.
+//        $this->addSql("UPDATE Donation SET paymentMethodType = :card WHERE paymentMethodType IS NULL", ['card' => 'card']);
     }
 
     public function down(Schema $schema): void


### PR DESCRIPTION
Work around Production update being too slow to complete during a deploy