### PR TITLE
MAT-289 – Stripe payout.paid message consumer fix and logging config improvement

### DIFF
--- a/app/dependencies.php
+++ b/app/dependencies.php
@@ -129,7 +129,7 @@ return function (ContainerBuilder $containerBuilder) {
             return $factory;
         },
 
-        LoggerInterface::class => function (ContainerInterface $c) {
+        LoggerInterface::class => function (ContainerInterface $c): Logger {
             $settings = $c->get('settings');
 
             $loggerSettings = $settings['logger'];
@@ -155,6 +155,9 @@ return function (ContainerBuilder $containerBuilder) {
         },
 
         MessageBusInterface::class => static function (ContainerInterface $c): MessageBusInterface {
+            /** @var LoggerInterface $logger */
+            $logger = $c->get(LoggerInterface::class);
+
             $sendMiddleware = new SendMessageMiddleware(new SendersLocator(
                 [
                     Messages\Donation::class => [ClaimBotTransport::class],
@@ -162,7 +165,7 @@ return function (ContainerBuilder $containerBuilder) {
                 ],
                 $c,
             ));
-            $sendMiddleware->setLogger($c->get(LoggerInterface::class));
+            $sendMiddleware->setLogger($logger);
 
             $handleMiddleware = new HandleMessageMiddleware(new HandlersLocator(
                 [
@@ -170,7 +173,7 @@ return function (ContainerBuilder $containerBuilder) {
                     StripePayout::class => [$c->get(StripePayoutHandler::class)],
                 ],
             ));
-            $handleMiddleware->setLogger($c->get(LoggerInterface::class));
+            $handleMiddleware->setLogger($logger);
 
             return new MessageBus([
                 $sendMiddleware,

--- a/tests/Application/Messenger/Handler/StripePayoutHandlerTest.php
+++ b/tests/Application/Messenger/Handler/StripePayoutHandlerTest.php
@@ -35,8 +35,11 @@ class StripePayoutHandlerTest extends TestCase
         $chargeResponse = $this->getStripeHookMock('ApiResponse/ch_list_with_invalid');
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
+        $entityManagerProphecy->beginTransaction()->shouldBeCalledOnce();
         $entityManagerProphecy->persist(Argument::type(Donation::class))->shouldNotBeCalled();
-        $entityManagerProphecy->flush()->shouldNotBeCalled();
+        // We call these anyway, now we use txns, to ensure they're closed cleanly.
+        $entityManagerProphecy->flush()->shouldBeCalledOnce();
+        $entityManagerProphecy->commit()->shouldBeCalledOnce();
 
         $stripeBalanceTransactionProphecy = $this->prophesize(BalanceTransactionService::class);
         $stripeBalanceTransactionProphecy->all(
@@ -129,8 +132,11 @@ class StripePayoutHandlerTest extends TestCase
         $donation->setDonationStatus('Failed');
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
+        $entityManagerProphecy->beginTransaction()->shouldBeCalledOnce();
         $entityManagerProphecy->persist(Argument::type(Donation::class))->shouldNotBeCalled();
-        $entityManagerProphecy->flush()->shouldNotBeCalled();
+        // We call these anyway, now we use txns, to ensure they're closed cleanly.
+        $entityManagerProphecy->flush()->shouldBeCalledOnce();
+        $entityManagerProphecy->commit()->shouldBeCalledOnce();
 
         $stripeBalanceTransactionProphecy = $this->prophesize(BalanceTransactionService::class);
         $stripeBalanceTransactionProphecy->all(
@@ -234,8 +240,10 @@ class StripePayoutHandlerTest extends TestCase
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
         $entityManagerProphecy->getRepository(Donation::class)->willReturn($donationRepoProphecy->reveal());
+        $entityManagerProphecy->beginTransaction()->shouldBeCalledOnce();
         $entityManagerProphecy->persist(Argument::type(Donation::class))->shouldBeCalledOnce();
         $entityManagerProphecy->flush()->shouldBeCalledOnce();
+        $entityManagerProphecy->commit()->shouldBeCalledOnce();
 
         $stripeClientProphecy = $this->getStripeClient();
         $stripeClientProphecy->balanceTransactions = $stripeBalanceTransactionProphecy->reveal();
@@ -336,8 +344,10 @@ class StripePayoutHandlerTest extends TestCase
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
         $entityManagerProphecy->getRepository(Donation::class)->willReturn($donationRepoProphecy->reveal());
+        $entityManagerProphecy->beginTransaction()->shouldBeCalledOnce();
         $entityManagerProphecy->persist(Argument::type(Donation::class))->shouldBeCalledTimes(2);
         $entityManagerProphecy->flush()->shouldBeCalledOnce();
+        $entityManagerProphecy->commit()->shouldBeCalledOnce();
 
         $stripeClientProphecy = $this->getStripeClient();
         $stripeClientProphecy->balanceTransactions = $stripeBalanceTransactionProphecy->reveal();

--- a/tests/Application/Messenger/Handler/StripePayoutHandlerTest.php
+++ b/tests/Application/Messenger/Handler/StripePayoutHandlerTest.php
@@ -37,8 +37,8 @@ class StripePayoutHandlerTest extends TestCase
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
         $entityManagerProphecy->beginTransaction()->shouldBeCalledOnce();
         $entityManagerProphecy->persist(Argument::type(Donation::class))->shouldNotBeCalled();
-        // We call these anyway, now we use txns, to ensure they're closed cleanly.
-        $entityManagerProphecy->flush()->shouldBeCalledOnce();
+        $entityManagerProphecy->flush()->shouldNotBeCalled();
+        // We call this on each iteration, now we use txns, to ensure it's closed cleanly.
         $entityManagerProphecy->commit()->shouldBeCalledOnce();
 
         $stripeBalanceTransactionProphecy = $this->prophesize(BalanceTransactionService::class);
@@ -134,8 +134,8 @@ class StripePayoutHandlerTest extends TestCase
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
         $entityManagerProphecy->beginTransaction()->shouldBeCalledOnce();
         $entityManagerProphecy->persist(Argument::type(Donation::class))->shouldNotBeCalled();
-        // We call these anyway, now we use txns, to ensure they're closed cleanly.
-        $entityManagerProphecy->flush()->shouldBeCalledOnce();
+        $entityManagerProphecy->flush()->shouldNotBeCalled();
+        // We call this on each iteration, now we use txns, to ensure it's closed cleanly.
         $entityManagerProphecy->commit()->shouldBeCalledOnce();
 
         $stripeBalanceTransactionProphecy = $this->prophesize(BalanceTransactionService::class);
@@ -344,10 +344,10 @@ class StripePayoutHandlerTest extends TestCase
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
         $entityManagerProphecy->getRepository(Donation::class)->willReturn($donationRepoProphecy->reveal());
-        $entityManagerProphecy->beginTransaction()->shouldBeCalledOnce();
+        $entityManagerProphecy->beginTransaction()->shouldBeCalledTimes(2);
         $entityManagerProphecy->persist(Argument::type(Donation::class))->shouldBeCalledTimes(2);
-        $entityManagerProphecy->flush()->shouldBeCalledOnce();
-        $entityManagerProphecy->commit()->shouldBeCalledOnce();
+        $entityManagerProphecy->flush()->shouldBeCalledTimes(2);
+        $entityManagerProphecy->commit()->shouldBeCalledTimes(2);
 
         $stripeClientProphecy = $this->getStripeClient();
         $stripeClientProphecy->balanceTransactions = $stripeBalanceTransactionProphecy->reveal();


### PR DESCRIPTION
* Stripe payout.paid message consumer: use database transactions as required for object locks
* Symfony Messenger general: Provide a non-null logger to message middlewares