### PR TITLE
MAT-260 – fix null handling in new repo helper

### DIFF
--- a/src/Domain/DonationRepository.php
+++ b/src/Domain/DonationRepository.php
@@ -679,14 +679,18 @@ class DonationRepository extends SalesforceWriteProxyRepository
     {
         // We can't actually lock the row until we know the ID of the donation, so we fetch it first
         // using the criteria, and then call find once we know the ID to lock.
-
+        /** @var Donation|null $donation */
         $donation = $this->findOneBy($criteria, $orderBy);
+
+        if ($donation === null) {
+            return null;
+        }
 
         // Donation is already in Doctrine identity map so this won't actually reload it from the DB,
         // and we don't need the return value.
         $this->find($donation->getId(), LockMode::PESSIMISTIC_WRITE);
         $this->_em->refresh($donation);
-        
+
         return $donation;
     }
 }


### PR DESCRIPTION
Missing donations are expected e.g. when a sandbox is handling Stripe hooks, as Stripe have only 1 test mode. And in all cases, a missing item in the first find call should return `null` instead of crashing.