### PR TITLE
MAT-302 – fix Update lock wait recovery

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1573,9 +1573,6 @@
     <InternalMethod>
       <code><![CDATA[new LockWaitTimeoutException($testCase->createStub(DriverException::class), null)]]></code>
     </InternalMethod>
-    <PossiblyUnusedParam>
-      <code>$newStatus</code>
-    </PossiblyUnusedParam>
   </file>
   <file src="tests/Application/Actions/Donations/UpdateTest.php">
     <MixedArrayAccess>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -241,18 +241,12 @@
     <InvalidArgument>
       <code>100_000 * (2 ** $retryCount)</code>
     </InvalidArgument>
-    <MixedArgument>
-      <code>$lockWaitTimeoutException</code>
-    </MixedArgument>
     <PossiblyNullArgument>
       <code><![CDATA[$exception->getStripeCode()]]></code>
       <code><![CDATA[$exception->getStripeCode()]]></code>
       <code><![CDATA[$exception->getStripeCode()]]></code>
       <code><![CDATA[$retryException->getStripeCode()]]></code>
     </PossiblyNullArgument>
-    <PossiblyUndefinedVariable>
-      <code>$lockWaitTimeoutException</code>
-    </PossiblyUndefinedVariable>
     <TypeDoesNotContainType>
       <code><![CDATA[isset($donationData->status)]]></code>
     </TypeDoesNotContainType>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -245,7 +245,6 @@
       <code>$lockWaitTimeoutException</code>
     </MixedArgument>
     <PossiblyNullArgument>
-      <code><![CDATA[$donation->getId()]]></code>
       <code><![CDATA[$exception->getStripeCode()]]></code>
       <code><![CDATA[$exception->getStripeCode()]]></code>
       <code><![CDATA[$exception->getStripeCode()]]></code>
@@ -254,9 +253,6 @@
     <PossiblyUndefinedVariable>
       <code>$lockWaitTimeoutException</code>
     </PossiblyUndefinedVariable>
-    <TooManyArguments>
-      <code>refresh</code>
-    </TooManyArguments>
     <TypeDoesNotContainType>
       <code><![CDATA[isset($donationData->status)]]></code>
     </TypeDoesNotContainType>

--- a/src/Domain/DonationRepository.php
+++ b/src/Domain/DonationRepository.php
@@ -52,7 +52,7 @@ class DonationRepository extends SalesforceWriteProxyRepository
         } catch (NotFoundException $ex) {
             // Thrown only for *sandbox* 404s -> quietly stop trying to push donation to a removed campaign.
             $this->logInfo(
-                "Marking Salesforce donation {$donation->getId()} as campaign removed; will not try to push again."
+                "Marking Salesforce donation {$donation->getUuid()} as campaign removed; will not try to push again."
             );
             $donation->setSalesforcePushStatus(SalesforceWriteProxy::PUSH_STATUS_REMOVED);
             $this->getEntityManager()->persist($donation);
@@ -98,7 +98,7 @@ class DonationRepository extends SalesforceWriteProxyRepository
         } catch (NotFoundException $ex) {
             // Thrown only for *sandbox* 404s -> quietly stop trying to push the removed donation.
             $this->logInfo(
-                "Marking old Salesforce donation {$donation->getId()} as removed; will not try to push again."
+                "Marking old Salesforce donation {$donation->getUuid()} as removed; will not try to push again."
             );
             $donation->setSalesforcePushStatus(SalesforceWriteProxy::PUSH_STATUS_REMOVED);
             $this->getEntityManager()->persist($donation);


### PR DESCRIPTION
Also:
* Reduce `Update`'s database access when we can fail validation earlier
* Use UUID over ID a bit more clearly & consistently in logs etc.