### PR TITLE
MAT-316: Prevent donations with negative tip

### DIFF
--- a/integrationTests/CreateDonationTest.php
+++ b/integrationTests/CreateDonationTest.php
@@ -14,12 +14,9 @@ class CreateDonationTest extends IntegrationTest
 {
     use \Prophecy\PhpUnit\ProphecyTrait;
 
-    public function testItCreatesADonation(): void
+    public function setUp(): void
     {
-        // This test should be using fake stripe and salesforce clients, but things within our app,
-        // from the HTTP router to the DB is using our real prod code.
-
-        // arrange
+        parent::setUp();
         $this->addCampaignAndCharityToDB($this->randomString());
 
         /** @var \DI\Container $container */
@@ -33,6 +30,12 @@ class CreateDonationTest extends IntegrationTest
         $donationRepo = $container->get(DonationRepository::class);
         assert($donationRepo instanceof DonationRepository);
         $donationRepo->setClient($donationClientProphecy->reveal());
+    }
+
+    public function testItCreatesADonation(): void
+    {
+        // This test should be using fake stripe and salesforce clients, but things within our app,
+        // from the HTTP router to the DB is using our real prod code.
 
         // act
         $response = $this->createDonation();
@@ -52,4 +55,16 @@ class CreateDonationTest extends IntegrationTest
         assert(is_array($donationFetchedFromDB));
         $this->assertSame('100.00', $donationFetchedFromDB['amount']);
     }
+
+    public function testCannotCreateDonationWithNegativeTip(): void
+    {
+        // This test should be using fake stripe and salesforce clients, but things within our app,
+        // from the HTTP router to the DB is using our real prod code.
+
+        // act
+        $response = $this->createDonation(tipAmount: -1);
+
+        $this->assertSame(400, $response->getStatusCode());
+    }
+
 }

--- a/integrationTests/IntegrationTest.php
+++ b/integrationTests/IntegrationTest.php
@@ -168,7 +168,7 @@ abstract class IntegrationTest extends TestCase
         return $fakeStripeClient;
     }
 
-    protected function createDonation(): \Psr\Http\Message\ResponseInterface
+    protected function createDonation(int $tipAmount = 0): \Psr\Http\Message\ResponseInterface
     {
         $campaignId = $this->randomString();
         $paymentIntentId = $this->randomString();
@@ -180,7 +180,6 @@ abstract class IntegrationTest extends TestCase
         $stripePaymentIntentsProphecy = $this->setUpFakeStripeClient();
 
         $stripePaymentIntentsProphecy->create(Argument::type('array'))
-            ->shouldBeCalled()
             ->willReturn($stripePaymentIntent);
 
         /** @var \DI\Container $container */
@@ -207,7 +206,8 @@ abstract class IntegrationTest extends TestCase
                     "currencyCode": "GBP",
                     "donationAmount": "100",
                     "projectId": "$campaignId",
-                    "psp": "stripe"
+                    "psp": "stripe",
+                    "tipAmount": $tipAmount
                 }
             EOF,
                 serverParams: ['REMOTE_ADDR' => '127.0.0.1']

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -887,6 +887,10 @@ class Donation extends SalesforceWriteProxy
             ));
         }
 
+        if (bccomp($tipAmount, '0', 2) === -1) {
+            throw new \UnexpectedValueException('Tip amount must not be negative');
+        }
+
         $this->tipAmount = $tipAmount;
     }
 

--- a/tests/Domain/DonationTest.php
+++ b/tests/Domain/DonationTest.php
@@ -12,6 +12,7 @@ use MatchBot\Domain\FundingWithdrawal;
 use MatchBot\Domain\PaymentMethodType;
 use MatchBot\Tests\Application\DonationTestDataTrait;
 use MatchBot\Tests\TestCase;
+use UnexpectedValueException;
 
 class DonationTest extends TestCase
 {
@@ -389,5 +390,19 @@ class DonationTest extends TestCase
 
         $this->expectExceptionMessage('Cannot cancel Paid donation');
         $donation->cancel();
+    }
+
+    public function testCannotCreateDonationWithNegativeTip(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+
+        Donation::fromApiModel(new DonationCreate(
+            currencyCode: 'GBP',
+            donationAmount: '10',
+            projectId: 'project-id',
+            psp: 'stripe',
+            tipAmount: '-0.01'
+        ), new Campaign());
+
     }
 }


### PR DESCRIPTION
We've never seen a donation with a negative tip, and the front end doesn't allow it, but best to block it just in case anyone tries or somehow creates one by mistake.