### PR TITLE
Mat 295 simplify unit test

### DIFF
--- a/tests/Application/Commands/DeleteStalePaymentDetailsTest.php
+++ b/tests/Application/Commands/DeleteStalePaymentDetailsTest.php
@@ -37,7 +37,6 @@ class DeleteStalePaymentDetailsTest extends TestCase
             'query' => 'customer:"cus_aaaaaaaaaaaa11" and payment_method_details.card.fingerprint:"TEST_CARD_FINGERPRINT" and status:"succeeded"',
             'limit' => 100,
         ])
-            ->shouldBeCalledOnce()
             ->willReturn($this->buildEmptyCollection());
 
         $stripePaymentMethodsProphecy = $this->prophesize(PaymentMethodService::class);
@@ -46,7 +45,6 @@ class DeleteStalePaymentDetailsTest extends TestCase
             'type' => 'card',
             'limit' => 100,
         ])
-            ->shouldBeCalledOnce()
             ->willReturn($this->buildCollectionFromSingleObjectFixture(
                 $this->getStripeHookMock('ApiResponse/pm'),
             ));
@@ -56,7 +54,6 @@ class DeleteStalePaymentDetailsTest extends TestCase
             'query' => "created<{$previousDay->getTimestamp()} and metadata['hasPasswordSince']:null",
             'limit' => 100,
         ])
-            ->shouldBeCalledOnce()
             ->willReturn($this->buildCollectionFromSingleObjectFixture(
                 $this->getStripeHookMock('ApiResponse/customer'),
             ));
@@ -103,7 +100,6 @@ class DeleteStalePaymentDetailsTest extends TestCase
             'query' => 'customer:"cus_aaaaaaaaaaaa11" and payment_method_details.card.fingerprint:"TEST_CARD_FINGERPRINT" and status:"succeeded"',
             'limit' => 100,
         ])
-            ->shouldBeCalledOnce()
             ->willReturn($this->buildCollectionFromSingleObjectFixture('ch_succeeded'));
 
         $stripePaymentMethodsProphecy = $this->prophesize(PaymentMethodService::class);
@@ -112,7 +108,6 @@ class DeleteStalePaymentDetailsTest extends TestCase
             'type' => 'card',
             'limit' => 100,
         ])
-            ->shouldBeCalledOnce()
             ->willReturn($this->buildCollectionFromSingleObjectFixture(
                 $this->getStripeHookMock('ApiResponse/pm'),
             ));

--- a/tests/Application/Commands/DeleteStalePaymentDetailsTest.php
+++ b/tests/Application/Commands/DeleteStalePaymentDetailsTest.php
@@ -147,7 +147,9 @@ class DeleteStalePaymentDetailsTest extends TestCase
             Deleted 0 payment methods from Stripe, having checked 1 customers
             matchbot:delete-stale-payment-details complete!
             
-            EXPECTED, $commandTester->getDisplay());
+            EXPECTED, 
+            $commandTester->getDisplay()
+        );
 
         $this->assertEquals(0, $commandTester->getStatusCode());
     }

--- a/tests/Application/Commands/DeleteStalePaymentDetailsTest.php
+++ b/tests/Application/Commands/DeleteStalePaymentDetailsTest.php
@@ -25,18 +25,16 @@ class DeleteStalePaymentDetailsTest extends TestCase
 
     public function testDeletingOneStaleCard(): void
     {
-        $initDate = new \DateTimeImmutable('now');
+        // arrange
+        $initDate = new \DateTimeImmutable('2023-04-10T00:00:00+0100');
+        $previousDay = new \DateTimeImmutable('2023-04-09T00:00:00+0100');
+
         $testCustomerId = 'cus_aaaaaaaaaaaa11';
         $testPaymentMethodId = 'pm_aaaaaaaaaaaa13';
-        $testPaymentMethodFingerprint = 'Xt5EWLLDS7FJjR1c';
 
         $stripeChargesProphecy = $this->prophesize(ChargeService::class);
         $stripeChargesProphecy->search([
-            'query' => sprintf(
-                'customer:"%s" and payment_method_details.card.fingerprint:"%s" and status:"succeeded"',
-                $testCustomerId,
-                $testPaymentMethodFingerprint,
-            ),
+            'query' => 'customer:"cus_aaaaaaaaaaaa11" and payment_method_details.card.fingerprint:"TEST_CARD_FINGERPRINT" and status:"succeeded"',
             'limit' => 100,
         ])
             ->shouldBeCalledOnce()
@@ -53,18 +51,9 @@ class DeleteStalePaymentDetailsTest extends TestCase
                 $this->getStripeHookMock('ApiResponse/pm'),
             ));
 
-        // One PM should be detached i.e. soft deleted.
-        $stripePaymentMethodsProphecy->detach($testPaymentMethodId)
-            ->shouldBeCalledOnce()
-            ->willReturn($this->getStripeHookMock('ApiResponse/pm'));
-
-        $oneDayBeforeTest = $initDate
-            ->sub(new \DateInterval('P1D'))
-            ->getTimestamp();
-
         $stripeCustomersProphecy = $this->prophesize(CustomerService::class);
         $stripeCustomersProphecy->search([
-            'query' => "created<$oneDayBeforeTest and metadata['hasPasswordSince']:null",
+            'query' => "created<{$previousDay->getTimestamp()} and metadata['hasPasswordSince']:null",
             'limit' => 100,
         ])
             ->shouldBeCalledOnce()
