### PR TITLE
Set currency before amount on Donation domain object

### DIFF
--- a/src/Domain/DonationRepository.php
+++ b/src/Domain/DonationRepository.php
@@ -181,8 +181,8 @@ class DonationRepository extends SalesforceWriteProxyRepository
         $donation->setDonationStatus(DonationStatus::Pending);
         $donation->setUuid((new UuidGenerator())->generateId($this->getEntityManager(), $donation));
         $donation->setCampaign($campaign); // Charity & match expectation determined implicitly from this
-        $donation->setAmount((string) $donationData->donationAmount);
         $donation->setCurrencyCode($donationData->currencyCode);
+        $donation->setAmount((string) $donationData->donationAmount);
         $donation->setGiftAid($donationData->giftAid);
         $donation->setCharityComms($donationData->optInCharityEmail);
         $donation->setChampionComms($donationData->optInChampionEmail);


### PR DESCRIPTION
If the amount is outside min / max limits it throws an error which includes the currency code, so currency code must be set first or we get fatal error as just seen in prod:

	Error: Typed property MatchBot\Domain\Donation::$currencyCode must not be accessed before initialization -