### PR TITLE
MAT-295: Detatch payment cards from passwordless accounts

### DIFF
--- a/src/Application/Commands/DeleteStalePaymentDetails.php
+++ b/src/Application/Commands/DeleteStalePaymentDetails.php
@@ -61,14 +61,14 @@ class DeleteStalePaymentDetails extends LockingCommand
             ]);
 
             foreach ($paymentMethods->autoPagingIterator() as $paymentMethod) {
-                    // Soft-delete / prevent reuse of the payment method.
-                    $this->logger->info(sprintf(
-                        'Detaching payment method %s, previously of customer %s',
-                        $paymentMethod->id,
-                        $customer->id,
-                    ));
-                    $this->stripeClient->paymentMethods->detach($paymentMethod->id);
-                    $methodsDeleted++;
+                // Soft-delete / prevent reuse of the payment method.
+                $this->logger->info(sprintf(
+                    'Detaching payment method %s, previously of customer %s',
+                    $paymentMethod->id,
+                    $customer->id,
+                ));
+                $this->stripeClient->paymentMethods->detach($paymentMethod->id);
+                $methodsDeleted++;
             }
 
             $this->stripeClient->customers->update(

--- a/tests/Application/Commands/DeleteStalePaymentDetailsTest.php
+++ b/tests/Application/Commands/DeleteStalePaymentDetailsTest.php
@@ -32,13 +32,6 @@ class DeleteStalePaymentDetailsTest extends TestCase
         $testCustomerId = 'cus_aaaaaaaaaaaa11';
         $testPaymentMethodId = 'pm_aaaaaaaaaaaa13';
 
-        $stripeChargesProphecy = $this->prophesize(ChargeService::class);
-        $stripeChargesProphecy->search([
-            'query' => 'customer:"cus_aaaaaaaaaaaa11" and payment_method_details.card.fingerprint:"TEST_CARD_FINGERPRINT" and status:"succeeded"',
-            'limit' => 100,
-        ])
-            ->willReturn($this->buildEmptyCollection());
-
         $stripePaymentMethodsProphecy = $this->prophesize(PaymentMethodService::class);
         $stripePaymentMethodsProphecy->all([
             'customer' => $testCustomerId,
@@ -60,7 +53,6 @@ class DeleteStalePaymentDetailsTest extends TestCase
 
         $stripeClientProphecy = $this->prophesize(StripeClient::class);
 
-        $stripeClientProphecy->charges = $stripeChargesProphecy->reveal();
         $stripeClientProphecy->customers = $stripeCustomersProphecy->reveal();
         $stripeClientProphecy->paymentMethods = $stripePaymentMethodsProphecy->reveal();
 
@@ -83,73 +75,6 @@ class DeleteStalePaymentDetailsTest extends TestCase
             'matchbot:delete-stale-payment-details complete!',
         ];
         $this->assertEquals(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
-
-        $this->assertEquals(0, $commandTester->getStatusCode());
-    }
-
-    public function testNotDeletingOneUsedCard(): void
-    {
-        // arrange
-        $initDate = new \DateTimeImmutable('2023-04-10T00:00:00+0100');
-        $previousDay = new \DateTimeImmutable('2023-04-09T00:00:00+0100');
-
-        $testCustomerId = 'cus_aaaaaaaaaaaa11';
-
-        $stripeChargesProphecy = $this->prophesize(ChargeService::class);
-        $stripeChargesProphecy->search([
-            'query' => 'customer:"cus_aaaaaaaaaaaa11" and payment_method_details.card.fingerprint:"TEST_CARD_FINGERPRINT" and status:"succeeded"',
-            'limit' => 100,
-        ])
-            ->willReturn($this->buildCollectionFromSingleObjectFixture('ch_succeeded'));
-
-        $stripePaymentMethodsProphecy = $this->prophesize(PaymentMethodService::class);
-        $stripePaymentMethodsProphecy->all([
-            'customer' => $testCustomerId,
-            'type' => 'card',
-            'limit' => 100,
-        ])
-            ->willReturn($this->buildCollectionFromSingleObjectFixture(
-                $this->getStripeHookMock('ApiResponse/pm'),
-            ));
-
-        $stripeCustomersProphecy = $this->prophesize(CustomerService::class);
-        $stripeCustomersProphecy->search([
-            'query' => "created<{$previousDay->getTimestamp()} and metadata['hasPasswordSince']:null",
-            'limit' => 100,
-        ])
-            ->shouldBeCalledOnce()
-            ->willReturn($this->buildCollectionFromSingleObjectFixture(
-                $this->getStripeHookMock('ApiResponse/customer'),
-            ));
-
-        $stripeClientProphecy = $this->prophesize(StripeClient::class);
-
-        $stripeClientProphecy->charges = $stripeChargesProphecy->reveal();
-        $stripeClientProphecy->customers = $stripeCustomersProphecy->reveal();
-        $stripeClientProphecy->paymentMethods = $stripePaymentMethodsProphecy->reveal();
-
-        $commandTester = new CommandTester($this->getCommand(
-            $stripeClientProphecy,
-            $initDate,
-        ));
-
-        // assert
-        // *No* PM should be detached i.e. soft deleted, with any ID.
-        $stripePaymentMethodsProphecy->detach(Argument::type('string'))
-            ->shouldNotBeCalled();
-
-        // act
-        $commandTester->execute([]);
-
-        // assert
-        $this->assertEquals(<<<EXPECTED
-            matchbot:delete-stale-payment-details starting!
-            Deleted 0 payment methods from Stripe, having checked 1 customers
-            matchbot:delete-stale-payment-details complete!
-            
-            EXPECTED, 
-            $commandTester->getDisplay()
-        );
 
         $this->assertEquals(0, $commandTester->getStatusCode());
     }

--- a/tests/Application/Commands/DeleteStalePaymentDetailsTest.php
+++ b/tests/Application/Commands/DeleteStalePaymentDetailsTest.php
@@ -44,7 +44,7 @@ class DeleteStalePaymentDetailsTest extends TestCase
 
         $stripeCustomersProphecy = $this->prophesize(CustomerService::class);
         $stripeCustomersProphecy->search([
-            'query' => "created<{$previousDay->getTimestamp()} and metadata['hasPasswordSince']:null",
+            'query' => "created<{$previousDay->getTimestamp()} and metadata['hasPasswordSince']:null and metadata['paymentMethodsCleared']:null",
             'limit' => 100,
         ])
             ->willReturn($this->buildCollectionFromSingleObjectFixture(
@@ -64,6 +64,8 @@ class DeleteStalePaymentDetailsTest extends TestCase
         // assert
         // One PM should be detached i.e. soft deleted.
         $stripePaymentMethodsProphecy->detach($testPaymentMethodId)->shouldBeCalledOnce();
+
+        $stripeCustomersProphecy->update($testCustomerId, ['metadata' => ['paymentMethodsCleared' => '2023-04-10 00:00:00']])->shouldBeCalledOnce();
 
         // act
         $commandTester->execute([]);

--- a/tests/Application/StripeFormattingTrait.php
+++ b/tests/Application/StripeFormattingTrait.php
@@ -33,12 +33,4 @@ trait StripeFormattingTrait
 
         return $this->buildAutoIterableCollection(json_encode($collectionRaw));
     }
-
-    protected function buildEmptyCollection(): Collection|ObjectProphecy
-    {
-        $collectionRaw = new \stdClass();
-        $collectionRaw->data = [];
-
-        return $this->buildAutoIterableCollection(json_encode($collectionRaw));
-    }
 }


### PR DESCRIPTION
Changes the logic of the payment method detacher to work based on newly complete metadata in stripe - and also adds an extra metadata field to stripe to track which customer accounts the command has operated on them so that it won't find the same account in search next time it runs.