### PR TITLE
Fix test at wrong namespace

### DIFF
--- a/tests/Application/Actions/DeletePaymentMethodTest.php
+++ b/tests/Application/Actions/DeletePaymentMethodTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace MatchBot\Tests\Application;
+namespace MatchBot\Tests\Application\Actions;
 
 use Laminas\Diactoros\ServerRequest;
 use MatchBot\Application\Actions\DeletePaymentMethod;


### PR DESCRIPTION
Stops every autoload generation from showing a warning