### PR TITLE
Spike (?) - construct donation in one step

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -279,7 +279,6 @@ components:
           readOnly: true
           type: string
           enum: [
-            "NotSet",
             "Pending",
             "Reserved",
             "Collected",

--- a/integrationTests/DonationPersistenceTest.php
+++ b/integrationTests/DonationPersistenceTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Doctrine\ORM\EntityManagerInterface;
+use MatchBot\Domain\Campaign;
 use MatchBot\Domain\Donation;
 use MatchBot\Domain\DonationRepository;
 use MatchBot\Domain\DonationStatus;
@@ -108,11 +109,19 @@ class DonationPersistenceTest extends IntegrationTest
      */
     public function makeDonationObject(): Donation
     {
-        $donation = new Donation();
-        $donation->setUuid(Uuid::uuid4());
-        $donation->setPsp('stripe');
-        $donation->setCurrencyCode('GBP');
-        $donation->setAmount('1');
+        $donation = Donation::createPendingStripeDonation(
+            Uuid::uuid4(),
+            'card',
+            '1',
+            'GBP',
+            $this->createStub(Campaign::class),
+            null,
+            null,
+            null,
+            null,
+            null,
+        );
+
         $donation->setDonationStatus(DonationStatus::Refunded);
 
         return $donation;

--- a/integrationTests/DonationPersistenceTest.php
+++ b/integrationTests/DonationPersistenceTest.php
@@ -18,6 +18,7 @@ class DonationPersistenceTest extends IntegrationTest
         $donation = $this->makeDonationObject();
 
         // act
+        $em->persist($donation->getCampaign());
         $em->persist($donation);
         $em->flush();
 
@@ -48,7 +49,7 @@ class DonationPersistenceTest extends IntegrationTest
      */
     private function assertRowsSimilar(array $expected, array $actual, string $message = ''): void
     {
-        $ignoredColumns = ['id' => 0, 'uuid' => 0, 'updatedAt' => 0, 'createdAt' => 0];
+        $ignoredColumns = ['id' => 0, 'uuid' => 0, 'updatedAt' => 0, 'createdAt' => 0, 'campaign_id' => 0];
 
         $this->assertSame($ignoredColumns + $expected, $ignoredColumns + $actual , $message);
     }
@@ -109,12 +110,19 @@ class DonationPersistenceTest extends IntegrationTest
      */
     public function makeDonationObject(): Donation
     {
+        $campaign = new Campaign();
+        $campaign->setCurrencyCode('GBP');
+        $campaign->setName('');
+        $campaign->setStartDate(new \DateTime());
+        $campaign->setEndDate(new \DateTime());
+        $campaign->setIsMatched(false);
+
         $donation = Donation::createPendingStripeDonation(
             Uuid::uuid4(),
             'card',
             '1',
             'GBP',
-            $this->createStub(Campaign::class),
+            $campaign,
             null,
             null,
             null,

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1074,10 +1074,6 @@
       <code>preUpdate</code>
     </PossiblyUnusedMethod>
     <PropertyNotSetInConstructor>
-      <code>$amount</code>
-      <code>$campaign</code>
-      <code>$currencyCode</code>
-      <code>$psp</code>
       <code>Donation</code>
       <code>Donation</code>
     </PropertyNotSetInConstructor>

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -146,7 +146,7 @@ class Donation extends SalesforceWriteProxy
     /**
      * @ORM\Column(type="string", enumType="MatchBot\Domain\DonationStatus")
      */
-    protected DonationStatus $donationStatus = DonationStatus::NotSet;
+    protected DonationStatus $donationStatus;
 
     /**
      * @ORM\Column(type="boolean", nullable=true)
@@ -366,7 +366,7 @@ class Donation extends SalesforceWriteProxy
     {
         return new self(
             uuid: Uuid::fromString(Uuid::NIL),
-            status: DonationStatus::NotSet,
+            status: DonationStatus::Pending,
             psp: 'stripe',
             paymentMethodType: 'card',
             amount: '1',

--- a/src/Domain/DonationRepository.php
+++ b/src/Domain/DonationRepository.php
@@ -16,6 +16,7 @@ use MatchBot\Client\BadRequestException;
 use MatchBot\Client\NotFoundException;
 use MatchBot\Domain\DomainException\DomainLockContentionException;
 use Ramsey\Uuid\Doctrine\UuidGenerator;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\Lock\Exception\LockAcquiringException;
 use Symfony\Component\Lock\LockFactory;
 
@@ -175,19 +176,19 @@ class DonationRepository extends SalesforceWriteProxyRepository
             ));
         }
 
-        $donation = new Donation();
-        $donation->setPsp($donationData->psp);
-        $donation->setPaymentMethodType($donationData->paymentMethodType);
-        $donation->setDonationStatus(DonationStatus::Pending);
-        $donation->setUuid((new UuidGenerator())->generateId($this->getEntityManager(), $donation));
-        $donation->setCampaign($campaign); // Charity & match expectation determined implicitly from this
-        $donation->setAmount((string) $donationData->donationAmount);
-        $donation->setCurrencyCode($donationData->currencyCode);
-        $donation->setGiftAid($donationData->giftAid);
-        $donation->setCharityComms($donationData->optInCharityEmail);
-        $donation->setChampionComms($donationData->optInChampionEmail);
-        $donation->setPspCustomerId($donationData->pspCustomerId);
-        $donation->setTbgComms($donationData->optInTbgEmail);
+        $donation = Donation::createPendingStripeDonation(
+            uuid: Uuid::uuid4(),
+            paymentMethodType: $donationData->paymentMethodType,
+            amount: (string) $donationData->donationAmount,
+            currencyCode: $donationData->currencyCode,
+            campaign: $campaign,  // Charity & match expectation determined implicitly from this
+            giftAid: $donationData->giftAid,
+            optInCharityEmail: $donationData->optInCharityEmail,
+            optInChampionEmail: $donationData->optInChampionEmail,
+            pspCustomerId: $donationData->pspCustomerId,
+            optInTbgEmail: $donationData->optInTbgEmail,
+        );
+
 
         if (!empty($donationData->countryCode)) {
             $donation->setDonorCountryCode($donationData->countryCode);

--- a/src/Domain/DonationStatus.php
+++ b/src/Domain/DonationStatus.php
@@ -13,7 +13,7 @@ enum DonationStatus: string
     public function isNew(): bool
     {
         return match ($this) {
-            self::NotSet, self::Pending => true,
+            self::Pending => true,
             default => false,
         };
     }
@@ -38,13 +38,6 @@ enum DonationStatus: string
             default => false,
         };
     }
-
-    /**
-     * Never saved to database - this is just a placeholder used on incomplete donation objects in memory.
-     * @todo consider removing this, either replace with `null` or preferably force every donation to have a real
-     * status when constructed.
-     */
-    case NotSet = 'NotSet';
 
     /**
      * A Pending donation represents a non-binding statement of intent to donate. We don't know whether

--- a/tests/Application/Actions/Donations/CreateTest.php
+++ b/tests/Application/Actions/Donations/CreateTest.php
@@ -1105,7 +1105,7 @@ class CreateTest extends TestCase
             $campaign->setEndDate((new \DateTime())->sub(new \DateInterval('P1D')));
         }
 
-        $donation = new Donation();
+        $donation = Donation::onePoundTestDonation();
         $donation->createdNow(); // Call same create/update time initialisers as lifecycle hooks
         $donation->setCurrencyCode('GBP');
         $donation->setAmount('12.00');

--- a/tests/Application/Actions/Donations/UpdateHandlesLockExceptionTest.php
+++ b/tests/Application/Actions/Donations/UpdateHandlesLockExceptionTest.php
@@ -166,7 +166,7 @@ class UpdateHandlesLockExceptionTest extends \PHPUnit\Framework\TestCase
         $campaign->setIsMatched(true);
         $campaign->setCharity($charity);
 
-        $donation = new Donation();
+        $donation = Donation::onePoundTestDonation();
         $donation->createdNow();
         $donation->setDonationStatus(DonationStatus::Pending);
         $donation->setCampaign($campaign);

--- a/tests/Application/Commands/ExpireMatchFundsTest.php
+++ b/tests/Application/Commands/ExpireMatchFundsTest.php
@@ -40,8 +40,8 @@ class ExpireMatchFundsTest extends TestCase
     {
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy->findWithExpiredMatching()->willReturn([
-            new Donation(),
-            new Donation()
+            Donation::onePoundTestDonation(),
+            Donation::onePoundTestDonation()
         ]);
         $donationRepoProphecy->releaseMatchFunds(Argument::type(Donation::class))
             ->shouldBeCalledTimes(2);

--- a/tests/Application/DonationTestDataTrait.php
+++ b/tests/Application/DonationTestDataTrait.php
@@ -35,7 +35,7 @@ trait DonationTestDataTrait
         $campaign->setName('Test campaign');
         $campaign->setSalesforceId('456ProjectId');
 
-        $donation = new Donation();
+        $donation = Donation::onePoundTestDonation();
         $donation->createdNow(); // Call same create/update time initialisers as lifecycle hooks
         $donation->setAmount('123.45');
         $donation->setCharityFee('2.05');
@@ -87,7 +87,7 @@ trait DonationTestDataTrait
         $campaign->setName('Test campaign');
         $campaign->setSalesforceId('456ProjectId');
 
-        $donation = new Donation();
+        $donation = Donation::onePoundTestDonation();
         $donation->createdNow(); // Call same create/update time initialisers as lifecycle hooks
         $donation->setAmount('124.56');
         $donation->setCharityFee('2.57');

--- a/tests/Application/Persistence/RetrySafeEntityManagerTest.php
+++ b/tests/Application/Persistence/RetrySafeEntityManagerTest.php
@@ -69,7 +69,7 @@ class RetrySafeEntityManagerTest extends TestCase
         $container = $app->getContainer();
         $container->set(EntityManager::class, $underlyingEmProphecy->reveal());
 
-        $this->retrySafeEntityManager->persist(new Donation());
+        $this->retrySafeEntityManager->persist(Donation::onePoundTestDonation());
     }
 
     public function testPersistWithRetry(): void
@@ -100,7 +100,7 @@ class RetrySafeEntityManagerTest extends TestCase
         $container->set(RetrySafeEntityManager::class, $this->retrySafeEntityManager);
         $container->set(EntityManagerInterface::class, $this->retrySafeEntityManager);
 
-        $this->retrySafeEntityManager->persist(new Donation());
+        $this->retrySafeEntityManager->persist(Donation::onePoundTestDonation());
     }
 
     public function testFlush(): void

--- a/tests/Domain/DonationTest.php
+++ b/tests/Domain/DonationTest.php
@@ -16,7 +16,7 @@ class DonationTest extends TestCase
 
     public function testBasicsAsExpectedOnInstantion(): void
     {
-        $donation = new Donation();
+        $donation = Donation::onePoundTestDonation();
 
         $this->assertFalse($donation->getDonationStatus()->isSuccessful());
         $this->assertEquals('not-sent', $donation->getSalesforcePushStatus());
@@ -30,7 +30,7 @@ class DonationTest extends TestCase
 
     public function testPendingDonationDoesNotHavePostCreateUpdates(): void
     {
-        $donation = new Donation();
+        $donation = Donation::onePoundTestDonation();
         $donation->setDonationStatus(DonationStatus::Pending);
 
         $this->assertFalse($donation->hasPostCreateUpdates());
@@ -38,7 +38,7 @@ class DonationTest extends TestCase
 
     public function testPendingDonationHasPostCreateUpdates(): void
     {
-        $donation = new Donation();
+        $donation = Donation::onePoundTestDonation();
         $donation->setDonationStatus(DonationStatus::Paid);
 
         $this->assertTrue($donation->hasPostCreateUpdates());
@@ -46,7 +46,7 @@ class DonationTest extends TestCase
 
     public function testValidDataPersisted(): void
     {
-        $donation = new Donation();
+        $donation = Donation::onePoundTestDonation();
         $donation->setCurrencyCode('GBP');
         $donation->setAmount('100.00');
         $donation->setTipAmount('1.13');
@@ -62,7 +62,7 @@ class DonationTest extends TestCase
         $this->expectException(\UnexpectedValueException::class);
         $this->expectExceptionMessage('Amount must be 1-25000 GBP');
 
-        $donation = new Donation();
+        $donation = Donation::onePoundTestDonation();
         $donation->setCurrencyCode('GBP');
         $donation->setAmount('0.99');
     }
@@ -72,7 +72,7 @@ class DonationTest extends TestCase
         $this->expectException(\UnexpectedValueException::class);
         $this->expectExceptionMessage('Amount must be 1-25000 GBP');
 
-        $donation = new Donation();
+        $donation = Donation::onePoundTestDonation();
         $donation->setCurrencyCode('GBP');
         $donation->setAmount('25000.01');
     }
@@ -82,7 +82,7 @@ class DonationTest extends TestCase
         $this->expectException(\UnexpectedValueException::class);
         $this->expectExceptionMessage('Tip amount must not exceed 25000 GBP');
 
-        $donation = new Donation();
+        $donation = Donation::onePoundTestDonation();
         $donation->setCurrencyCode('GBP');
         $donation->setTipAmount('25000.01');
     }
@@ -92,14 +92,14 @@ class DonationTest extends TestCase
         $this->expectException(\UnexpectedValueException::class);
         $this->expectExceptionMessage("Unexpected PSP 'paypal'");
 
-        $donation = new Donation();
+        $donation = Donation::onePoundTestDonation();
         /** @psalm-suppress InvalidArgument */
         $donation->setPsp('paypal');
     }
 
     public function testValidPspAccepted(): void
     {
-        $donation = new Donation();
+        $donation = Donation::onePoundTestDonation();
         $donation->setPsp('stripe');
 
         $this->addToAssertionCount(1); // Just check setPsp() doesn't hit an exception
@@ -107,7 +107,7 @@ class DonationTest extends TestCase
 
     public function testSetAndGetOriginalFee(): void
     {
-        $donation = new Donation();
+        $donation = Donation::onePoundTestDonation();
         $donation->setOriginalPspFeeFractional(123);
 
         $this->assertEquals('1.23', $donation->getOriginalPspFee());


### PR DESCRIPTION
Not entirely sure if this is just a spike (i.e. code edits done purely for learning purposes with the intention to throw away) or a real PR to potentially merge. I think it is a real improvement to the design, making it very easy to see e.g. that we only ever construct donations in the Pending state. But it goes against the principle of only refactoring if and when it will help us complete an imediate user story.

Following advice from
https://matthiasnoback.nl/2018/07/objects-should-be-constructed-in-one-go/