@@ -82,8 +71,17 @@ class DeleteStalePaymentDetailsTest extends TestCase
             $stripeClientProphecy,
             $initDate,
         ));
+
+        // assert
+        // One PM should be detached i.e. soft deleted.
+        $stripePaymentMethodsProphecy->detach($testPaymentMethodId)
+            ->shouldBeCalledOnce()
+            ->willReturn($this->getStripeHookMock('ApiResponse/pm'));
+
+        // act
         $commandTester->execute([]);
 
+        // assert
         $expectedOutputLines = [
             'matchbot:delete-stale-payment-details starting!',
             'Deleted 1 payment methods from Stripe, having checked 1 customers',
@@ -96,17 +94,15 @@ class DeleteStalePaymentDetailsTest extends TestCase
 
     public function testNotDeletingOneUsedCard(): void
     {
-        $initDate = new \DateTimeImmutable('now');
+        // arrange
+        $initDate = new \DateTimeImmutable('2023-04-10T00:00:00+0100');
+        $previousDay = new \DateTimeImmutable('2023-04-09T00:00:00+0100');
+
         $testCustomerId = 'cus_aaaaaaaaaaaa11';
-        $testPaymentMethodFingerprint = 'Xt5EWLLDS7FJjR1c';
 
         $stripeChargesProphecy = $this->prophesize(ChargeService::class);
         $stripeChargesProphecy->search([
-            'query' => sprintf(
-                'customer:"%s" and payment_method_details.card.fingerprint:"%s" and status:"succeeded"',
-                $testCustomerId,
-                $testPaymentMethodFingerprint,
-            ),
+            'query' => 'customer:"cus_aaaaaaaaaaaa11" and payment_method_details.card.fingerprint:"TEST_CARD_FINGERPRINT" and status:"succeeded"',
             'limit' => 100,
         ])
             ->shouldBeCalledOnce()
@@ -123,17 +119,9 @@ class DeleteStalePaymentDetailsTest extends TestCase
                 $this->getStripeHookMock('ApiResponse/pm'),
             ));
 
-        // *No* PM should be detached i.e. soft deleted, with any ID.
-        $stripePaymentMethodsProphecy->detach(Argument::type('string'))
-            ->shouldNotBeCalled();
-
-        $oneDayBeforeTest = $initDate
-            ->sub(new \DateInterval('P1D'))
-            ->getTimestamp();
-
         $stripeCustomersProphecy = $this->prophesize(CustomerService::class);
         $stripeCustomersProphecy->search([
-            'query' => "created<$oneDayBeforeTest and metadata['hasPasswordSince']:null",
+            'query' => "created<{$previousDay->getTimestamp()} and metadata['hasPasswordSince']:null",
             'limit' => 100,
         ])
             ->shouldBeCalledOnce()
@@ -151,14 +139,22 @@ class DeleteStalePaymentDetailsTest extends TestCase
             $stripeClientProphecy,
             $initDate,
         ));
+
+        // assert
+        // *No* PM should be detached i.e. soft deleted, with any ID.
+        $stripePaymentMethodsProphecy->detach(Argument::type('string'))
+            ->shouldNotBeCalled();
+
+        // act
         $commandTester->execute([]);
 
-        $expectedOutputLines = [
-            'matchbot:delete-stale-payment-details starting!',
-            'Deleted 0 payment methods from Stripe, having checked 1 customers',
-            'matchbot:delete-stale-payment-details complete!',
-        ];
-        $this->assertEquals(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
+        // assert
+        $this->assertEquals(<<<EXPECTED
+            matchbot:delete-stale-payment-details starting!
+            Deleted 0 payment methods from Stripe, having checked 1 customers
+            matchbot:delete-stale-payment-details complete!
+            
+            EXPECTED, $commandTester->getDisplay());
 
         $this->assertEquals(0, $commandTester->getStatusCode());
     }

--- a/tests/Application/Commands/DeleteStalePaymentDetailsTest.php
+++ b/tests/Application/Commands/DeleteStalePaymentDetailsTest.php
@@ -74,9 +74,7 @@ class DeleteStalePaymentDetailsTest extends TestCase
 
         // assert
         // One PM should be detached i.e. soft deleted.
-        $stripePaymentMethodsProphecy->detach($testPaymentMethodId)
-            ->shouldBeCalledOnce()
-            ->willReturn($this->getStripeHookMock('ApiResponse/pm'));
+        $stripePaymentMethodsProphecy->detach($testPaymentMethodId)->shouldBeCalledOnce();
 
         // act
         $commandTester->execute([]);

--- a/tests/TestData/StripeWebhook/ApiResponse/pm.json
+++ b/tests/TestData/StripeWebhook/ApiResponse/pm.json
@@ -24,7 +24,7 @@
     "country": "US",
     "exp_month": 8,
     "exp_year": 2024,
-    "fingerprint": "Xt5EWLLDS7FJjR1c",
+    "fingerprint": "TEST_CARD_FINGERPRINT",
     "funding": "credit",
     "generated_from": null,
     "last4": "4242",


### PR DESCRIPTION
Could go further and extracted repeated code from between the two tests into either setup or just new private methods.

Another thing I haven't fixed is the union types - quite a few things are using unnecessary union types with ObjectProphecy, when it's always one side of the union or the other.