### PR TITLE
ID-32: Run tests integrated with MySQL in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,24 @@ jobs:
         auth:
           username: $DOCKER_HUB_USERNAME
           password: $DOCKER_HUB_ACCESS_TOKEN
+        environment:
+          MYSQL_HOST: 127.0.0.1
+          MYSQL_SCHEMA: matchbot
+          MYSQL_USER: root
+          MYSQL_PASSWORD: tbgCircle123
+
+          REDIS_HOST: 127.0.0.1
+      - image: cimg/mysql:8.0
+        auth:
+          username: $DOCKER_HUB_USERNAME
+          password: $DOCKER_HUB_ACCESS_TOKEN
+        environment:
+          MYSQL_DATABASE: matchbot
+          MYSQL_ROOT_PASSWORD: tbgCircle123
+      - image: redis:6.2
+        auth:
+          username: $DOCKER_HUB_USERNAME
+          password: $DOCKER_HUB_ACCESS_TOKEN
 
     steps:
       - checkout
@@ -37,6 +55,8 @@ jobs:
       - run: composer run sa:check
 
       - run: composer run test
+
+      - run: vendor/bin/doctrine-migrations migrate --no-interaction --allow-no-migration --verbose
 
       - codecov/upload:
           file: 'coverage.xml'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,8 @@ jobs:
 
       - run: vendor/bin/doctrine-migrations migrate --no-interaction --allow-no-migration --verbose
 
+      - run: composer run integration-test
+
       - codecov/upload:
           file: 'coverage.xml'
 

--- a/Readme.md
+++ b/Readme.md
@@ -54,6 +54,7 @@ Docker container, or just flush the data store:
 Once you have the app running, you can test with: 
 
     docker-compose exec app composer run test
+    docker-compose exec app composer run integration-test
 
 When run with a coverage driver (e.g. Xdebug enabled by using `thebiggive/php:dev-8.1`),
 this will save coverage data to `./coverage.xml`.

--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "MatchBot\\Tests\\": "tests/"
+            "MatchBot\\Tests\\": "tests/",
+            "MatchBot\\IntegrationTests\\": "integrationTests/"
         }
     },
     "scripts": {
@@ -145,6 +146,7 @@
             "php matchbot-cli.php messenger:consume -vv --time-limit=7080"
         ],
         "start": "php -S localhost:8080 -t public",
-        "test": "XDEBUG_MODE=coverage phpunit"
+        "test": "XDEBUG_MODE=coverage phpunit --order-by=random",
+        "integration-test": "XDEBUG_MODE=coverage phpunit --config=phpunit-integration.xml --order-by=random"
     }
 }

--- a/integrationTests/CharityRepositoryTest.php
+++ b/integrationTests/CharityRepositoryTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
 
         $found = $sut->find("non-existant-id");
 
-        $this->assertSame(null, $found);
+        $this->assertNull($found);
     }
 
     public function testItFindsACharity(): void

--- a/integrationTests/CharityRepositoryTest.php
+++ b/integrationTests/CharityRepositoryTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace MatchBot\IntegrationTests;
+
+use Doctrine\ORM\EntityManagerInterface;
+use MatchBot\Domain\Charity;
+use MatchBot\Domain\CharityRepository;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * CharityRepository probably doesn't really need testing since it has no code of its own, but this
+ * is a proof of concept integration test + serves to check that the database connection and ORM are configured
+ * correctly and migrations have been run.
+ */class CharityRepositoryTest extends IntegrationTest
+{
+    public function testItDoesNotFindCharityThatDoesNotExist(): void
+    {
+        $sut = $this->getService(CharityRepository::class);
+
+        $found = $sut->find("non-existant-id");
+
+        $this->assertSame(null, $found);
+    }
+
+    public function testItFindsACharity(): void
+    {
+        // arrange
+        $sut = $this->getService(CharityRepository::class);
+
+        $charity = new Charity();
+        $charity->setDonateLinkId("doesn't matter, has to be set");
+        $charity->setName("Charity Name");
+
+        $em = $this->getService(EntityManagerInterface::class);
+        $em->persist($charity);
+        $em->flush();
+
+        $charityId = $charity->getId(); // ID is set by the ORM, so we can't hard-code it here.
+
+        $em->clear(); // forces loading a fresh copy from the DB when we call find.
+
+        // act
+        $charityReturnedFromDB = $sut->find($charityId);
+        assert($charityReturnedFromDB instanceof Charity);
+
+        // assert
+        $this->assertNotSame($charity, $charityReturnedFromDB); // proves that we loaded a new copy of the charity out of the DB.
+        $this->assertSame("Charity Name", $charity->getName());
+    }
+}

--- a/integrationTests/IntegrationTest.php
+++ b/integrationTests/IntegrationTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace MatchBot\IntegrationTests;
+
+use IntegrationTests;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Slim\App;
+
+abstract class IntegrationTest extends TestCase
+{
+    public static ?ContainerInterface $integrationTestContainer = null;
+    public static ?App $app = null;
+
+    public static function setContainer(ContainerInterface $container): void
+    {
+        self::$integrationTestContainer = $container;
+    }
+
+    public static function setApp(App $app): void
+    {
+        self::$app = $app;
+    }
+
+    protected function getContainer(): ContainerInterface
+    {
+        if (self::$integrationTestContainer === null) {
+            throw new \Exception("Test container not set");
+        }
+        return self::$integrationTestContainer;
+    }
+
+    protected function getApp(): App
+    {
+        if (self::$app === null) {
+            throw new \Exception("Test app not set");
+        }
+        return self::$app;
+    }
+
+    /**
+     * @template T
+     * @param class-string<T> $name
+     * @return T
+     */ public function getService(string $name): mixed
+    {
+        $service = $this->getContainer()->get($name);
+        $this->assertInstanceOf($name, $service);
+
+        return $service;
+    }
+}

