### PR TITLE
MAT-275: Optimize query in \MatchBot\Domain\DonationRepository::findW…

### DIFF
--- a/src/Domain/DonationRepository.php
+++ b/src/Domain/DonationRepository.php
@@ -406,7 +406,7 @@ class DonationRepository extends SalesforceWriteProxyRepository
             ->leftJoin('d.fundingWithdrawals', 'fw')
             ->where('d.donationStatus = :expireWithStatus')
             ->andWhere('d.createdAt < :expireBefore')
-            ->groupBy('d')
+            ->groupBy('d.id')
             ->having('COUNT(fw) > 0')
             ->setParameter('expireWithStatus', 'Pending')
             ->setParameter('expireBefore', $cutoff);


### PR DESCRIPTION
…ithExpiredMatching

Grouping by the donation ID, instead of by all fields of donation allows MySQL to use the existing index on ID for grouping purposes.

Id is a primary key, so we know that when the ID matches all fields of donation match.