### PR TITLE
Bg2-2296 document donation statuses ii

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -286,8 +286,7 @@ components:
             "Cancelled",
             "Refunded",
             "Failed",
-            "Chargedback",
-            "PendingCancellation"
+            "Chargedback"
           ]
           example: "Paid"
         feeCoverAmount:

--- a/api.yaml
+++ b/api.yaml
@@ -287,7 +287,6 @@ components:
             "Refunded",
             "Failed",
             "Chargedback",
-            "RefundingPending",
             "PendingCancellation"
           ]
           example: "Paid"

--- a/api.yaml
+++ b/api.yaml
@@ -275,6 +275,7 @@ components:
           enum: ["card", "customer_balance"]
           default: "card"
         status:
+          description: See comments in \MatchBot\Domain\DonationStatus for semantics
           readOnly: true
           type: string
           enum: [

--- a/src/Application/Actions/Donations/Update.php
+++ b/src/Application/Actions/Donations/Update.php
@@ -276,7 +276,7 @@ class Update extends Action
             return $this->respondWithData($response, $donation->toApiModel());
         }
 
-        if ($donation->isSuccessful()) {
+        if ($donation->getDonationStatus()->isSuccessful()) {
             // If a donor uses browser back before loading the thank you page, it is possible for them to get
             // a Cancel dialog and send a cancellation attempt to this endpoint after finishing the donation.
             $this->entityManager->rollback();

--- a/src/Application/Actions/Hooks/StripeChargeUpdate.php
+++ b/src/Application/Actions/Hooks/StripeChargeUpdate.php
@@ -300,7 +300,7 @@ class StripeChargeUpdate extends Stripe
         // the refunded amount is equal to the local txn amount.
         if (
             $isFullRefundOrLostDispute &&
-            $donation->isReversed() &&
+            $donation->getDonationStatus()->isReversed() &&
             $donation->getCampaign()->isMatched()
         ) {
             $this->donationRepository->releaseMatchFunds($donation);

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -369,7 +369,7 @@ class Donation extends SalesforceWriteProxy
             'homeAddress' => $this->getDonorHomeAddressLine1(),
             'homePostcode' => $this->getDonorHomePostcode(),
             'lastName' => $this->getDonorLastName(true),
-            'matchedAmount' => $this->isSuccessful() ? (float) $this->getFundingWithdrawalTotal() : 0,
+            'matchedAmount' => $this->getDonationStatus()->isSuccessful() ? (float) $this->getFundingWithdrawalTotal() : 0,
             'matchReservedAmount' => 0,
             'optInCharityEmail' => $this->getCharityComms(),
             'optInChampionEmail' => $this->getChampionComms(),
@@ -389,16 +389,6 @@ class Donation extends SalesforceWriteProxy
         }
 
         return $data;
-    }
-
-    /**
-     * @return bool Whether this donation is *currently* in a state that we consider to be successful.
-     *              Note that this is not guaranteed to be permanent: donations can be refunded or charged back after
-     *              being in a state where this method is `true`.
-     */
-    public function isSuccessful(): bool
-    {
-        return in_array($this->donationStatus, DonationStatus::SUCCESS_STATUSES, true);
     }
 
     /**
@@ -641,7 +631,7 @@ class Donation extends SalesforceWriteProxy
      */
     public function getConfirmedChampionWithdrawalTotal(): string
     {
-        if (!$this->isSuccessful()) {
+        if (!$this->getDonationStatus()->isSuccessful()) {
             return '0.0';
         }
 
@@ -661,7 +651,7 @@ class Donation extends SalesforceWriteProxy
      */
     public function getConfirmedPledgeWithdrawalTotal(): string
     {
-        if (!$this->isSuccessful()) {
+        if (!$this->getDonationStatus()->isSuccessful()) {
             return '0.0';
         }
 

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -852,7 +852,7 @@ class Donation extends SalesforceWriteProxy
      */
     public function hasPostCreateUpdates(): bool
     {
-        return !in_array($this->getDonationStatus(), DonationStatus::NEW_STATUSES, true);
+        return ! $this->getDonationStatus()->isNew();
     }
 
     /**
@@ -1122,11 +1122,6 @@ class Donation extends SalesforceWriteProxy
     public function hasEnoughDataForSalesforce(): bool
     {
         return !empty($this->getDonorFirstName()) && !empty($this->getDonorLastName());
-    }
-
-    public function isNew(): bool
-    {
-        return in_array($this->donationStatus, DonationStatus::NEW_STATUSES, true);
     }
 
     public function toClaimBotModel(): Messages\Donation

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -384,7 +384,7 @@ class Donation extends SalesforceWriteProxy
             'transactionId' => $this->getTransactionId(),
         ];
 
-        if (in_array($this->getDonationStatus(), [DonationStatus::Pending, DonationStatus::Reserved], true)) {
+        if ($this->getDonationStatus() === DonationStatus::Pending) {
             $data['matchReservedAmount'] = (float) $this->getFundingWithdrawalTotal();
         }
 

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -391,14 +391,6 @@ class Donation extends SalesforceWriteProxy
         return $data;
     }
 
-    /**
-     * @return bool Whether this donation is in a reversed / failed state.
-     */
-    public function isReversed(): bool
-    {
-        return in_array($this->donationStatus, DonationStatus::REVERSED_STATUSES, true);
-    }
-
     public function getDonationStatus(): DonationStatus
     {
         return $this->donationStatus;
@@ -1174,4 +1166,5 @@ class Donation extends SalesforceWriteProxy
 
         return mb_substr($text, 0, 40);
     }
+
 }

--- a/src/Domain/DonationRepository.php
+++ b/src/Domain/DonationRepository.php
@@ -77,7 +77,7 @@ class DonationRepository extends SalesforceWriteProxyRepository
         }
 
         try {
-            if ($donation->isNew()) {
+            if ($donation->getDonationStatus()->isNew()) {
                 // A new status but an existing Salesforce ID suggests pushes might have ended up out
                 // of order due to race conditions pushing to Salesforce, variable and quite slow
                 // Salesforce performance characteristics, and both client (this) & server (SF) apps being

--- a/src/Domain/DonationStatus.php
+++ b/src/Domain/DonationStatus.php
@@ -20,6 +20,12 @@ enum DonationStatus: string
     public const REVERSED_STATUSES = [self::Refunded, self::Failed, self::Chargedback];
 
     case Cancelled = 'Cancelled';
+
+    /**
+     * Exists in database entries from 2020 only. There is now no code that can set a Chargedback status.
+     * We may want to see if eventually these can be archived and moved out of the live DB, and then this case can be
+     * removed.
+     */
     case Chargedback = 'Chargedback';
     case Collected = 'Collected';
     case Failed = 'Failed';

--- a/src/Domain/DonationStatus.php
+++ b/src/Domain/DonationStatus.php
@@ -26,6 +26,5 @@ enum DonationStatus: string
     case NotSet = 'NotSet';
     case Paid = 'Paid';
     case Pending = 'Pending';
-    case PendingCancellation = 'PendingCancellation';
     case Refunded = 'Refunded';
 }

--- a/src/Domain/DonationStatus.php
+++ b/src/Domain/DonationStatus.php
@@ -12,11 +12,6 @@ enum DonationStatus: string
 {
     public const SUCCESS_STATUSES = [self::Collected, self::Paid];
 
-    /**
-     * @link https://thebiggive.slack.com/archives/GGQRV08BZ/p1576070168066200?thread_ts=1575655432.161800&cid=GGQRV08BZ
-     */
-    public const REVERSED_STATUSES = [self::Refunded, self::Failed, self::Chargedback];
-
     public function isNew(): bool
     {
         return match ($this) {
@@ -35,9 +30,15 @@ enum DonationStatus: string
         return in_array($this, self::SUCCESS_STATUSES, true);
     }
 
+    /**
+     * @link https://thebiggive.slack.com/archives/GGQRV08BZ/p1576070168066200?thread_ts=1575655432.161800&cid=GGQRV08BZ
+     */
     public function isReversed(): bool
     {
-        return in_array($this, DonationStatus::REVERSED_STATUSES, true);
+        return match ($this) {
+            self::Refunded, self::Failed, self::Chargedback => true,
+            default => false,
+        };
     }
 
     /**

--- a/src/Domain/DonationStatus.php
+++ b/src/Domain/DonationStatus.php
@@ -19,7 +19,13 @@ enum DonationStatus: string
      */
     public const REVERSED_STATUSES = [self::Refunded, self::Failed, self::Chargedback];
 
+    case NotSet = 'NotSet';
+    case Pending = 'Pending';
+    case Collected = 'Collected';
+    case Paid = 'Paid';
+    case Refunded = 'Refunded';
     case Cancelled = 'Cancelled';
+    case Failed = 'Failed';
 
     /**
      * Exists in database entries from 2020 only. There is now no code that can set a Chargedback status.
@@ -27,10 +33,4 @@ enum DonationStatus: string
      * removed.
      */
     case Chargedback = 'Chargedback';
-    case Collected = 'Collected';
-    case Failed = 'Failed';
-    case NotSet = 'NotSet';
-    case Paid = 'Paid';
-    case Pending = 'Pending';
-    case Refunded = 'Refunded';
 }

--- a/src/Domain/DonationStatus.php
+++ b/src/Domain/DonationStatus.php
@@ -19,16 +19,63 @@ enum DonationStatus: string
      */
     public const REVERSED_STATUSES = [self::Refunded, self::Failed, self::Chargedback];
 
+    /**
+     * Never saved to database - this is just a placeholder used on incomplete donation objects in memory.
+     * @todo consider removing this, either replace with `null` or preferably force every donation to have a real
+     * status when constructed.
+     */
     case NotSet = 'NotSet';
+
+    /**
+     * A Pending donation represents a non-binding statement of intent to donate. We don't know whether
+     * it will turn into a real donation, but if a donation is old and still pending we can assume it will never
+     * be completed.
+     *
+     * We temporarily reserve match funds for pending donations.
+     */
     case Pending = 'Pending';
+
+    /**
+     * Set when "a charge is successful" in stripe.
+     *
+     * TBH I'm (bdsl) not clear on the difference in meaning between this and Paid. Both are considered succesful
+     * donations.
+     *
+     * @see https://stripe.com/docs/api/events/types/#event_types-charge.succeeded
+     */
     case Collected = 'Collected';
+
+    /**
+     * A donor has transferred the funds for their donation to Big Give.
+     * @see https://stripe.com/docs/api/events/types#event_types-payout.paid
+     */
     case Paid = 'Paid';
+
+    /**
+     * Set when we return the donated money - e.g. in case of a dispute or if we decided to issue a refund for
+     * any other business reason.
+     */
     case Refunded = 'Refunded';
+
+    /**
+     * A donor changed their mind and decided not to donate after initially declaring an intention to donate.
+     *
+     * Currently, this status is only set when sent explicilty from the doante-frontend, e.g. if they leave the
+     * browser open for a long time without completing the donation.
+     *
+     * @todo In future, we might think about auto-cancelling old pending donations.
+     */
     case Cancelled = 'Cancelled';
+
+    /**
+     * I guess historically this would have been set when a payment attempt failed - but we now have no code to set
+     * it, so a donation with a failed payment attempt would remain Pending. As with `Chargedback` we may
+     * want to remove this case defintion from the code.
+     */
     case Failed = 'Failed';
 
     /**
-     * Exists in database entries from 2020 only. There is now no code that can set a Chargedback status.
+     * Exists in database entries from 2020 only. There is now no code that can set this status.
      * We may want to see if eventually these can be archived and moved out of the live DB, and then this case can be
      * removed.
      */

--- a/src/Domain/DonationStatus.php
+++ b/src/Domain/DonationStatus.php
@@ -2,10 +2,6 @@
 
 namespace MatchBot\Domain;
 
-/**
- * @link https://docs.google.com/document/d/11ukX2jOxConiVT3BhzbUKzLfSybG8eie7MX0b0kG89U/edit?usp=sharing
- * @todo Consider vs. Stripe options
- */
 enum DonationStatus: string
 {
     public const SUCCESS_STATUSES = [self::Collected, self::Paid];

--- a/src/Domain/DonationStatus.php
+++ b/src/Domain/DonationStatus.php
@@ -26,6 +26,16 @@ enum DonationStatus: string
     }
 
     /**
+     * @return bool Whether this donation is *currently* in a state that we consider to be successful.
+     *              Note that this is not guaranteed to be permanent: donations can be refunded or charged back after
+     *              being in a state where this method is `true`.
+     */
+    public function isSuccessful(): bool
+    {
+        return in_array($this, self::SUCCESS_STATUSES, true);
+    }
+
+    /**
      * Never saved to database - this is just a placeholder used on incomplete donation objects in memory.
      * @todo consider removing this, either replace with `null` or preferably force every donation to have a real
      * status when constructed.

--- a/src/Domain/DonationStatus.php
+++ b/src/Domain/DonationStatus.php
@@ -58,17 +58,20 @@ enum DonationStatus: string
     case Pending = 'Pending';
 
     /**
-     * Set when "a charge is successful" in stripe.
+     * Donation has been paid in to Big Give's Stripe account, but not yet transferred to the charity.
      *
-     * TBH I'm (bdsl) not clear on the difference in meaning between this and Paid. Both are considered succesful
-     * donations.
+     * Generally this should just be temporary status, but there are a few old donations marked 'Collected' in the DB
+     * for historical reasons.
      *
+     * Set when receive the charge.succeded event from Stripe.
      * @see https://stripe.com/docs/api/events/types/#event_types-charge.succeeded
      */
     case Collected = 'Collected';
 
     /**
-     * A donor has transferred the funds for their donation to Big Give.
+     * Donation has been paid out to the charity.
+     *
+     * Set when we receive the payout.paid event from Stripe.
      * @see https://stripe.com/docs/api/events/types#event_types-payout.paid
      */
     case Paid = 'Paid';

--- a/src/Domain/DonationStatus.php
+++ b/src/Domain/DonationStatus.php
@@ -23,11 +23,10 @@ enum DonationStatus: string
     case Chargedback = 'Chargedback';
     case Collected = 'Collected';
     case Failed = 'Failed';
-    case NotSet = "NotSet";
+    case NotSet = 'NotSet';
     case Paid = 'Paid';
-    case Pending = "Pending";
+    case Pending = 'Pending';
     case PendingCancellation = 'PendingCancellation';
-    case Refunded = "Refunded";
+    case Refunded = 'Refunded';
     case RefundingPending = 'RefundingPending';
-    case Reserved = 'Reserved';
 }

--- a/src/Domain/DonationStatus.php
+++ b/src/Domain/DonationStatus.php
@@ -28,5 +28,4 @@ enum DonationStatus: string
     case Pending = 'Pending';
     case PendingCancellation = 'PendingCancellation';
     case Refunded = 'Refunded';
-    case RefundingPending = 'RefundingPending';
 }

--- a/src/Domain/DonationStatus.php
+++ b/src/Domain/DonationStatus.php
@@ -5,8 +5,6 @@ namespace MatchBot\Domain;
 /**
  * @link https://docs.google.com/document/d/11ukX2jOxConiVT3BhzbUKzLfSybG8eie7MX0b0kG89U/edit?usp=sharing
  * @todo Consider vs. Stripe options
- *
- * @todo before merging BG2-2296 - check that the prod DB doesn't have any statuses recorded not listed below.
  */
 enum DonationStatus: string
 {

--- a/src/Domain/DonationStatus.php
+++ b/src/Domain/DonationStatus.php
@@ -83,10 +83,11 @@ enum DonationStatus: string
     /**
      * A donor changed their mind and decided not to donate after initially declaring an intention to donate.
      *
-     * Currently, this status is only set when sent explicilty from the doante-frontend, e.g. if they leave the
+     * Currently, this status is only set when sent explicitly from the donate-frontend, e.g. if they leave the
      * browser open for a long time without completing the donation.
      *
-     * @todo In future, we might think about auto-cancelling old pending donations.
+     * @todo In future, we might think about auto-cancelling old pending donations - or alternately merging this status
+     *       with Pending if we don't need a distinction.
      */
     case Cancelled = 'Cancelled';
 

--- a/src/Domain/DonationStatus.php
+++ b/src/Domain/DonationStatus.php
@@ -12,12 +12,18 @@ enum DonationStatus: string
 {
     public const SUCCESS_STATUSES = [self::Collected, self::Paid];
 
-    public const NEW_STATUSES = [self::NotSet, self::Pending];
-
     /**
      * @link https://thebiggive.slack.com/archives/GGQRV08BZ/p1576070168066200?thread_ts=1575655432.161800&cid=GGQRV08BZ
      */
     public const REVERSED_STATUSES = [self::Refunded, self::Failed, self::Chargedback];
+
+    public function isNew(): bool
+    {
+        return match ($this) {
+            self::NotSet, self::Pending => true,
+            default => false,
+        };
+    }
 
     /**
      * Never saved to database - this is just a placeholder used on incomplete donation objects in memory.

--- a/src/Domain/DonationStatus.php
+++ b/src/Domain/DonationStatus.php
@@ -35,6 +35,11 @@ enum DonationStatus: string
         return in_array($this, self::SUCCESS_STATUSES, true);
     }
 
+    public function isReversed(): bool
+    {
+        return in_array($this, DonationStatus::REVERSED_STATUSES, true);
+    }
+
     /**
      * Never saved to database - this is just a placeholder used on incomplete donation objects in memory.
      * @todo consider removing this, either replace with `null` or preferably force every donation to have a real

--- a/tests/Domain/DonationTest.php
+++ b/tests/Domain/DonationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MatchBot\Tests\Domain;
 
 use MatchBot\Domain\Donation;
+use MatchBot\Domain\DonationStatus;
 use MatchBot\Domain\FundingWithdrawal;
 use MatchBot\Tests\Application\DonationTestDataTrait;
 use MatchBot\Tests\TestCase;
@@ -25,6 +26,22 @@ class DonationTest extends TestCase
         $this->assertNull($donation->hasGiftAid());
         $this->assertNull($donation->getCharityComms());
         $this->assertNull($donation->getTbgComms());
+    }
+
+    public function testPendingDonationDoesNotHavePostCreateUpdates(): void
+    {
+        $donation = new Donation();
+        $donation->setDonationStatus(DonationStatus::Pending);
+
+        $this->assertFalse($donation->hasPostCreateUpdates());
+    }
+
+    public function testPendingDonationHasPostCreateUpdates(): void
+    {
+        $donation = new Donation();
+        $donation->setDonationStatus(DonationStatus::Paid);
+
+        $this->assertTrue($donation->hasPostCreateUpdates());
     }
 
     public function testValidDataPersisted(): void

--- a/tests/Domain/DonationTest.php
+++ b/tests/Domain/DonationTest.php
@@ -36,7 +36,7 @@ class DonationTest extends TestCase
         $this->assertFalse($donation->hasPostCreateUpdates());
     }
 
-    public function testPendingDonationHasPostCreateUpdates(): void
+    public function testPaidDonationHasPostCreateUpdates(): void
     {
         $donation = new Donation();
         $donation->setDonationStatus(DonationStatus::Paid);

--- a/tests/Domain/DonationTest.php
+++ b/tests/Domain/DonationTest.php
@@ -18,7 +18,7 @@ class DonationTest extends TestCase
     {
         $donation = new Donation();
 
-        $this->assertFalse($donation->isSuccessful());
+        $this->assertFalse($donation->getDonationStatus()->isSuccessful());
         $this->assertEquals('not-sent', $donation->getSalesforcePushStatus());
         $this->assertNull($donation->getSalesforceLastPush());
         $this->assertNull($donation->getSalesforceId());


### PR DESCRIPTION
Putting the docs here means (at least in PHPStorm) that we can hover over any line of code that mentions a status to see the documentation:

![image](https://user-images.githubusercontent.com/159481/227497738-f6a719c1-7225-4d3e-9a91-fb49875f0ffd.png)
