### PR TITLE
BG2-2306: Prepare to send refund timestamp to salesforce

### DIFF
--- a/integrationTests/DonationPersistenceTest.php
+++ b/integrationTests/DonationPersistenceTest.php
@@ -15,6 +15,7 @@ class DonationPersistenceTest extends IntegrationTest
         $em = $this->getService(EntityManagerInterface::class);
         $connection = $em->getConnection();
         $donation = $this->makeDonationObject();
+        $donation->recordRefundAt(new \DateTimeImmutable('2023-06-22 10:00:00'));
 
         // act
         $em->persist($donation);
@@ -39,7 +40,7 @@ class DonationPersistenceTest extends IntegrationTest
         $donation = $donationRepo->findOneBy(['uuid' => $donationRow['uuid']]);
 
         $this->assertNotNull($donation);
-        $this->assertSame(DonationStatus::Collected, $donation->getDonationStatus());
+        $this->assertEquals(DonationStatus::Refunded, $donation->getDonationStatus());
     }
 
     /**
@@ -62,7 +63,7 @@ class DonationPersistenceTest extends IntegrationTest
             'uuid' => Uuid::uuid4(),
             'transactionId' => NULL,
             'amount' => '1.00',
-            'donationStatus' => 'Collected',
+            'donationStatus' => 'Refunded',
             'charityComms' => NULL,
             'giftAid' => NULL,
             'tbgComms' => NULL,
@@ -88,6 +89,7 @@ class DonationPersistenceTest extends IntegrationTest
             'currencyCode' => 'GBP',
             'feeCoverAmount' => '0.00',
             'collectedAt' => NULL,
+            'refundedAt' => '2023-06-22 10:00:00',
             'tbgShouldProcessGiftAid' => NULL,
             'tbgGiftAidRequestQueuedAt' => NULL,
             'tbgGiftAidRequestFailedAt' => NULL,

--- a/integrationTests/DonationPersistenceTest.php
+++ b/integrationTests/DonationPersistenceTest.php
@@ -39,7 +39,7 @@ class DonationPersistenceTest extends IntegrationTest
         $donation = $donationRepo->findOneBy(['uuid' => $donationRow['uuid']]);
 
         $this->assertNotNull($donation);
-        $this->assertSame(DonationStatus::Refunded, $donation->getDonationStatus());
+        $this->assertSame(DonationStatus::Collected, $donation->getDonationStatus());
     }
 
     /**
@@ -62,7 +62,7 @@ class DonationPersistenceTest extends IntegrationTest
             'uuid' => Uuid::uuid4(),
             'transactionId' => NULL,
             'amount' => '1.00',
-            'donationStatus' => 'Refunded',
+            'donationStatus' => 'Collected',
             'charityComms' => NULL,
             'giftAid' => NULL,
             'tbgComms' => NULL,
@@ -112,7 +112,7 @@ class DonationPersistenceTest extends IntegrationTest
         $donation->setUuid(Uuid::uuid4());
         $donation->setPsp('stripe');
         $donation->setCurrencyCode('GBP');
-        $donation->setDonationStatus(DonationStatus::Refunded);
+        $donation->setDonationStatus(DonationStatus::Collected);
 
         return $donation;
     }

--- a/src/Application/Actions/Hooks/StripeChargeUpdate.php
+++ b/src/Application/Actions/Hooks/StripeChargeUpdate.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace MatchBot\Application\Actions\Hooks;
 
+use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use MatchBot\Application\Actions\ActionPayload;
 use MatchBot\Application\Notifier\StripeChatterInterface;
 use MatchBot\Domain\Donation;
 use MatchBot\Domain\DonationRepository;
 use MatchBot\Domain\DonationStatus;
-use Monolog\DateTimeImmutable;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;

--- a/src/Application/Actions/Hooks/StripeChargeUpdate.php
+++ b/src/Application/Actions/Hooks/StripeChargeUpdate.php
@@ -219,7 +219,7 @@ class StripeChargeUpdate extends Stripe
             $intentId,
         ));
 
-        $donation->setDonationStatus(DonationStatus::Refunded);
+        $donation->recordRefundAt(new \DateTimeImmutable());
         $this->doPostMarkRefundedUpdates($donation, true);
 
         return $this->respondWithData($response, $event->data->object);
@@ -274,7 +274,7 @@ class StripeChargeUpdate extends Stripe
                 $donation->getUuid(),
                 $charge->id,
             ));
-            $donation->setDonationStatus(DonationStatus::Refunded);
+            $donation->recordRefundAt(new \DateTimeImmutable());
         } elseif ($isOverRefund) {
             $this->warnAboutOverRefund(
                 'charge.refunded',
@@ -288,7 +288,7 @@ class StripeChargeUpdate extends Stripe
                 $donation->getUuid(),
                 $charge->id,
             ));
-            $donation->setDonationStatus(DonationStatus::Refunded);
+            $donation->recordRefundAt(new \DateTimeImmutable());
         } else {
             $this->logger->error(sprintf(
                 'Skipping unexpected partial non-tip refund amount %s pence for donation %s based on charge ID %s',

--- a/src/Client/Donation.php
+++ b/src/Client/Donation.php
@@ -71,7 +71,6 @@ class Donation extends Common
      */
     public function put(DonationModel $donation): bool
     {
-        // this should start to send the refunded datetime
         if (getenv('DISABLE_CLIENT_PUSH')) {
             $this->logger->info("Client push off: Skipping update of donation {$donation->getUuid()}");
 

--- a/src/Client/Donation.php
+++ b/src/Client/Donation.php
@@ -71,6 +71,7 @@ class Donation extends Common
      */
     public function put(DonationModel $donation): bool
     {
+        // this should start to send the refunded datetime
         if (getenv('DISABLE_CLIENT_PUSH')) {
             $this->logger->info("Client push off: Skipping update of donation {$donation->getUuid()}");
 

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -1277,4 +1277,13 @@ class Donation extends SalesforceWriteProxy
         $this->donationStatus = DonationStatus::Refunded;
         $this->refundedAt = $refundDate;
     }
+
+    /**
+     * When a donation has been partially refunded (e.g. a tip-only refund) we record the refund date but we
+     * don't change the status.
+     */
+    public function setPartialRefundDate(\DateTimeImmutable $datetime): void
+    {
+        $this->refundedAt = $datetime;
+    }
 }

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -391,7 +391,6 @@ class Donation extends SalesforceWriteProxy
      */
     public function toHookModel(): array
     {
-        // this should include the refund datetime
         $data = $this->toApiModel();
 
         // MAT-234 - remove dubious patterns from email for now so records can save in SF.

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -469,6 +469,10 @@ class Donation extends SalesforceWriteProxy
 
     public function setDonationStatus(DonationStatus $donationStatus): void
     {
+        if ($donationStatus === DonationStatus::Refunded) {
+            throw new \Exception('Donation::recordRefundAt must be used to set refunded status');
+        }
+
         $this->donationStatus = $donationStatus;
     }
 
@@ -1266,6 +1270,9 @@ class Donation extends SalesforceWriteProxy
 
     public function recordRefundAt(\DateTimeImmutable $refundDate): void
     {
+        if ($this->donationStatus === DonationStatus::Refunded) {
+            return;
+        }
         $this->donationStatus = DonationStatus::Refunded;
         $this->refundedAt = $refundDate;
     }

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -298,6 +298,8 @@ class Donation extends SalesforceWriteProxy
      * DonationStatus::Refunded
      *
      * @ORM\Column(nullable=true)
+     *
+     * @psalm-suppress UnusedProperty - this is just because we have some temporarily commented out code.
      */
     private ?\DateTimeImmutable $refundedAt = null;
 
@@ -400,10 +402,12 @@ class Donation extends SalesforceWriteProxy
         }
 
         $data['updatedTime'] = $this->getUpdatedDate()->format(DateTimeInterface::ATOM);
-        $data['refundedTime'] = $this->refundedAt?->format(DateTimeInterface::ATOM);
         $data['amountMatchedByChampionFunds'] = (float) $this->getConfirmedChampionWithdrawalTotal();
         $data['amountMatchedByPledges'] = (float) $this->getConfirmedPledgeWithdrawalTotal();
         $data['originalPspFee'] = (float) $this->getOriginalPspFee();
+
+        // We can't send refundedTime to SF yet as SF isn't ready to take it. When it is ready, uncomment the next line. See BG2-2306
+        // $data['refundedTime'] = $this->refundedAt?->format(DateTimeInterface::ATOM);
 
         unset(
             $data['clientSecret'],

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -296,6 +296,8 @@ class Donation extends SalesforceWriteProxy
     /**
      * Date at which we refunded this to the donor. Ideally will be null. Should be not null only iff status is
      * DonationStatus::Refunded
+     *
+     * @ORM\Column(nullable=true)
      */
     private ?\DateTimeImmutable $refundedAt = null;
 

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -145,7 +145,7 @@ class Donation extends SalesforceWriteProxy
     /**
      * @ORM\Column(type="string", enumType="MatchBot\Domain\DonationStatus")
      */
-    protected DonationStatus $donationStatus = DonationStatus::NotSet;
+    protected DonationStatus $donationStatus = DonationStatus::Pending;
 
     /**
      * @ORM\Column(type="boolean", nullable=true)
@@ -327,7 +327,6 @@ class Donation extends SalesforceWriteProxy
         $donation = new self($donationData->donationAmount, $donationData->currencyCode, $donationData->paymentMethodType);
 
         $donation->setPsp($psp);
-        $donation->setDonationStatus(DonationStatus::Pending);
         $donation->setUuid(Uuid::uuid4());
         $donation->setCampaign($campaign); // Charity & match expectation determined implicitly from this
         $donation->setGiftAid($donationData->giftAid);
@@ -934,7 +933,7 @@ class Donation extends SalesforceWriteProxy
      */
     public function hasPostCreateUpdates(): bool
     {
-        return ! $this->getDonationStatus()->isNew();
+        return $this->getDonationStatus() !== DonationStatus::Pending;
     }
 
     /**

--- a/src/Domain/DonationRepository.php
+++ b/src/Domain/DonationRepository.php
@@ -78,8 +78,8 @@ class DonationRepository extends SalesforceWriteProxyRepository
         }
 
         try {
-            if ($donation->getDonationStatus()->isNew()) {
-                // A new status but an existing Salesforce ID suggests pushes might have ended up out
+            if ($donation->getDonationStatus() === DonationStatus::Pending) {
+                // A pending status but an existing Salesforce ID suggests pushes might have ended up out
                 // of order due to race conditions pushing to Salesforce, variable and quite slow
                 // Salesforce performance characteristics, and both client (this) & server (SF) apps being
                 // multi-threaded. The safest thing is not to push a Pending donation to Salesforce a 2nd

--- a/src/Domain/DonationStatus.php
+++ b/src/Domain/DonationStatus.php
@@ -6,14 +6,6 @@ enum DonationStatus: string
 {
     public const SUCCESS_STATUSES = [self::Collected, self::Paid];
 
-    public function isNew(): bool
-    {
-        return match ($this) {
-            self::NotSet, self::Pending => true,
-            default => false,
-        };
-    }
-
     /**
      * @return bool Whether this donation is *currently* in a state that we consider to be successful.
      *              Note that this is not guaranteed to be permanent: donations can be refunded or charged back after
@@ -34,13 +26,6 @@ enum DonationStatus: string
             default => false,
         };
     }
-
-    /**
-     * Never saved to database - this is just a placeholder used on incomplete donation objects in memory.
-     * @todo consider removing this, either replace with `null` or preferably force every donation to have a real
-     * status when constructed.
-     */
-    case NotSet = 'NotSet';
 
     /**
      * A Pending donation represents a non-binding statement of intent to donate. We don't know whether

--- a/src/Migrations/Version20230622095211.php
+++ b/src/Migrations/Version20230622095211.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20230622095211 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add Donation.refundedAt field';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE Donation ADD refundedAt DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\' AFTER collectedAt');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE Donation DROP refundedAt');
+    }
+}

--- a/tests/Domain/DonationTest.php
+++ b/tests/Domain/DonationTest.php
@@ -315,4 +315,29 @@ class DonationTest extends TestCase
 
         $donation->getStripeMethodProperties(); // Throws in this getter for now.
     }
+
+    public function testDonationDateTimeIsIncludedInSfHookModel(): void
+    {
+        $donation = $this->getTestDonation();
+
+        $donation->recordRefundAt(new \DateTimeImmutable('2023-06-22 15:00'));
+
+        $toHookModel = $donation->toHookModel();
+        $this->assertSame(DonationStatus::Refunded, $toHookModel['status']);
+        $this->assertSame('2023-06-22T15:00:00+00:00', $toHookModel['refundedTime']);
+    }
+
+    public function testMarkingRefundTwiceOnSameDonationDoesNotUpdateRefundTime(): void
+    {
+        $donation = $this->getTestDonation();
+
+        $donation->recordRefundAt(new \DateTimeImmutable('2023-06-22 15:00'));
+        $donation->recordRefundAt(new \DateTimeImmutable('2023-06-22 16:00'));
+
+
+        $toHookModel = $donation->toHookModel();
+        $this->assertSame(DonationStatus::Refunded, $toHookModel['status']);
+        $this->assertSame('2023-06-22T15:00:00+00:00', $toHookModel['refundedTime']);
+    }
+
 }

--- a/tests/Domain/DonationTest.php
+++ b/tests/Domain/DonationTest.php
@@ -316,17 +316,28 @@ class DonationTest extends TestCase
         $donation->getStripeMethodProperties(); // Throws in this getter for now.
     }
 
-    public function testDonationDateTimeIsIncludedInSfHookModel(): void
+
+    /**
+     * @psalm-suppress UnusedVariable
+     * @psalm-suppress UnevaluatedCode
+     */
+    public function testDonationRefundDateTimeIsIncludedInSfHookModel(): void
     {
         $donation = $this->getTestDonation();
 
         $donation->recordRefundAt(new \DateTimeImmutable('2023-06-22 15:00'));
 
         $toHookModel = $donation->toHookModel();
+
+        $this->markTestIncomplete("Waiting for changes in Salesforce before we can turn this on, see BG2-2306");
         $this->assertSame(DonationStatus::Refunded, $toHookModel['status']);
         $this->assertSame('2023-06-22T15:00:00+00:00', $toHookModel['refundedTime']);
     }
 
+    /**
+     * @psalm-suppress UnusedVariable
+     * @psalm-suppress UnevaluatedCode
+     */
     public function testMarkingRefundTwiceOnSameDonationDoesNotUpdateRefundTime(): void
     {
         $donation = $this->getTestDonation();
@@ -336,8 +347,9 @@ class DonationTest extends TestCase
 
 
         $toHookModel = $donation->toHookModel();
+
+        $this->markTestIncomplete("Waiting for changes in Salesforce before we can turn this on, see BG2-2306");
         $this->assertSame(DonationStatus::Refunded, $toHookModel['status']);
         $this->assertSame('2023-06-22T15:00:00+00:00', $toHookModel['refundedTime']);
     }
-
 }


### PR DESCRIPTION
Because the salesforce part isn't done yet, (see https://github.com/thebiggive/salesforce/pull/1316) the one line here that does the actual sending of new data to SF is commented out. But the code to pull it from Stripe into Matchbot's DB etc should be fine to start running whenever we want to deploy.