### PR TITLE
Write proxy method rename

### DIFF
--- a/src/Application/Commands/PushDonations.php
+++ b/src/Application/Commands/PushDonations.php
@@ -29,7 +29,7 @@ class PushDonations extends LockingCommand
             $output->writeln("Abandoned $numberAbandoned old Cancelled donations from Salesforce push");
         }
 
-        $numberPushed = $this->donationRepository->pushAllPending();
+        $numberPushed = $this->donationRepository->pushSalesforcePending();
         $output->writeln("Pushed $numberPushed donations to Salesforce");
 
         return 0;

--- a/src/Domain/SalesforceWriteProxyRepository.php
+++ b/src/Domain/SalesforceWriteProxyRepository.php
@@ -106,7 +106,7 @@ abstract class SalesforceWriteProxyRepository extends SalesforceProxyRepository
      * @param int $limit    Maximum of each type of pending object to process
      * @return int  Number of objects pushed
      */
-    public function pushAllPending(int $limit = 200): int
+    public function pushSalesforcePending(int $limit = 200): int
     {
         $proxiesToCreate = $this->findBy(
             ['salesforcePushStatus' => SalesforceWriteProxy::PUSH_STATUS_PENDING_CREATE],

--- a/tests/Application/Commands/PushDonationsTest.php
+++ b/tests/Application/Commands/PushDonationsTest.php
@@ -19,7 +19,7 @@ class PushDonationsTest extends TestCase
         $donationRepoProphecy->abandonOldCancelled()
             ->willReturn(0)
             ->shouldBeCalledOnce();
-        $donationRepoProphecy->pushAllPending()
+        $donationRepoProphecy->pushSalesforcePending()
             ->willReturn(1)
             ->shouldBeCalledOnce();
 
@@ -45,7 +45,7 @@ class PushDonationsTest extends TestCase
         $donationRepoProphecy->abandonOldCancelled()
             ->willReturn(1)
             ->shouldBeCalledOnce();
-        $donationRepoProphecy->pushAllPending()
+        $donationRepoProphecy->pushSalesforcePending()
             ->willReturn(1)
             ->shouldBeCalledOnce();
 


### PR DESCRIPTION
Tiny refinement following trying to explain this method today! The old name is confusing both in looking too much like it might relate to donation status when in a Donation-related context, and in saying "all" when it has a limit by default