--- a/integrationTests/PingSmokeTest.php
+++ b/integrationTests/PingSmokeTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use GuzzleHttp\Psr7\ServerRequest;
+use MatchBot\IntegrationTests\IntegrationTest;
+
+class PingSmokeTest extends IntegrationTest
+{
+    public function testItReturnsOKStatus(): void
+    {
+        $request = new ServerRequest('GET', '/ping');
+
+        $response = $this->getApp()->handle($request);
+
+        $this->assertJsonStringEqualsJsonString(
+            '{"status": "OK"}',
+            (string) $response->getBody()
+        );
+    }
+}

--- a/integrationTests/bootstrap.php
+++ b/integrationTests/bootstrap.php
@@ -1,0 +1,19 @@
+<?php
+
+use MatchBot\IntegrationTests\IntegrationTest;
+use Slim\Factory\AppFactory;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$container = require __DIR__ . '/../bootstrap.php';
+IntegrationTest::setContainer($container);
+
+// Instantiate the app
+AppFactory::setContainer($container);
+$app = AppFactory::create();
+
+// Register routes
+$routes = require __DIR__ . '/../app/routes.php';
+$routes($app);
+
+IntegrationTest::setApp($app);

--- a/phpunit-integration.xml
+++ b/phpunit-integration.xml
@@ -1,22 +1,5 @@
 <?xml version="1.0"?>
-<phpunit
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
-        backupGlobals="false"
-        backupStaticAttributes="false"
-        beStrictAboutTestsThatDoNotTestAnything="true"
-        beStrictAboutChangesToGlobalState="true"
-        beStrictAboutOutputDuringTests="true"
-        colors="true"
-        convertErrorsToExceptions="true"
-        convertNoticesToExceptions="true"
-        convertWarningsToExceptions="true"
-        processIsolation="false"
-        stopOnFailure="false"
-        bootstrap="tests/bootstrap.php"
-
->
-
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" backupStaticAttributes="false" beStrictAboutTestsThatDoNotTestAnything="true" beStrictAboutChangesToGlobalState="true" beStrictAboutOutputDuringTests="true" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="integrationTests/bootstrap.php">
   <coverage processUncoveredFiles="true">
     <include>
       <directory suffix=".php">./src</directory>
@@ -30,7 +13,7 @@
   </coverage>
   <testsuites>
     <testsuite name="Test Suite">
-      <directory>./tests/</directory>
+      <directory>./integrationTests/</directory>
     </testsuite>
   </testsuites>
   <php>
@@ -40,8 +23,6 @@
     <env name="JWT_DONATION_SECRET" value="unitTestJWTSecret" force="true"/>
     <env name="JWT_ID_SECRET" value="unitTestJWTSecret" force="true"/>
     <env name="MAX_CREATES_PER_IP_PER_5M" value="1" force="true" />
-    <env name="MYSQL_HOST" value="dummy-mysql-hostname" force="true"/>
-    <env name="REDIS_HOST" value="dummy-redis-hostname" force="true"/>
     <env name="STRIPE_API_VERSION" value="2022-08-01" />
     <env name="STRIPE_SECRET_KEY" value="sk_test_unitTestFakeKey" force="true"/>
     <env name="STRIPE_WEBHOOK_SIGNING_SECRET" value="whsec_test_unitTestFakeKey" force="true"/>

--- a/psalm.xml
+++ b/psalm.xml
@@ -14,6 +14,7 @@
         <directory name="public"/>
         <directory name="src"/>
         <directory name="tests"/>
+        <directory name="integrationTests"/>
         <ignoreFiles>
             <directory name="vendor"/>
         </ignoreFiles>
@@ -22,6 +23,7 @@
         <UnusedClass>
             <errorLevel type="suppress">
                 <directory name="src/Migrations" />
+                <directory name="integrationTests" />
             </errorLevel>
         </UnusedClass>
         <PossiblyUnusedMethod>

--- a/src/Migrations/Version20230117173337.php
+++ b/src/Migrations/Version20230117173337.php
@@ -21,7 +21,7 @@ final class Version20230117173337 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $updateCollectedAtSql = <<<EOT
-UPDATE Donation
+UPDATE DonationXXXXXXXXXx
 SET salesforcePushStatus = 'pending-update', donationStatus = 'Paid', collectedAt = createdAt
 WHERE salesforceId IN (:sfIds)
 LIMIT 3

--- a/src/Migrations/Version20230117173337.php
+++ b/src/Migrations/Version20230117173337.php
@@ -21,7 +21,7 @@ final class Version20230117173337 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $updateCollectedAtSql = <<<EOT
-UPDATE DonationXXXXXXXXXx
+UPDATE Donation
 SET salesforcePushStatus = 'pending-update', donationStatus = 'Paid', collectedAt = createdAt
 WHERE salesforceId IN (:sfIds)
 LIMIT 3


### PR DESCRIPTION
Sorry this is in matchbot and the Jira was `id` - it felt like it was most urgent to get this done for `matchbot`. If this is approved it should be pretty simple to copy the setup into `identity` and run similar checks there.

The other idea suggest in the ticket that isn't done yet but could be is checking that `migrations:diff` doesn't attempt to make any changes if run in Circle - i.e. that whatever changes it would make have already been committed into a migrations file.