### PR TITLE
MAT-287 – clearer failed payout notifications

### DIFF
--- a/app/settings.php
+++ b/app/settings.php
@@ -85,7 +85,10 @@ return function (ContainerBuilder $containerBuilder) {
             'notifier' => [
                 'slack' => [
                     'api_token' => getenv('SLACK_API_TOKEN'),
+                    // e.g. '#matchbot' – channel for app's own general actions.
                     'channel' => getenv('SLACK_CHANNEL'),
+                    // Override channel for administrative Stripe notifications.
+                    'stripe_channel' => 'stripe',
                 ],
             ],
 

--- a/src/Application/Actions/Hooks/StripePayoutUpdate.php
+++ b/src/Application/Actions/Hooks/StripePayoutUpdate.php
@@ -27,7 +27,7 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 class StripePayoutUpdate extends Stripe
 {
     private SlackChannelChatterFactory $chatterFactory;
-    protected string $slackStripeChannel;
+    private string $slackStripeChannel;
 
     public function __construct(
         ContainerInterface $container,

--- a/tests/Application/Actions/Hooks/StripePayoutUpdateTest.php
+++ b/tests/Application/Actions/Hooks/StripePayoutUpdateTest.php
@@ -154,9 +154,9 @@ class StripePayoutUpdateTest extends StripeTest
             ->withHeader('Stripe-Signature', $this->generateSignature($time, $this->getStripeHookMock('po_failed'), $webhookSecret));
 
         $chatterProphecy->send(
-            new ChatMessage('payout.failed for ID po_externalId_123, account acct_unitTest543')
+            new ChatMessage('[test] payout.failed for ID po_externalId_123, account acct_unitTest543')
         )
-            ->shouldBeCalled();
+            ->shouldBeCalledOnce();
         $response = $app->handle($request);
 
         $this->assertEquals(200, $response->getStatusCode());


### PR DESCRIPTION
* Make it explicit which environment a notification is coming from
* Move implicit Slack configuration requirement nearer to other settings