### PR TITLE
DON-772: Stop accepting tips on customer balance based donations

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -971,7 +971,6 @@
       <code><![CDATA[$this->getFeeCoverAmount()]]></code>
       <code><![CDATA[$this->getTipAmount()]]></code>
       <code><![CDATA[$this->getTipAmount()]]></code>
-      <code>$tipAmount</code>
     </ArgumentTypeCoercion>
     <MethodSignatureMustProvideReturnType>
       <code>__toString</code>

--- a/tests/Application/Actions/Donations/UpdateTest.php
+++ b/tests/Application/Actions/Donations/UpdateTest.php
@@ -1640,10 +1640,10 @@ class UpdateTest extends TestCase
         /** @var Container $container */
         $container = $app->getContainer();
 
-        $donation = $this->getTestDonation(paymentMethodType: PaymentMethodType::CustomerBalance);
+        $donation = $this->getTestDonation(paymentMethodType: PaymentMethodType::CustomerBalance, tipAmount: '0');
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
-        $donationInRepo = $this->getTestDonation(paymentMethodType: PaymentMethodType::CustomerBalance);  // Get a new mock object so DB has old values.
+        $donationInRepo = $this->getTestDonation(paymentMethodType: PaymentMethodType::CustomerBalance, tipAmount: '0');  // Get a new mock object so DB has old values.
 
         $donationRepoProphecy
             ->findAndLockOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])
@@ -1777,7 +1777,7 @@ class UpdateTest extends TestCase
         /** @var Container $container */
         $container = $app->getContainer();
 
-        $donation = $this->getTestDonation(paymentMethodType: PaymentMethodType::CustomerBalance);
+        $donation = $this->getTestDonation(paymentMethodType: PaymentMethodType::CustomerBalance, tipAmount: '0');
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $donationInRepo = $this->getTestDonation(paymentMethodType: PaymentMethodType::Card);
@@ -1845,10 +1845,10 @@ class UpdateTest extends TestCase
         /** @var Container $container */
         $container = $app->getContainer();
 
-        $donation = $this->getTestDonation(paymentMethodType: PaymentMethodType::CustomerBalance);
+        $donation = $this->getTestDonation(paymentMethodType: PaymentMethodType::CustomerBalance, tipAmount: '0');
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
-        $donationInRepo = $this->getTestDonation(paymentMethodType: PaymentMethodType::CustomerBalance);  // Get a new mock object so DB has old values.
+        $donationInRepo = $this->getTestDonation(paymentMethodType: PaymentMethodType::CustomerBalance, tipAmount: '0');  // Get a new mock object so DB has old values.
         // Make it explicit that the payment method type is (the unsupported
         // for auto-confirms) "card".
 

--- a/tests/Application/DonationTestDataTrait.php
+++ b/tests/Application/DonationTestDataTrait.php
@@ -23,7 +23,11 @@ trait DonationTestDataTrait
         return file_get_contents($fullPath);
     }
 
-    protected function getTestDonation(string $amount = '123.45', PaymentMethodType $paymentMethodType = PaymentMethodType::Card): Donation
+    protected function getTestDonation(
+        string $amount = '123.45',
+        PaymentMethodType $paymentMethodType = PaymentMethodType::Card,
+        string $tipAmount = '1.00',
+    ): Donation
     {
         $charity = new Charity();
         $charity->setDonateLinkId('123CharityId');
@@ -57,7 +61,7 @@ trait DonationTestDataTrait
         $donation->setSalesforceId('sfDonation369');
         $donation->setSalesforcePushStatus(SalesforceWriteProxy::PUSH_STATUS_COMPLETE);
         $donation->setTbgComms(false);
-        $donation->setTipAmount('1.00');
+        $donation->setTipAmount($tipAmount);
         $donation->setTransferId('tr_externalId_123');
         $donation->setTransactionId('pi_externalId_123');
         $donation->setChargeId('ch_externalId_123');


### PR DESCRIPTION
Frontend already refuses tips for these donations, but I think that logic may been only in the HTML template:
https://github.com/thebiggive/donate-frontend/blob/4a1a0788441b796394bbfd1d7d1381dffcff5811/src/app/donation-start/donation-start-form/donation-start-form.component.html#L63