### PR TITLE
MAT-276 – fix log error noise in new edge case of an edge case

### DIFF
--- a/src/Application/Actions/Donations/Update.php
+++ b/src/Application/Actions/Donations/Update.php
@@ -374,7 +374,7 @@ class Update extends Action
     }
 
     /**
-     * @return Response? Response to send client, if appropriate. HTTP 500.
+     * @return ?Response Response to send client, if appropriate. HTTP 500.
      */
     private function handleGeneralStripeError(ApiErrorException $exception, Donation $donation): ?Response
     {


### PR DESCRIPTION
When Stripe object lock acquisition takes two goes, and then the second Payment Intent update fails due to capture being done, and we have no fee change to send, this can just be an `INFO` log.