### PR TITLE
DON-706: Allow setting donor name and email on new donations

### DIFF
--- a/src/Application/HttpModels/DonationCreate.php
+++ b/src/Application/HttpModels/DonationCreate.php
@@ -32,9 +32,9 @@ class DonationCreate
         public ?bool $optInTbgEmail = null,
         public ?string $pspCustomerId = null,
         public ?string $tipAmount = '0.00',
-        public ?string $donorFirstName = null,
-        public ?string $donorLastName = null,
-        public ?string $donorEmail = null
+        public ?string $firstName = null,
+        public ?string $lastName = null,
+        public ?string $emailAddress = null
     ) {
     }
 }

--- a/src/Application/HttpModels/DonationCreate.php
+++ b/src/Application/HttpModels/DonationCreate.php
@@ -32,6 +32,9 @@ class DonationCreate
         public ?bool $optInTbgEmail = null,
         public ?string $pspCustomerId = null,
         public ?string $tipAmount = '0.00',
+        public ?string $donorFirstName = null,
+        public ?string $donorLastName = null,
+        public ?string $donorEmail = null
     ) {
     }
 }

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -334,6 +334,9 @@ class Donation extends SalesforceWriteProxy
         $donation->setChampionComms($donationData->optInChampionEmail);
         $donation->setPspCustomerId($donationData->pspCustomerId);
         $donation->setTbgComms($donationData->optInTbgEmail);
+        $donation->setDonorFirstName($donationData->donorFirstName);
+        $donation->setDonorLastName($donationData->donorLastName);
+        $donation->setDonorEmailAddress($donationData->donorEmail);
 
         if (!empty($donationData->countryCode)) {
             $donation->setDonorCountryCode($donationData->countryCode);

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -334,9 +334,9 @@ class Donation extends SalesforceWriteProxy
         $donation->setChampionComms($donationData->optInChampionEmail);
         $donation->setPspCustomerId($donationData->pspCustomerId);
         $donation->setTbgComms($donationData->optInTbgEmail);
-        $donation->setDonorFirstName($donationData->donorFirstName);
-        $donation->setDonorLastName($donationData->donorLastName);
-        $donation->setDonorEmailAddress($donationData->donorEmail);
+        $donation->setDonorFirstName($donationData->firstName);
+        $donation->setDonorLastName($donationData->lastName);
+        $donation->setDonorEmailAddress($donationData->emailAddress);
 
         if (!empty($donationData->countryCode)) {
             $donation->setDonorCountryCode($donationData->countryCode);

--- a/tests/Domain/DonationTest.php
+++ b/tests/Domain/DonationTest.php
@@ -355,19 +355,16 @@ class DonationTest extends TestCase
     }
 
     public function testCreateDonationModelWithDonorFields(): void {
-
-
         $donation = Donation::fromApiModel(new DonationCreate(
-            donorFirstName: 'Test First Name',
-            donorLastName: 'Test Last Name',
-            donorEmail: 'donor@email.test',
+            firstName: 'Test First Name',
+            lastName: 'Test Last Name',
+            emailAddress: 'donor@email.test',
             currencyCode: 'GBP',
             donationAmount: '200000',
             projectId: "any project",
             psp:'stripe',
             paymentMethodType: PaymentMethodType::CustomerBalance
         ), new Campaign());
-
 
         $this->assertSame('Test First Name', $donation->getDonorFirstName(true));
         $this->assertSame('Test Last Name', $donation->getDonorLastName(true));

--- a/tests/Domain/DonationTest.php
+++ b/tests/Domain/DonationTest.php
@@ -353,4 +353,24 @@ class DonationTest extends TestCase
         $this->assertSame(DonationStatus::Refunded, $toHookModel['status']);
         $this->assertSame('2023-06-22T15:00:00+00:00', $toHookModel['refundedTime']);
     }
+
+    public function testCreateDonationModelWithDonorFields(): void {
+
+
+        $donation = Donation::fromApiModel(new DonationCreate(
+            donorFirstName: 'Test First Name',
+            donorLastName: 'Test Last Name',
+            donorEmail: 'donor@email.test',
+            currencyCode: 'GBP',
+            donationAmount: '200000',
+            projectId: "any project",
+            psp:'stripe',
+            paymentMethodType: PaymentMethodType::CustomerBalance
+        ), new Campaign());
+
+
+        $this->assertSame('Test First Name', $donation->getDonorFirstName(true));
+        $this->assertSame('Test Last Name', $donation->getDonorLastName(true));
+        $this->assertSame('donor@email.test', $donation->getDonorEmailAddress());
+    }
 }


### PR DESCRIPTION
Currently the donation has to be created without these details and then they can be added later in a PUT request.