### PR TITLE
DON-800: Increase donation limit for donation account users to £200k

### DIFF
--- a/integrationTests/DonationPersistenceTest.php
+++ b/integrationTests/DonationPersistenceTest.php
@@ -108,11 +108,10 @@ class DonationPersistenceTest extends IntegrationTest
      */
     public function makeDonationObject(): Donation
     {
-        $donation = Donation::emptyTestDonation();
+        $donation = Donation::emptyTestDonation('1');
         $donation->setUuid(Uuid::uuid4());
         $donation->setPsp('stripe');
         $donation->setCurrencyCode('GBP');
-        $donation->setAmount('1');
         $donation->setDonationStatus(DonationStatus::Refunded);
 
         return $donation;

--- a/integrationTests/DonationPersistenceTest.php
+++ b/integrationTests/DonationPersistenceTest.php
@@ -108,7 +108,7 @@ class DonationPersistenceTest extends IntegrationTest
      */
     public function makeDonationObject(): Donation
     {
-        $donation = new Donation();
+        $donation = Donation::emptyTestDonation();
         $donation->setUuid(Uuid::uuid4());
         $donation->setPsp('stripe');
         $donation->setCurrencyCode('GBP');

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -197,6 +197,11 @@
       <code>$response</code>
     </UnusedClosureParam>
   </file>
+  <file src="integrationTests/DonationPersistenceTest.php">
+    <DeprecatedMethod>
+      <code>Donation::emptyTestDonation()</code>
+    </DeprecatedMethod>
+  </file>
   <file src="public/index.php">
     <MixedArgument>
       <code><![CDATA[$app->getContainer()->get(LoggerInterface::class)]]></code>
@@ -1527,6 +1532,9 @@
     </DeprecatedMethod>
   </file>
   <file src="tests/Application/Actions/Donations/CreateTest.php">
+    <DeprecatedMethod>
+      <code>Donation::emptyTestDonation()</code>
+    </DeprecatedMethod>
     <MixedArrayAccess>
       <code><![CDATA[$payloadArray['error']]]></code>
       <code><![CDATA[$payloadArray['error']]]></code>
@@ -1556,6 +1564,9 @@
     </MixedArrayAccess>
   </file>
   <file src="tests/Application/Actions/Donations/UpdateHandlesLockExceptionTest.php">
+    <DeprecatedMethod>
+      <code>Donation::emptyTestDonation()</code>
+    </DeprecatedMethod>
     <InternalMethod>
       <code><![CDATA[new LockWaitTimeoutException($testCase->createStub(DriverException::class), null)]]></code>
     </InternalMethod>
@@ -1744,6 +1755,10 @@
     </MixedArgumentTypeCoercion>
   </file>
   <file src="tests/Application/Commands/ExpireMatchFundsTest.php">
+    <DeprecatedMethod>
+      <code>Donation::emptyTestDonation()</code>
+      <code>Donation::emptyTestDonation()</code>
+    </DeprecatedMethod>
     <MixedArgument>
       <code><![CDATA[$donationRepoProphecy->reveal()]]></code>
     </MixedArgument>
@@ -1813,6 +1828,12 @@
       <code>get</code>
     </PossiblyNullReference>
   </file>
+  <file src="tests/Application/DonationTestDataTrait.php">
+    <DeprecatedMethod>
+      <code>Donation::emptyTestDonation()</code>
+      <code>Donation::emptyTestDonation()</code>
+    </DeprecatedMethod>
+  </file>
   <file src="tests/Application/Fees/CalculatorTest.php">
     <MixedArgument>
       <code><![CDATA[$this->getAppInstance()->getContainer()->get('settings')]]></code>
@@ -1881,6 +1902,12 @@
     </UndefinedPropertyAssignment>
   </file>
   <file src="tests/Application/Persistence/RetrySafeEntityManagerTest.php">
+    <DeprecatedMethod>
+      <code>Donation::emptyTestDonation()</code>
+      <code>Donation::emptyTestDonation()</code>
+      <code>Donation::emptyTestDonation()</code>
+      <code>Donation::emptyTestDonation()</code>
+    </DeprecatedMethod>
     <InternalClass>
       <code><![CDATA[new ReturnCallback(static function () use ($retrySafeEm, $underlyingEmToResetTo) {
                 $retrySafeEm->setEntityManager($underlyingEmToResetTo);
@@ -1946,6 +1973,18 @@
     </PossiblyNullReference>
   </file>
   <file src="tests/Domain/DonationTest.php">
+    <DeprecatedMethod>
+      <code>Donation::emptyTestDonation()</code>
+      <code>Donation::emptyTestDonation()</code>
+      <code>Donation::emptyTestDonation()</code>
+      <code>Donation::emptyTestDonation()</code>
+      <code>Donation::emptyTestDonation()</code>
+      <code>Donation::emptyTestDonation()</code>
+      <code>Donation::emptyTestDonation()</code>
+      <code>Donation::emptyTestDonation()</code>
+      <code>Donation::emptyTestDonation()</code>
+      <code>Donation::emptyTestDonation()</code>
+    </DeprecatedMethod>
     <InternalMethod>
       <code>addToAssertionCount</code>
     </InternalMethod>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1142,11 +1142,6 @@
     <PossiblyUnusedMethod>
       <code>setFundRepository</code>
     </PossiblyUnusedMethod>
-    <RedundantCast>
-      <code><![CDATA[(string) $donationData->donationAmount]]></code>
-      <code><![CDATA[(string) $donationData->feeCoverAmount]]></code>
-      <code><![CDATA[(string) $donationData->tipAmount]]></code>
-    </RedundantCast>
     <TooManyArguments>
       <code>refresh</code>
     </TooManyArguments>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -199,7 +199,7 @@
   </file>
   <file src="integrationTests/DonationPersistenceTest.php">
     <DeprecatedMethod>
-      <code>Donation::emptyTestDonation()</code>
+      <code><![CDATA[Donation::emptyTestDonation('1')]]></code>
     </DeprecatedMethod>
   </file>
   <file src="public/index.php">
@@ -1016,9 +1016,7 @@
       <code>preUpdate</code>
     </PossiblyUnusedMethod>
     <PropertyNotSetInConstructor>
-      <code>$amount</code>
       <code>$campaign</code>
-      <code>$currencyCode</code>
       <code>$psp</code>
       <code>Donation</code>
       <code>Donation</code>
@@ -1533,7 +1531,7 @@
   </file>
   <file src="tests/Application/Actions/Donations/CreateTest.php">
     <DeprecatedMethod>
-      <code>Donation::emptyTestDonation()</code>
+      <code><![CDATA[Donation::emptyTestDonation('12.00')]]></code>
     </DeprecatedMethod>
     <MixedArrayAccess>
       <code><![CDATA[$payloadArray['error']]]></code>
@@ -1565,7 +1563,7 @@
   </file>
   <file src="tests/Application/Actions/Donations/UpdateHandlesLockExceptionTest.php">
     <DeprecatedMethod>
-      <code>Donation::emptyTestDonation()</code>
+      <code><![CDATA[Donation::emptyTestDonation('1')]]></code>
     </DeprecatedMethod>
     <InternalMethod>
       <code><![CDATA[new LockWaitTimeoutException($testCase->createStub(DriverException::class), null)]]></code>
@@ -1756,8 +1754,8 @@
   </file>
   <file src="tests/Application/Commands/ExpireMatchFundsTest.php">
     <DeprecatedMethod>
-      <code>Donation::emptyTestDonation()</code>
-      <code>Donation::emptyTestDonation()</code>
+      <code><![CDATA[Donation::emptyTestDonation('1')]]></code>
+      <code><![CDATA[Donation::emptyTestDonation('1')]]></code>
     </DeprecatedMethod>
     <MixedArgument>
       <code><![CDATA[$donationRepoProphecy->reveal()]]></code>
@@ -1830,8 +1828,8 @@
   </file>
   <file src="tests/Application/DonationTestDataTrait.php">
     <DeprecatedMethod>
-      <code>Donation::emptyTestDonation()</code>
-      <code>Donation::emptyTestDonation()</code>
+      <code>Donation::emptyTestDonation($amount, $paymentMethodType)</code>
+      <code><![CDATA[Donation::emptyTestDonation('124.56')]]></code>
     </DeprecatedMethod>
   </file>
   <file src="tests/Application/Fees/CalculatorTest.php">
@@ -1903,10 +1901,10 @@
   </file>
   <file src="tests/Application/Persistence/RetrySafeEntityManagerTest.php">
     <DeprecatedMethod>
-      <code>Donation::emptyTestDonation()</code>
-      <code>Donation::emptyTestDonation()</code>
-      <code>Donation::emptyTestDonation()</code>
-      <code>Donation::emptyTestDonation()</code>
+      <code><![CDATA[Donation::emptyTestDonation('1')]]></code>
+      <code><![CDATA[Donation::emptyTestDonation('1')]]></code>
+      <code><![CDATA[Donation::emptyTestDonation('1')]]></code>
+      <code><![CDATA[Donation::emptyTestDonation('1')]]></code>
     </DeprecatedMethod>
     <InternalClass>
       <code><![CDATA[new ReturnCallback(static function () use ($retrySafeEm, $underlyingEmToResetTo) {
@@ -1974,16 +1972,16 @@
   </file>
   <file src="tests/Domain/DonationTest.php">
     <DeprecatedMethod>
-      <code>Donation::emptyTestDonation()</code>
-      <code>Donation::emptyTestDonation()</code>
-      <code>Donation::emptyTestDonation()</code>
-      <code>Donation::emptyTestDonation()</code>
-      <code>Donation::emptyTestDonation()</code>
-      <code>Donation::emptyTestDonation()</code>
-      <code>Donation::emptyTestDonation()</code>
-      <code>Donation::emptyTestDonation()</code>
-      <code>Donation::emptyTestDonation()</code>
-      <code>Donation::emptyTestDonation()</code>
+      <code><![CDATA[Donation::emptyTestDonation('0.99')]]></code>
+      <code><![CDATA[Donation::emptyTestDonation('1')]]></code>
+      <code><![CDATA[Donation::emptyTestDonation('1')]]></code>
+      <code><![CDATA[Donation::emptyTestDonation('1')]]></code>
+      <code><![CDATA[Donation::emptyTestDonation('1')]]></code>
+      <code><![CDATA[Donation::emptyTestDonation('1')]]></code>
+      <code><![CDATA[Donation::emptyTestDonation('1')]]></code>
+      <code><![CDATA[Donation::emptyTestDonation('1')]]></code>
+      <code><![CDATA[Donation::emptyTestDonation('100.00')]]></code>
+      <code><![CDATA[Donation::emptyTestDonation('25000.01')]]></code>
     </DeprecatedMethod>
     <InternalMethod>
       <code>addToAssertionCount</code>

--- a/src/Application/Actions/Donations/Update.php
+++ b/src/Application/Actions/Donations/Update.php
@@ -227,7 +227,7 @@ class Update extends Action
         $donation->setChampionComms($donationData->optInChampionEmail);
         $donation->setDonorBillingAddress($donationData->billingPostalAddress);
 
-        $donation = $this->donationRepository->deriveFees(
+        $this->donationRepository->deriveFees(
             $donation,
             $donationData->cardBrand,
             $donationData->cardCountry

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -293,7 +293,16 @@ class Donation extends SalesforceWriteProxy
      */
     protected $fundingWithdrawals;
 
-    public function __construct()
+    /**
+     * @deprecated but retained for now as used in old test classes. Not recommend for continued use - either use
+     * fromApiModel or create a new named constructor that takes required data for your use case.
+     */
+    public static function emptyTestDonation(): self
+    {
+        return new self();
+    }
+
+    private function __construct()
     {
         $this->fundingWithdrawals = new ArrayCollection();
     }

--- a/src/Domain/DonationRepository.php
+++ b/src/Domain/DonationRepository.php
@@ -16,6 +16,7 @@ use MatchBot\Client\BadRequestException;
 use MatchBot\Client\NotFoundException;
 use MatchBot\Domain\DomainException\DomainLockContentionException;
 use Ramsey\Uuid\Doctrine\UuidGenerator;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\Lock\Exception\LockAcquiringException;
 use Symfony\Component\Lock\LockFactory;
 
@@ -156,32 +157,7 @@ class DonationRepository extends SalesforceWriteProxyRepository
             ));
         }
 
-        $donation = new Donation();
-        $donation->setPsp($donationData->psp);
-        $donation->setPaymentMethodType($donationData->paymentMethodType);
-        $donation->setDonationStatus(DonationStatus::Pending);
-        $donation->setUuid((new UuidGenerator())->generateId($this->getEntityManager(), $donation));
-        $donation->setCampaign($campaign); // Charity & match expectation determined implicitly from this
-        $donation->setCurrencyCode($donationData->currencyCode);
-        $donation->setAmount((string) $donationData->donationAmount);
-        $donation->setGiftAid($donationData->giftAid);
-        $donation->setCharityComms($donationData->optInCharityEmail);
-        $donation->setChampionComms($donationData->optInChampionEmail);
-        $donation->setPspCustomerId($donationData->pspCustomerId);
-        $donation->setTbgComms($donationData->optInTbgEmail);
-
-        if (!empty($donationData->countryCode)) {
-            $donation->setDonorCountryCode($donationData->countryCode);
-        }
-
-        if (isset($donationData->feeCoverAmount)) {
-            $donation->setFeeCoverAmount((string) $donationData->feeCoverAmount);
-        }
-
-        if (isset($donationData->tipAmount)) {
-            $donation->setTipAmount((string) $donationData->tipAmount);
-        }
-
+        $donation = Donation::fromApiModel($donationData, $campaign);
         $this->deriveFees($donation);
 
         return $donation;

--- a/src/Domain/DonationRepository.php
+++ b/src/Domain/DonationRepository.php
@@ -73,7 +73,7 @@ class DonationRepository extends SalesforceWriteProxyRepository
     public function doUpdate(SalesforceWriteProxy $donation): bool
     {
         if ($donation->getPaymentMethodType() === null) {
-            $donation->setPaymentMethodType(PaymentMethodType::Card);
+            $donation->replaceNullPaymentMethodTypeWithCard();
             $this->getEntityManager()->persist($donation);
         }
 

--- a/src/Domain/DonationRepository.php
+++ b/src/Domain/DonationRepository.php
@@ -182,7 +182,7 @@ class DonationRepository extends SalesforceWriteProxyRepository
             $donation->setTipAmount((string) $donationData->tipAmount);
         }
 
-        $donation = $this->deriveFees($donation);
+        $this->deriveFees($donation);
 
         return $donation;
     }
@@ -561,7 +561,7 @@ class DonationRepository extends SalesforceWriteProxyRepository
         return count($donations);
     }
 
-    public function deriveFees(Donation $donation, ?string $cardBrand = null, ?string $cardCountry = null): Donation
+    public function deriveFees(Donation $donation, ?string $cardBrand = null, ?string $cardCountry = null): void
     {
         $incursGiftAidFee = $donation->hasGiftAid() && $donation->hasTbgShouldProcessGiftAid();
 
@@ -577,8 +577,6 @@ class DonationRepository extends SalesforceWriteProxyRepository
         );
         $donation->setCharityFee($structure->getCoreFee());
         $donation->setCharityFeeVat($structure->getFeeVat());
-
-        return $donation;
     }
 
     /**

--- a/tests/Application/Actions/Donations/CreateTest.php
+++ b/tests/Application/Actions/Donations/CreateTest.php
@@ -1082,7 +1082,7 @@ class CreateTest extends TestCase
             $campaign->setEndDate((new \DateTime())->sub(new \DateInterval('P1D')));
         }
 
-        $donation = new Donation();
+        $donation = Donation::emptyTestDonation();
         $donation->createdNow(); // Call same create/update time initialisers as lifecycle hooks
         $donation->setCurrencyCode('GBP');
         $donation->setAmount('12.00');

--- a/tests/Application/Actions/Donations/CreateTest.php
+++ b/tests/Application/Actions/Donations/CreateTest.php
@@ -1082,10 +1082,9 @@ class CreateTest extends TestCase
             $campaign->setEndDate((new \DateTime())->sub(new \DateInterval('P1D')));
         }
 
-        $donation = Donation::emptyTestDonation();
+        $donation = Donation::emptyTestDonation('12.00');
         $donation->createdNow(); // Call same create/update time initialisers as lifecycle hooks
         $donation->setCurrencyCode('GBP');
-        $donation->setAmount('12.00');
         $donation->setCampaign($campaign);
         $donation->setPsp('stripe');
         $donation->setUuid(Uuid::fromString('12345678-1234-1234-1234-1234567890ab'));

--- a/tests/Application/Actions/Donations/UpdateHandlesLockExceptionTest.php
+++ b/tests/Application/Actions/Donations/UpdateHandlesLockExceptionTest.php
@@ -60,7 +60,7 @@ class UpdateHandlesLockExceptionTest extends TestCase
 
         $this->setExpectationsForPersistAfterRetry($donationId, $donation, DonationStatus::Pending);
 
-        $this->donationRepositoryProphecy->deriveFees($donation, 'some-card-brand', 'some-country')->shouldBeCalled()->willReturn($donation);
+        $this->donationRepositoryProphecy->deriveFees($donation, 'some-card-brand', 'some-country')->shouldBeCalled();
 
         $updateAction = new Update(
             $this->donationRepositoryProphecy->reveal(),

--- a/tests/Application/Actions/Donations/UpdateHandlesLockExceptionTest.php
+++ b/tests/Application/Actions/Donations/UpdateHandlesLockExceptionTest.php
@@ -126,7 +126,7 @@ class UpdateHandlesLockExceptionTest extends TestCase
         $campaign->setIsMatched(true);
         $campaign->setCharity($charity);
 
-        $donation = new Donation();
+        $donation = Donation::emptyTestDonation();
         $donation->createdNow();
         $donation->setDonationStatus(DonationStatus::Pending);
         $donation->setCampaign($campaign);

--- a/tests/Application/Actions/Donations/UpdateHandlesLockExceptionTest.php
+++ b/tests/Application/Actions/Donations/UpdateHandlesLockExceptionTest.php
@@ -126,13 +126,12 @@ class UpdateHandlesLockExceptionTest extends TestCase
         $campaign->setIsMatched(true);
         $campaign->setCharity($charity);
 
-        $donation = Donation::emptyTestDonation();
+        $donation = Donation::emptyTestDonation('1');
         $donation->createdNow();
         $donation->setDonationStatus(DonationStatus::Pending);
         $donation->setCampaign($campaign);
         $donation->setPsp('stripe');
         $donation->setCurrencyCode('GBP');
-        $donation->setAmount('1');
         $donation->setUuid(Uuid::uuid4());
         $donation->setDonorFirstName('Donor first name');
         $donation->setDonorLastName('Donor last name');

--- a/tests/Application/Actions/Donations/UpdateTest.php
+++ b/tests/Application/Actions/Donations/UpdateTest.php
@@ -949,10 +949,9 @@ class UpdateTest extends TestCase
         $donation->setDonorBillingAddress('Y1 1YX');
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
-        $donationInRepo = $this->getTestDonation();  // Get a new mock object so DB has old values.
         $donationRepoProphecy
             ->findAndLockOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
-            ->willReturn($donationInRepo)
+            ->willReturn($donation)
             ->shouldBeCalledOnce();
         $donationRepoProphecy
             ->releaseMatchFunds(Argument::type(Donation::class))
@@ -961,8 +960,7 @@ class UpdateTest extends TestCase
             ->push(Argument::type(Donation::class), false)
             ->shouldNotBeCalled();
         $donationRepoProphecy
-            ->deriveFees(Argument::type(Donation::class), null, null)
-            ->willReturn($donation) // Actual fee calculation is tested elsewhere.
+            ->deriveFees(Argument::type(Donation::class), null, null)// Actual fee calculation is tested elsewhere.
             ->shouldBeCalledOnce();
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
@@ -1045,17 +1043,15 @@ class UpdateTest extends TestCase
         $donation->setDonorBillingAddress('Y1 1YX');
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
-        $donationInRepo = $this->getTestDonation(); // Get a new mock object so DB has old values.
         $donationRepoProphecy
             ->findAndLockOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
-            ->willReturn($donationInRepo)
+            ->willReturn($donation)
             ->shouldBeCalledOnce();
         $donationRepoProphecy
             ->push(Argument::type(Donation::class), false)
             ->shouldBeCalledOnce();
-        $donationRepoProphecy
-            ->deriveFees(Argument::type(Donation::class), null, null)
-            ->willReturn($donation) // Actual fee calculation is tested elsewhere.
+        $donationRepoProphecy // here
+            ->deriveFees(Argument::type(Donation::class), null, null)// Actual fee calculation is tested elsewhere.
             ->shouldBeCalledOnce();
 
         // Persist as normal.
@@ -1144,10 +1140,9 @@ class UpdateTest extends TestCase
         $donation->setDonorBillingAddress('Y1 1YX');
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
-        $donationInRepo = $this->getTestDonation();  // Get a new mock object so DB has old values.
         $donationRepoProphecy
             ->findAndLockOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
-            ->willReturn($donationInRepo)
+            ->willReturn($donation)
             ->shouldBeCalledOnce();
         $donationRepoProphecy
             ->releaseMatchFunds(Argument::type(Donation::class))
@@ -1156,8 +1151,7 @@ class UpdateTest extends TestCase
             ->push(Argument::type(Donation::class), false)
             ->shouldNotBeCalled();
         $donationRepoProphecy
-            ->deriveFees(Argument::type(Donation::class), null, null)
-            ->willReturn($donation) // Actual fee calculation is tested elsewhere.
+            ->deriveFees(Argument::type(Donation::class), null, null)// Actual fee calculation is tested elsewhere.
             ->shouldBeCalledOnce();
 
         // Internal persist still goes ahead.
@@ -1252,17 +1246,15 @@ class UpdateTest extends TestCase
         $donation->setDonorBillingAddress('Y1 1YX');
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
-        $donationInRepo = $this->getTestDonation();  // Get a new mock object so DB has old values.
         $donationRepoProphecy
             ->findAndLockOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
-            ->willReturn($donationInRepo)
+            ->willReturn($donation)
             ->shouldBeCalledOnce();
         $donationRepoProphecy
             ->push(Argument::type(Donation::class), false)
             ->shouldBeCalledOnce();
         $donationRepoProphecy
-            ->deriveFees(Argument::type(Donation::class), null, null)
-            ->willReturn($donation) // Actual fee calculation is tested elsewhere.
+            ->deriveFees(Argument::type(Donation::class), null, null) // Actual fee calculation is tested elsewhere.
             ->shouldBeCalledOnce();
 
         // Persist as normal.
@@ -1354,10 +1346,9 @@ class UpdateTest extends TestCase
         $donation->setDonorBillingAddress('Y1 1YX');
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
-        $donationInRepo = $this->getTestDonation(); // Get a new mock object so DB has old values.
         $donationRepoProphecy
             ->findAndLockOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
-            ->willReturn($donationInRepo)
+            ->willReturn($donation)
             ->shouldBeCalledOnce();
         $donationRepoProphecy
             ->releaseMatchFunds(Argument::type(Donation::class))
@@ -1366,8 +1357,7 @@ class UpdateTest extends TestCase
             ->push(Argument::type(Donation::class), false)
             ->shouldNotBeCalled();
         $donationRepoProphecy
-            ->deriveFees(Argument::type(Donation::class), null, null)
-            ->willReturn($donation) // Actual fee calculation is tested elsewhere.
+            ->deriveFees(Argument::type(Donation::class), null, null) // Actual fee calculation is tested elsewhere.
             ->shouldBeCalledOnce();
 
         // Internal persist still goes ahead.
@@ -1460,17 +1450,15 @@ class UpdateTest extends TestCase
         $donation->setDonorBillingAddress('Y1 1YX');
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
-        $donatinInRepo = $this->getTestDonation();  // Get a new mock object so DB has old values.
         $donationRepoProphecy
             ->findAndLockOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
-            ->willReturn($donatinInRepo)
+            ->willReturn($donation)
             ->shouldBeCalledOnce();
         $donationRepoProphecy
             ->push(Argument::type(Donation::class), false)
             ->shouldBeCalledOnce();
         $donationRepoProphecy
-            ->deriveFees(Argument::type(Donation::class), null, null)
-            ->willReturn($donation) // Actual fee calculation is tested elsewhere.
+            ->deriveFees(Argument::type(Donation::class), null, null)// Actual fee calculation is tested elsewhere.
             ->shouldBeCalledOnce();
 
         // Persist as normal.
@@ -1563,10 +1551,9 @@ class UpdateTest extends TestCase
         $donation->setDonorBillingAddress('Y1 1YX');
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
-        $donationInRepo = $this->getTestDonation();  // Get a new mock object so DB has old values.
         $donationRepoProphecy
             ->findAndLockOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
-            ->willReturn($donationInRepo)
+            ->willReturn($donation)
             ->shouldBeCalledOnce();
         $donationRepoProphecy
             ->releaseMatchFunds(Argument::type(Donation::class))
@@ -1575,8 +1562,7 @@ class UpdateTest extends TestCase
             ->push(Argument::type(Donation::class), false)
             ->shouldBeCalledOnce(); // Updates pushed to Salesforce
         $donationRepoProphecy
-            ->deriveFees(Argument::type(Donation::class), null, null)
-            ->willReturn($donation) // Actual fee calculation is tested elsewhere.
+            ->deriveFees(Argument::type(Donation::class), null, null) // Actual fee calculation is tested elsewhere.
             ->shouldBeCalledOnce();
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
@@ -1675,8 +1661,7 @@ class UpdateTest extends TestCase
             ->push(Argument::type(Donation::class), false)
             ->shouldBeCalledOnce(); // Updates pushed to Salesforce
         $donationRepoProphecy
-            ->deriveFees(Argument::type(Donation::class), null, null)
-            ->willReturn($donation) // Actual fee calculation is tested elsewhere.
+            ->deriveFees(Argument::type(Donation::class), null, null) // Actual fee calculation is tested elsewhere.
             ->shouldBeCalledOnce();
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
@@ -1812,8 +1797,7 @@ class UpdateTest extends TestCase
             ->willReturn($donationInRepo)
             ->shouldBeCalledOnce();
         $donationRepoProphecy
-            ->deriveFees(Argument::type(Donation::class), null, null)
-            ->willReturn($donation) // Actual fee calculation is tested elsewhere.
+            ->deriveFees(Argument::type(Donation::class), null, null) // Actual fee calculation is tested elsewhere.
             ->shouldBeCalledOnce();
         $donationRepoProphecy
             ->push(Argument::type(Donation::class), false)
@@ -1888,8 +1872,7 @@ class UpdateTest extends TestCase
             ->willReturn($donationInRepo)
             ->shouldBeCalledOnce();
         $donationRepoProphecy
-            ->deriveFees(Argument::type(Donation::class), null, null)
-            ->willReturn($donation) // Actual fee calculation is tested elsewhere.
+            ->deriveFees(Argument::type(Donation::class), null, null)// Actual fee calculation is tested elsewhere.
             ->shouldBeCalledOnce();
         $donationRepoProphecy
             ->push(Argument::type(Donation::class), false)

--- a/tests/Application/Actions/Donations/UpdateTest.php
+++ b/tests/Application/Actions/Donations/UpdateTest.php
@@ -325,12 +325,11 @@ class UpdateTest extends TestCase
         /** @var Container $container */
         $container = $app->getContainer();
 
-        $donation = $this->getTestDonation();
+        $donation = $this->getTestDonation('999.99');
         $donation->setDonationStatus(DonationStatus::Cancelled);
         // Check this is ignored and only status patched. N.B. this is currently a bit circular as we simulate both
         // the request and response, but it's (maybe) marginally better than the test not mentioning this behaviour
         // at all.
-        $donation->setAmount('999.99');
 
         $responseDonation = $this->getTestDonation();
         $responseDonation->setDonationStatus(DonationStatus::Cancelled);
@@ -388,12 +387,11 @@ class UpdateTest extends TestCase
         /** @var Container $container */
         $container = $app->getContainer();
 
-        $donation = $this->getTestDonation();
+        $donation = $this->getTestDonation('999.99');
         $donation->setDonationStatus(DonationStatus::Cancelled);
         // Check this is ignored and only status patched. N.B. this is currently a bit circular as we simulate both
         // the request and response, but it's (maybe) marginally better than the test not mentioning this behaviour
         // at all.
-        $donation->setAmount('999.99');
 
         $responseDonation = $this->getTestDonation();
         // This is the mock repo's response, not the API response. So it's the *prior* state before we cancel the
@@ -671,8 +669,7 @@ class UpdateTest extends TestCase
         /** @var Container $container */
         $container = $app->getContainer();
 
-        $donationInRequest = $this->getTestDonation();
-        $donationInRequest->setAmount('99.99');
+        $donationInRequest = $this->getTestDonation('99.99');
 
         $donationInRepo = $this->getTestDonation(); //  // Get a new mock object so it's £123.45.
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);

--- a/tests/Application/Actions/Hooks/StripeChargeUpdateTest.php
+++ b/tests/Application/Actions/Hooks/StripeChargeUpdateTest.php
@@ -157,8 +157,7 @@ class StripeChargeUpdateTest extends StripeTest
         $container = $app->getContainer();
 
         $body = $this->getStripeHookMock('ch_succeeded_sek');
-        $donation = $this->getTestDonation();
-        $donation->setAmount('6000.00');
+        $donation = $this->getTestDonation('6000.00');
         $donation->setCurrencyCode('SEK');
 
         $webhookSecret = $this->getValidWebhookSecret($container);

--- a/tests/Application/Commands/ExpireMatchFundsTest.php
+++ b/tests/Application/Commands/ExpireMatchFundsTest.php
@@ -40,8 +40,8 @@ class ExpireMatchFundsTest extends TestCase
     {
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy->findWithExpiredMatching()->willReturn([
-            Donation::emptyTestDonation(),
-            Donation::emptyTestDonation()
+            Donation::emptyTestDonation('1'),
+            Donation::emptyTestDonation('1')
         ]);
         $donationRepoProphecy->releaseMatchFunds(Argument::type(Donation::class))
             ->shouldBeCalledTimes(2);

--- a/tests/Application/Commands/ExpireMatchFundsTest.php
+++ b/tests/Application/Commands/ExpireMatchFundsTest.php
@@ -40,8 +40,8 @@ class ExpireMatchFundsTest extends TestCase
     {
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationRepoProphecy->findWithExpiredMatching()->willReturn([
-            new Donation(),
-            new Donation()
+            Donation::emptyTestDonation(),
+            Donation::emptyTestDonation()
         ]);
         $donationRepoProphecy->releaseMatchFunds(Argument::type(Donation::class))
             ->shouldBeCalledTimes(2);

--- a/tests/Application/DonationTestDataTrait.php
+++ b/tests/Application/DonationTestDataTrait.php
@@ -22,7 +22,7 @@ trait DonationTestDataTrait
         return file_get_contents($fullPath);
     }
 
-    protected function getTestDonation(): Donation
+    protected function getTestDonation(string $amount = '123.45'): Donation
     {
         $charity = new Charity();
         $charity->setDonateLinkId('123CharityId');
@@ -35,9 +35,8 @@ trait DonationTestDataTrait
         $campaign->setName('Test campaign');
         $campaign->setSalesforceId('456ProjectId');
 
-        $donation = Donation::emptyTestDonation();
+        $donation = Donation::emptyTestDonation($amount);
         $donation->createdNow(); // Call same create/update time initialisers as lifecycle hooks
-        $donation->setAmount('123.45');
         $donation->setCharityFee('2.05');
         $donation->setCampaign($campaign);
         $donation->setCharityComms(true);
@@ -78,9 +77,8 @@ trait DonationTestDataTrait
         $campaign->setName('Test campaign');
         $campaign->setSalesforceId('456ProjectId');
 
-        $donation = Donation::emptyTestDonation();
+        $donation = Donation::emptyTestDonation('124.56');
         $donation->createdNow(); // Call same create/update time initialisers as lifecycle hooks
-        $donation->setAmount('124.56');
         $donation->setCharityFee('2.57');
         $donation->setCampaign($campaign);
         $donation->setCurrencyCode('GBP');

--- a/tests/Application/DonationTestDataTrait.php
+++ b/tests/Application/DonationTestDataTrait.php
@@ -35,7 +35,7 @@ trait DonationTestDataTrait
         $campaign->setName('Test campaign');
         $campaign->setSalesforceId('456ProjectId');
 
-        $donation = new Donation();
+        $donation = Donation::emptyTestDonation();
         $donation->createdNow(); // Call same create/update time initialisers as lifecycle hooks
         $donation->setAmount('123.45');
         $donation->setCharityFee('2.05');
@@ -78,7 +78,7 @@ trait DonationTestDataTrait
         $campaign->setName('Test campaign');
         $campaign->setSalesforceId('456ProjectId');
 
-        $donation = new Donation();
+        $donation = Donation::emptyTestDonation();
         $donation->createdNow(); // Call same create/update time initialisers as lifecycle hooks
         $donation->setAmount('124.56');
         $donation->setCharityFee('2.57');

--- a/tests/Application/DonationTestDataTrait.php
+++ b/tests/Application/DonationTestDataTrait.php
@@ -6,6 +6,7 @@ use MatchBot\Domain\Campaign;
 use MatchBot\Domain\Charity;
 use MatchBot\Domain\Donation;
 use MatchBot\Domain\DonationStatus;
+use MatchBot\Domain\PaymentMethodType;
 use MatchBot\Domain\SalesforceWriteProxy;
 use Ramsey\Uuid\Uuid;
 
@@ -22,7 +23,7 @@ trait DonationTestDataTrait
         return file_get_contents($fullPath);
     }
 
-    protected function getTestDonation(string $amount = '123.45'): Donation
+    protected function getTestDonation(string $amount = '123.45', PaymentMethodType $paymentMethodType = PaymentMethodType::Card): Donation
     {
         $charity = new Charity();
         $charity->setDonateLinkId('123CharityId');
@@ -35,7 +36,7 @@ trait DonationTestDataTrait
         $campaign->setName('Test campaign');
         $campaign->setSalesforceId('456ProjectId');
 
-        $donation = Donation::emptyTestDonation($amount);
+        $donation = Donation::emptyTestDonation($amount, $paymentMethodType);
         $donation->createdNow(); // Call same create/update time initialisers as lifecycle hooks
         $donation->setCharityFee('2.05');
         $donation->setCampaign($campaign);

--- a/tests/Application/Persistence/RetrySafeEntityManagerTest.php
+++ b/tests/Application/Persistence/RetrySafeEntityManagerTest.php
@@ -69,7 +69,7 @@ class RetrySafeEntityManagerTest extends TestCase
         $container = $app->getContainer();
         $container->set(EntityManager::class, $underlyingEmProphecy->reveal());
 
-        $this->retrySafeEntityManager->persist(Donation::emptyTestDonation());
+        $this->retrySafeEntityManager->persist(Donation::emptyTestDonation('1'));
     }
 
     public function testPersistWithRetry(): void
@@ -100,7 +100,7 @@ class RetrySafeEntityManagerTest extends TestCase
         $container->set(RetrySafeEntityManager::class, $this->retrySafeEntityManager);
         $container->set(EntityManagerInterface::class, $this->retrySafeEntityManager);
 
-        $this->retrySafeEntityManager->persist(Donation::emptyTestDonation());
+        $this->retrySafeEntityManager->persist(Donation::emptyTestDonation('1'));
     }
 
     public function testFlush(): void
@@ -164,7 +164,7 @@ class RetrySafeEntityManagerTest extends TestCase
         $emProperty = $retrySafeEntityManagerReflected->getProperty('entityManager');
         $emProperty->setValue($this->retrySafeEntityManager, $underlyingEmProphecy->reveal());
 
-        $this->retrySafeEntityManager->refresh(Donation::emptyTestDonation(), LockMode::PESSIMISTIC_WRITE);
+        $this->retrySafeEntityManager->refresh(Donation::emptyTestDonation('1'), LockMode::PESSIMISTIC_WRITE);
     }
 
     public function testRefreshRetriesOnEmClosed(): void
@@ -190,7 +190,7 @@ class RetrySafeEntityManagerTest extends TestCase
             $underlyingEmProphecy2->reveal(),
         );
 
-        $retrySafeEntityManager->refresh(Donation::emptyTestDonation(), LockMode::PESSIMISTIC_WRITE);
+        $retrySafeEntityManager->refresh(Donation::emptyTestDonation('1'), LockMode::PESSIMISTIC_WRITE);
     }
 
     /**

--- a/tests/Application/Persistence/RetrySafeEntityManagerTest.php
+++ b/tests/Application/Persistence/RetrySafeEntityManagerTest.php
@@ -69,7 +69,7 @@ class RetrySafeEntityManagerTest extends TestCase
         $container = $app->getContainer();
         $container->set(EntityManager::class, $underlyingEmProphecy->reveal());
 
-        $this->retrySafeEntityManager->persist(new Donation());
+        $this->retrySafeEntityManager->persist(Donation::emptyTestDonation());
     }
 
     public function testPersistWithRetry(): void
@@ -100,7 +100,7 @@ class RetrySafeEntityManagerTest extends TestCase
         $container->set(RetrySafeEntityManager::class, $this->retrySafeEntityManager);
         $container->set(EntityManagerInterface::class, $this->retrySafeEntityManager);
 
-        $this->retrySafeEntityManager->persist(new Donation());
+        $this->retrySafeEntityManager->persist(Donation::emptyTestDonation());
     }
 
     public function testFlush(): void
@@ -164,7 +164,7 @@ class RetrySafeEntityManagerTest extends TestCase
         $emProperty = $retrySafeEntityManagerReflected->getProperty('entityManager');
         $emProperty->setValue($this->retrySafeEntityManager, $underlyingEmProphecy->reveal());
 
-        $this->retrySafeEntityManager->refresh(new Donation(), LockMode::PESSIMISTIC_WRITE);
+        $this->retrySafeEntityManager->refresh(Donation::emptyTestDonation(), LockMode::PESSIMISTIC_WRITE);
     }
 
     public function testRefreshRetriesOnEmClosed(): void
@@ -190,7 +190,7 @@ class RetrySafeEntityManagerTest extends TestCase
             $underlyingEmProphecy2->reveal(),
         );
 
-        $retrySafeEntityManager->refresh(new Donation(), LockMode::PESSIMISTIC_WRITE);
+        $retrySafeEntityManager->refresh(Donation::emptyTestDonation(), LockMode::PESSIMISTIC_WRITE);
     }
 
     /**

--- a/tests/Domain/DonationRepositoryTest.php
+++ b/tests/Domain/DonationRepositoryTest.php
@@ -208,8 +208,7 @@ class DonationRepositoryTest extends TestCase
     {
         // N.B. tip to TBG should not change the amount the charity receives, and the tip
         // is not included in the core donation amount set by `setAmount()`.
-        $donation = $this->getTestDonation();
-        $donation->setAmount('987.65');
+        $donation = $this->getTestDonation('987.65');;
         $donation->setCurrencyCode('GBP');
         $donation->setPsp('stripe');
         $donation->setTipAmount('10.00');
@@ -229,8 +228,7 @@ class DonationRepositoryTest extends TestCase
     {
         // N.B. tip to TBG should not change the amount the charity receives, and the tip
         // is not included in the core donation amount set by `setAmount()`.
-        $donation = $this->getTestDonation();
-        $donation->setAmount('987.65');
+        $donation = $this->getTestDonation('987.65');;
         $donation->setCurrencyCode('GBP');
         $donation->setPsp('stripe');
         $donation->setTipAmount('10.00');
@@ -253,8 +251,7 @@ class DonationRepositoryTest extends TestCase
     {
         // N.B. tip to TBG should not change the amount the charity receives, and the tip
         // is not included in the core donation amount set by `setAmount()`.
-        $donation = $this->getTestDonation();
-        $donation->setAmount('987.65');
+        $donation = $this->getTestDonation('987.65');;
         $donation->setTipAmount('0.00');
         $donation->setPsp('stripe');
         $donation->setFeeCoverAmount('44.44'); // 4.5% fee, inc. any VAT.
@@ -277,8 +274,7 @@ class DonationRepositoryTest extends TestCase
     {
         // N.B. tip to TBG should not change the amount the charity receives, and the tip
         // is not included in the core donation amount set by `setAmount()`.
-        $donation = $this->getTestDonation();
-        $donation->setAmount('987.65');
+        $donation = $this->getTestDonation('987.65');;
         $donation->setCurrencyCode('GBP');
         $donation->setPsp('stripe');
         $donation->setTipAmount('10.00');
@@ -298,8 +294,7 @@ class DonationRepositoryTest extends TestCase
     {
         // N.B. tip to TBG should not change the amount the charity receives, and the tip
         // is not included in the core donation amount set by `setAmount()`.
-        $donation = $this->getTestDonation();
-        $donation->setAmount('987.65');
+        $donation = $this->getTestDonation('987.65');;
         $donation->setCurrencyCode('GBP');
         $donation->setPsp('stripe');
         $donation->setTipAmount('10.00');
@@ -322,8 +317,7 @@ class DonationRepositoryTest extends TestCase
 
     public function testStripeAmountForCharityWithoutTip(): void
     {
-        $donation = $this->getTestDonation();
-        $donation->setAmount('987.65');
+        $donation = $this->getTestDonation('987.65');;
         $donation->setCurrencyCode('GBP');
         $donation->setPsp('stripe');
         $donation->setTipAmount('0.00');
@@ -340,9 +334,8 @@ class DonationRepositoryTest extends TestCase
 
     public function testStripeAmountForCharityWithoutTipWhenTbgClaimingGiftAid(): void
     {
-        $donation = $this->getTestDonation();
+        $donation = $this->getTestDonation('987.65');
         $donation->setTbgShouldProcessGiftAid(true);
-        $donation->setAmount('987.65');
         $donation->setCurrencyCode('GBP');
         $donation->setPsp('stripe');
         $donation->setTipAmount('0.00');
@@ -360,9 +353,8 @@ class DonationRepositoryTest extends TestCase
 
     public function testStripeAmountForCharityWithoutTipRoundingOnPointFive(): void
     {
-        $donation = $this->getTestDonation();
+        $donation = $this->getTestDonation('6.25');
         $donation->setPsp('stripe');
-        $donation->setAmount('6.25');
         $donation->setTipAmount('0.00');
         $donation->setCurrencyCode('GBP');
         $this->getRepo()->deriveFees($donation);

--- a/tests/Domain/DonationRepositoryTest.php
+++ b/tests/Domain/DonationRepositoryTest.php
@@ -213,7 +213,7 @@ class DonationRepositoryTest extends TestCase
         $donation->setCurrencyCode('GBP');
         $donation->setPsp('stripe');
         $donation->setTipAmount('10.00');
-        $donation = $this->getRepo()->deriveFees($donation, 'amex');
+        $this->getRepo()->deriveFees($donation, 'amex');
 
         // £987.65 * 3.2%   = £ 31.60 (to 2 d.p.)
         // Fixed fee        = £  0.20
@@ -234,7 +234,7 @@ class DonationRepositoryTest extends TestCase
         $donation->setCurrencyCode('GBP');
         $donation->setPsp('stripe');
         $donation->setTipAmount('10.00');
-        $donation = $this->getRepo()->deriveFees($donation, 'visa', 'US');
+        $this->getRepo()->deriveFees($donation, 'visa', 'US');
 
         // £987.65 * 3.2%   = £ 31.60 (to 2 d.p.)
         // Fixed fee        = £  0.20
@@ -259,7 +259,7 @@ class DonationRepositoryTest extends TestCase
         $donation->setPsp('stripe');
         $donation->setFeeCoverAmount('44.44'); // 4.5% fee, inc. any VAT.
         $donation->getCampaign()->setFeePercentage(4.5);
-        $donation = $this->getRepo()->deriveFees($donation);
+        $this->getRepo()->deriveFees($donation);
 
         // £987.65 * 4.5%   = £ 44.44 (to 2 d.p.)
         // Fixed fee        = £  0.00
@@ -282,7 +282,7 @@ class DonationRepositoryTest extends TestCase
         $donation->setCurrencyCode('GBP');
         $donation->setPsp('stripe');
         $donation->setTipAmount('10.00');
-        $donation = $this->getRepo()->deriveFees($donation);
+        $this->getRepo()->deriveFees($donation);
 
         // £987.65 * 1.5%   = £ 14.81 (to 2 d.p.)
         // Fixed fee        = £  0.20
@@ -305,7 +305,7 @@ class DonationRepositoryTest extends TestCase
         $donation->setTipAmount('10.00');
 
         // Get repo with 20% VAT enabled from now setting override.
-        $donation = $this->getRepo(null, true)->deriveFees($donation);
+        $this->getRepo(null, true)->deriveFees($donation);
 
         // £987.65 * 1.5%   = £ 14.81 (to 2 d.p.)
         // Fixed fee        = £  0.20
@@ -327,7 +327,7 @@ class DonationRepositoryTest extends TestCase
         $donation->setCurrencyCode('GBP');
         $donation->setPsp('stripe');
         $donation->setTipAmount('0.00');
-        $donation = $this->getRepo()->deriveFees($donation);
+        $this->getRepo()->deriveFees($donation);
 
         // £987.65 * 1.5%   = £ 14.81 (to 2 d.p.)
         // Fixed fee        = £  0.20
@@ -346,7 +346,7 @@ class DonationRepositoryTest extends TestCase
         $donation->setCurrencyCode('GBP');
         $donation->setPsp('stripe');
         $donation->setTipAmount('0.00');
-        $donation = $this->getRepo()->deriveFees($donation);
+        $this->getRepo()->deriveFees($donation);
 
         // £987.65 *  1.5%  = £ 14.81 (to 2 d.p.)
         // Fixed fee        = £  0.20
@@ -365,7 +365,7 @@ class DonationRepositoryTest extends TestCase
         $donation->setAmount('6.25');
         $donation->setTipAmount('0.00');
         $donation->setCurrencyCode('GBP');
-        $donation = $this->getRepo()->deriveFees($donation);
+        $this->getRepo()->deriveFees($donation);
 
         // £6.25 * 1.5% = £ 0.19 (to 2 d.p. – following normal mathematical rounding from £0.075)
         // Fixed fee    = £ 0.20

--- a/tests/Domain/DonationTest.php
+++ b/tests/Domain/DonationTest.php
@@ -225,9 +225,8 @@ class DonationTest extends TestCase
 
     public function testGetStripePIHelpersWithCustomerBalanceGbp(): void
     {
-        $donation = $this->getTestDonation();
+        $donation = $this->getTestDonation(paymentMethodType: PaymentMethodType::CustomerBalance);
         $donation->setCurrencyCode('GBP');
-        $donation->setPaymentMethodType(PaymentMethodType::CustomerBalance);
 
         $expectedPaymentMethodProperties = [
             'payment_method_types' => ['customer_balance'],
@@ -254,9 +253,8 @@ class DonationTest extends TestCase
         $this->expectException(\UnexpectedValueException::class);
         $this->expectExceptionMessage('Customer balance payments only supported for GBP');
 
-        $donation = $this->getTestDonation();
+        $donation = $this->getTestDonation(paymentMethodType: PaymentMethodType::CustomerBalance);
         $donation->setCurrencyCode('USD');
-        $donation->setPaymentMethodType(PaymentMethodType::CustomerBalance);
 
         $donation->getStripeMethodProperties(); // Throws in this getter for now.
     }

--- a/tests/Domain/DonationTest.php
+++ b/tests/Domain/DonationTest.php
@@ -17,7 +17,7 @@ class DonationTest extends TestCase
 
     public function testBasicsAsExpectedOnInstantion(): void
     {
-        $donation = new Donation();
+        $donation = Donation::emptyTestDonation();
 
         $this->assertFalse($donation->getDonationStatus()->isSuccessful());
         $this->assertEquals('not-sent', $donation->getSalesforcePushStatus());
@@ -31,7 +31,7 @@ class DonationTest extends TestCase
 
     public function testPendingDonationDoesNotHavePostCreateUpdates(): void
     {
-        $donation = new Donation();
+        $donation = Donation::emptyTestDonation();
         $donation->setDonationStatus(DonationStatus::Pending);
 
         $this->assertFalse($donation->hasPostCreateUpdates());
@@ -39,7 +39,7 @@ class DonationTest extends TestCase
 
     public function testPaidDonationHasPostCreateUpdates(): void
     {
-        $donation = new Donation();
+        $donation = Donation::emptyTestDonation();
         $donation->setDonationStatus(DonationStatus::Paid);
 
         $this->assertTrue($donation->hasPostCreateUpdates());
@@ -47,7 +47,7 @@ class DonationTest extends TestCase
 
     public function testValidDataPersisted(): void
     {
-        $donation = new Donation();
+        $donation = Donation::emptyTestDonation();
         $donation->setCurrencyCode('GBP');
         $donation->setAmount('100.00');
         $donation->setTipAmount('1.13');
@@ -63,7 +63,7 @@ class DonationTest extends TestCase
         $this->expectException(\UnexpectedValueException::class);
         $this->expectExceptionMessage('Amount must be 1-25000 GBP');
 
-        $donation = new Donation();
+        $donation = Donation::emptyTestDonation();
         $donation->setCurrencyCode('GBP');
         $donation->setAmount('0.99');
     }
@@ -73,7 +73,7 @@ class DonationTest extends TestCase
         $this->expectException(\UnexpectedValueException::class);
         $this->expectExceptionMessage('Amount must be 1-25000 GBP');
 
-        $donation = new Donation();
+        $donation = Donation::emptyTestDonation();
         $donation->setCurrencyCode('GBP');
         $donation->setAmount('25000.01');
     }
@@ -83,7 +83,7 @@ class DonationTest extends TestCase
         $this->expectException(\UnexpectedValueException::class);
         $this->expectExceptionMessage('Tip amount must not exceed 25000 GBP');
 
-        $donation = new Donation();
+        $donation = Donation::emptyTestDonation();
         $donation->setCurrencyCode('GBP');
         $donation->setTipAmount('25000.01');
     }
@@ -93,14 +93,14 @@ class DonationTest extends TestCase
         $this->expectException(\UnexpectedValueException::class);
         $this->expectExceptionMessage("Unexpected PSP 'paypal'");
 
-        $donation = new Donation();
+        $donation = Donation::emptyTestDonation();
         /** @psalm-suppress InvalidArgument */
         $donation->setPsp('paypal');
     }
 
     public function testValidPspAccepted(): void
     {
-        $donation = new Donation();
+        $donation = Donation::emptyTestDonation();
         $donation->setPsp('stripe');
 
         $this->addToAssertionCount(1); // Just check setPsp() doesn't hit an exception
@@ -108,7 +108,7 @@ class DonationTest extends TestCase
 
     public function testSetAndGetOriginalFee(): void
     {
-        $donation = new Donation();
+        $donation = Donation::emptyTestDonation();
         $donation->setOriginalPspFeeFractional(123);
 
         $this->assertEquals('1.23', $donation->getOriginalPspFee());


### PR DESCRIPTION
Fairly substantial refactoring involved in this PR, must of it done with the PhpStorm tools, and actually the changes in production code are minimal so it's pretty safe, it's mostly changes in test code. The main reason is that the new requirement has the maximum donation amount dependant on the payment method type, and so the donation class can only enforce that if it doesn't allow them to be set separately, or at least doesn't allow the method to be changed after the amount is set.

Our site doesn't actually support changing the amount on an existing donation, so there's no need for the class to support it. Now amount, currency code and payment method type are all required params of the domain donation constructor. In production we only ever construct a donation by calling `\MatchBot\Domain\Donation::fromApiModel` (or letting Doctrine instantiate it from the DB, which doesn't run use any constructor function).

The refactors take us most of the way towards https://github.com/thebiggive/matchbot/pull/509

I'm assuming we want the maximum tip to be the same as the maximum donation, as it has been up to now.