### PR TITLE
Upgrade Psalm to latest release 5.13.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "psalm/plugin-phpunit": "^0.18.4",
         "roave/security-advisories": "dev-latest",
         "squizlabs/php_codesniffer": "^3.6",
-        "vimeo/psalm": "^5.7.4",
+        "vimeo/psalm": "^5.13.0",
         "weirdan/doctrine-psalm-plugin": "^2.8"
     },
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "58227cff0c7357e463cf594106df42f2",
+    "content-hash": "4a5ce9a54d374076e3fd5e12741cc936",
     "packages": [
         {
             "name": "async-aws/core",
@@ -9640,22 +9640,22 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "5.7.4",
+            "version": "5.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "c46eccda769925073b8f65d66c4a3a7dc5d440b1"
+                "reference": "a0a9c27630bcf8301ee78cb06741d2907d8c9fef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/c46eccda769925073b8f65d66c4a3a7dc5d440b1",
-                "reference": "c46eccda769925073b8f65d66c4a3a7dc5d440b1",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/a0a9c27630bcf8301ee78cb06741d2907d8c9fef",
+                "reference": "a0a9c27630bcf8301ee78cb06741d2907d8c9fef",
                 "shasum": ""
             },
             "require": {
                 "amphp/amp": "^2.4.2",
                 "amphp/byte-stream": "^1.5",
-                "composer/package-versions-deprecated": "^1.10.0",
+                "composer-runtime-api": "^2",
                 "composer/semver": "^1.4 || ^2.0 || ^3.0",
                 "composer/xdebug-handler": "^2.0 || ^3.0",
                 "dnoegel/php-xdg-base-dir": "^0.1.1",
@@ -9670,7 +9670,7 @@
                 "felixfbecker/language-server-protocol": "^1.5.2",
                 "fidry/cpu-core-counter": "^0.4.1 || ^0.5.1",
                 "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
-                "nikic/php-parser": "^4.13",
+                "nikic/php-parser": "^4.14",
                 "php": "^7.4 || ~8.0.0 || ~8.1.0 || ~8.2.0",
                 "sebastian/diff": "^4.0 || ^5.0",
                 "spatie/array-to-xml": "^2.17.0 || ^3.0",
@@ -9681,6 +9681,7 @@
                 "psalm/psalm": "self.version"
             },
             "require-dev": {
+                "amphp/phpunit-util": "^2.0",
                 "bamarni/composer-bin-plugin": "^1.4",
                 "brianium/paratest": "^6.9",
                 "ext-curl": "*",
@@ -9739,9 +9740,9 @@
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/5.7.4"
+                "source": "https://github.com/vimeo/psalm/tree/5.13.0"
             },
-            "time": "2023-02-21T06:57:53+00:00"
+            "time": "2023-06-24T17:05:12+00:00"
         },
         {
             "name": "weirdan/doctrine-psalm-plugin",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.7.4@c46eccda769925073b8f65d66c4a3a7dc5d440b1">
+<files psalm-version="5.13.0@a0a9c27630bcf8301ee78cb06741d2907d8c9fef">
   <file src="app/dependencies.php">
     <DeprecatedClass>
       <code><![CDATA[Setup::createAnnotationMetadataConfiguration(
@@ -193,7 +193,6 @@
     </MixedMethodCall>
     <UnusedClosureParam>
       <code>$args</code>
-      <code>$request</code>
       <code>$response</code>
     </UnusedClosureParam>
   </file>
@@ -657,6 +656,7 @@
     </DocblockTypeContradiction>
     <InvalidArgument>
       <code>$paidChargeIds</code>
+      <code>$sourceTransferIds</code>
     </InvalidArgument>
     <InvalidReturnStatement>
       <code>$originalChargeIds</code>
@@ -664,18 +664,6 @@
     <InvalidReturnType>
       <code>string[]</code>
     </InvalidReturnType>
-    <MixedArgumentTypeCoercion>
-      <code>$sourceTransferIds</code>
-    </MixedArgumentTypeCoercion>
-    <MixedAssignment>
-      <code><![CDATA[$chargeListParams['starting_after']]]></code>
-      <code>$lastChargeId</code>
-      <code>$sourceTransferIds[]</code>
-    </MixedAssignment>
-    <PossiblyInvalidPropertyFetch>
-      <code><![CDATA[$charges->data]]></code>
-      <code><![CDATA[$charges->has_more]]></code>
-    </PossiblyInvalidPropertyFetch>
     <PossiblyNullArgument>
       <code><![CDATA[$exception->getStripeCode()]]></code>
     </PossiblyNullArgument>
@@ -976,7 +964,6 @@
       <code>__toString</code>
     </MethodSignatureMustProvideReturnType>
     <MixedArgument>
-      <code><![CDATA[$data['emailAddress']]]></code>
       <code><![CDATA[$data['emailAddress']]]></code>
       <code><![CDATA[$fundingWithdrawal->getAmount()]]></code>
       <code><![CDATA[$fundingWithdrawal->getAmount()]]></code>

--- a/src/Application/Messenger/Handler/StripePayoutHandler.php
+++ b/src/Application/Messenger/Handler/StripePayoutHandler.php
@@ -204,7 +204,6 @@ class StripePayoutHandler implements MessageHandlerInterface
         ];
 
         while ($moreCharges) {
-            /** @var Charge[]|Collection $charges */
             $charges = $this->stripeClient->charges->all(
                 $chargeListParams,
                 ['stripe_account' => $connectAccountId],


### PR DESCRIPTION
Only changes to PHP code are deleting an unecassary and misleading docblock. There's one new issue in the baseline relating to unchanged code where Psalm now detects a possible issue, I think it's not anything we need to worry about though.

For Psalm changes see everything after 5.7.4 and up to and including 5.13.0 at https://github.com/vimeo/psalm/releases