### PR TITLE
Temporarily decrease log level for a charity we know have Stripe config issues

### DIFF
--- a/src/Application/Actions/Donations/Create.php
+++ b/src/Application/Actions/Donations/Create.php
@@ -191,15 +191,27 @@ class Create extends Action
             try {
                 $intent = $this->stripeClient->paymentIntents->create($createPayload);
             } catch (ApiErrorException $exception) {
-                $this->logger->error(sprintf(
-                    'Stripe Payment Intent create error on %s, %s [%s]: %s. Charity: %s [%s].',
-                    $donation->getUuid(),
-                    $exception->getStripeCode(),
-                    get_class($exception),
-                    $exception->getMessage(),
-                    $donation->getCampaign()->getCharity()->getName(),
-                    $donation->getCampaign()->getCharity()->getStripeAccountId()
-                ));
+                if ($donation->getCampaign()->getId() === 4690) {
+                    $this->logger->warning(sprintf(
+                        'Stripe Payment Intent create error on %s, %s [%s]: %s. Known charity: %s [%s].',
+                        $donation->getUuid(),
+                        $exception->getStripeCode(),
+                        get_class($exception),
+                        $exception->getMessage(),
+                        $donation->getCampaign()->getCharity()->getName(),
+                        $donation->getCampaign()->getCharity()->getStripeAccountId()
+                    ));
+                } else {
+                    $this->logger->error(sprintf(
+                        'Stripe Payment Intent create error on %s, %s [%s]: %s. Charity: %s [%s].',
+                        $donation->getUuid(),
+                        $exception->getStripeCode(),
+                        get_class($exception),
+                        $exception->getMessage(),
+                        $donation->getCampaign()->getCharity()->getName(),
+                        $donation->getCampaign()->getCharity()->getStripeAccountId()
+                    ));
+                }
                 $error = new ActionError(ActionError::SERVER_ERROR, 'Could not make Stripe Payment Intent (B)');
                 return $this->respond($response, new ActionPayload(500, null, $error));
             }


### PR DESCRIPTION
Still returns a 500 so will lead to 5xx errors, but we can more quickly rule these out for urgent follow-up for the rest of the week, as they won't be accompanied by a non-zero "web-errors" CloudWatch metric filter