### PR TITLE
DON-893: Allow confirming payment methods on server side from matchbot

### DIFF
--- a/app/routes.php
+++ b/app/routes.php
@@ -43,10 +43,9 @@ return function (App $app) {
             ->add(DonationPublicAuthMiddleware::class);
 
         $versionGroup->post('/donations/{donationId:[a-z0-9-]{36}}/confirm', Donations\Confirm::class)
-            // todo - add needed middlewares. Not in right now as interferes with testing.
-//            ->add(DonationRecaptchaMiddleware::class) // Runs last
-//            ->add($ipMiddleware)
-//            ->add(RateLimitMiddleware::class)
+            ->add(DonationRecaptchaMiddleware::class) // Runs last
+            ->add($ipMiddleware)
+            ->add(RateLimitMiddleware::class)
         ;
 
         $versionGroup->post('/people/{personId:[a-z0-9-]{36}}/donations', Donations\Create::class)

--- a/app/routes.php
+++ b/app/routes.php
@@ -43,7 +43,7 @@ return function (App $app) {
             ->add(DonationPublicAuthMiddleware::class);
 
         $versionGroup->post('/donations/{donationId:[a-z0-9-]{36}}/confirm', Donations\Confirm::class)
-            ->add(DonationPublicAuthMiddleware::class);;
+            ->add(DonationPublicAuthMiddleware::class);
 
         $versionGroup->post('/people/{personId:[a-z0-9-]{36}}/donations', Donations\Create::class)
             ->add(PersonManagementAuthMiddleware::class)

--- a/app/routes.php
+++ b/app/routes.php
@@ -42,6 +42,13 @@ return function (App $app) {
         })
             ->add(DonationPublicAuthMiddleware::class);
 
+        $versionGroup->post('/donations/{donationId:[a-z0-9-]{36}}/confirm', Donations\Confirm::class)
+            // todo - add needed middlewares. Not in right now as interferes with testing.
+//            ->add(DonationRecaptchaMiddleware::class) // Runs last
+//            ->add($ipMiddleware)
+//            ->add(RateLimitMiddleware::class)
+        ;
+
         $versionGroup->post('/people/{personId:[a-z0-9-]{36}}/donations', Donations\Create::class)
             ->add(PersonManagementAuthMiddleware::class)
             ->add($ipMiddleware)

--- a/app/routes.php
+++ b/app/routes.php
@@ -43,10 +43,7 @@ return function (App $app) {
             ->add(DonationPublicAuthMiddleware::class);
 
         $versionGroup->post('/donations/{donationId:[a-z0-9-]{36}}/confirm', Donations\Confirm::class)
-            ->add(DonationRecaptchaMiddleware::class) // Runs last
-            ->add($ipMiddleware)
-            ->add(RateLimitMiddleware::class)
-        ;
+            ->add(DonationPublicAuthMiddleware::class);;
 
         $versionGroup->post('/people/{personId:[a-z0-9-]{36}}/donations', Donations\Create::class)
             ->add(PersonManagementAuthMiddleware::class)

--- a/app/routes.php
+++ b/app/routes.php
@@ -39,10 +39,8 @@ return function (App $app) {
         $versionGroup->group('/donations/{donationId:[a-z0-9-]{36}}', function (RouteCollectorProxy $group) {
             $group->get('', Donations\Get::class);
             $group->put('', Donations\Update::class); // Includes cancelling.
+            $group->post('/confirm', Donations\Confirm::class);
         })
-            ->add(DonationPublicAuthMiddleware::class);
-
-        $versionGroup->post('/donations/{donationId:[a-z0-9-]{36}}/confirm', Donations\Confirm::class)
             ->add(DonationPublicAuthMiddleware::class);
 
         $versionGroup->post('/people/{personId:[a-z0-9-]{36}}/donations', Donations\Create::class)

--- a/psalm.xml
+++ b/psalm.xml
@@ -6,7 +6,7 @@
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
     errorBaseline="psalm-baseline.xml"
-    findUnusedBaselineEntry="true"
+    findUnusedBaselineEntry="false"
     findUnusedCode="true"
 >
     <projectFiles>

--- a/src/Application/Actions/Donations/Confirm.php
+++ b/src/Application/Actions/Donations/Confirm.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace MatchBot\Application\Actions\Donations;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Laminas\Diactoros\Response\JsonResponse;
+use MatchBot\Application\Actions\Action;
+use MatchBot\Client\NotFoundException;
+use MatchBot\Domain\DonationRepository;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Log\LoggerInterface;
+use Stripe\StripeClient;
+
+class Confirm extends Action
+{
+    public function __construct(
+        LoggerInterface $logger,
+        private DonationRepository $donationRepository,
+        private StripeClient $stripeClient,
+        private EntityManagerInterface $entityManager,
+    ) {
+        parent::__construct($logger);
+    }
+
+    /**
+     * Called to confirm that the donor wishes to make a donation immediately. We will tell Stripe to take their money
+     * using the payment method provided.
+     */
+    protected function action(Request $request, Response $response, array $args): Response
+    {
+        // todo - harden code - make sure we bail out early if any needed data is missing or doesn't make sense.
+
+        // todo - add tests. Might have done test-first, but was copying JS code from
+        // https://stripe.com/docs/payments/finalize-payments-on-the-server?platform=web&type=payment and translating to PHP.
+
+        $requestBody = json_decode(json: $request->getBody(), associative: true, flags: JSON_THROW_ON_ERROR);
+
+        $pamentMethodId = $requestBody['stripePaymentMethodId'];
+
+        $this->entityManager->beginTransaction();
+
+        $donation = $this->donationRepository->findAndLockOneBy(['uuid' => $args['donationId']]);
+        if (! $donation) {
+            throw new NotFoundException();
+        }
+
+        $paymentIntent = $this->stripeClient->paymentIntents->retrieve($donation->getTransactionId());
+        $paymentMethod = $this->stripeClient->paymentMethods->retrieve($pamentMethodId);
+
+        // todo - use paymentMethod object to get card type and country, derive fees on donation and apply those fees
+        // before or when confirming the payment.
+
+        $paymentIntent->confirm([
+            'payment_method' => $paymentMethod->id,
+        ]);
+
+        $this->logger->info("Confirmed donation " . $donation->getUuid() . " using payment method id " . $paymentMethod->id);
+
+        return new JsonResponse([]);
+    }
+}

--- a/src/Application/Actions/Donations/Confirm.php
+++ b/src/Application/Actions/Donations/Confirm.php
@@ -55,7 +55,10 @@ class Confirm extends Action
         // before or when confirming the payment.
 
         // documented at https://stripe.com/docs/api/payment_methods/object?lang=php
+        // Contrary to what Stripes docblock says, in my testing 'brand' is strings like 'visa' or 'amex'. Not 'Visa' or 'American Express'
         $cardBrand = $paymentMethod->card->brand;
+
+        // two letter upper string, e.g. 'GB', 'US'.
         $cardCountry = $paymentMethod->card->country;
 
         // at present if the following line was left out we would charge a wrong fee in some cases. I'm not happy with
@@ -82,6 +85,8 @@ class Confirm extends Action
         ]);
 
         $updatedIntent = $this->stripeClient->paymentIntents->retrieve($donation->getTransactionId());
+        var_dump($paymentMethod->toArray());
+        $this->logger->info($paymentMethod->card->brand);
 
         $this->entityManager->flush();
 

--- a/src/Application/Actions/Donations/Confirm.php
+++ b/src/Application/Actions/Donations/Confirm.php
@@ -34,9 +34,11 @@ class Confirm extends Action
         // todo - add tests. Might have done test-first, but was copying JS code from
         // https://stripe.com/docs/payments/finalize-payments-on-the-server?platform=web&type=payment and translating to PHP.
 
-        $requestBody = json_decode(json: $request->getBody(), associative: true, flags: JSON_THROW_ON_ERROR);
+        $requestBody = json_decode(json: $request->getBody()->getContents(), associative: true, flags: JSON_THROW_ON_ERROR);
+        \assert(is_array($requestBody));
 
         $pamentMethodId = $requestBody['stripePaymentMethodId'];
+        \assert((is_string($pamentMethodId)));
 
         $this->entityManager->beginTransaction();
 

--- a/src/Application/Actions/Donations/Confirm.php
+++ b/src/Application/Actions/Donations/Confirm.php
@@ -33,13 +33,10 @@ class Confirm extends Action
      */
     protected function action(Request $request, Response $response, array $args): Response
     {
-        // todo - harden code - make sure we bail out early if any needed data is missing or doesn't make sense.
-
-        // todo - add tests. Might have done test-first, but was copying JS code from
-        // https://stripe.com/docs/payments/finalize-payments-on-the-server?platform=web&type=payment and translating to PHP.
-
         try {
-            $requestBody = json_decode(json: $request->getBody()->getContents(), associative: true, flags: JSON_THROW_ON_ERROR);
+            $requestBody = json_decode(
+                $request->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR
+            );
         } catch (\JsonException) {
             throw new HttpBadRequestException($request, 'Cannot parse request body as JSON');
         }
@@ -63,7 +60,8 @@ class Confirm extends Action
         }
 
         // documented at https://stripe.com/docs/api/payment_methods/object?lang=php
-        // Contrary to what Stripes docblock says, in my testing 'brand' is strings like 'visa' or 'amex'. Not 'Visa' or 'American Express'
+        // Contrary to what Stripes docblock says, in my testing 'brand' is strings like 'visa' or 'amex'. Not 'Visa' or
+        // 'American Express'
         $cardBrand = $paymentMethod->card->brand;
         \assert(is_string($cardBrand));
 
@@ -84,8 +82,8 @@ class Confirm extends Action
                 'stripeFeeRechargeVat' => $donation->getCharityFeeVat(),
             ],
             // See https://stripe.com/docs/connect/destination-charges#application-fee
-            // Update the fee amount incase the final charge was from
-            // a Non EU / Amex card where fees are varied.
+            // Update the fee amount in case the final charge was from
+            // e.g. a Non EU / Amex card where fees are varied.
             'application_fee_amount' => $donation->getAmountToDeductFractional(),
             // Note that `on_behalf_of` is set up on create and is *not allowed* on update.
         ]);

--- a/src/Application/Actions/Donations/Confirm.php
+++ b/src/Application/Actions/Donations/Confirm.php
@@ -99,7 +99,7 @@ class Confirm extends Action
         return new JsonResponse([
                 'paymentIntent' => [
                     'status' => $updatedIntent->status,
-                    'next_action' => $updatedIntent->next_action
+                    'client_secret' => $updatedIntent->client_secret
                 ]]
         );
     }

--- a/src/Application/Fees/Calculator.php
+++ b/src/Application/Fees/Calculator.php
@@ -6,10 +6,13 @@ namespace MatchBot\Application\Fees;
 
 use JetBrains\PhpStorm\Pure;
 
+/**
+ * @psalm-immutable
+ */
 class Calculator
 {
     /** @var string[]   EU + GB ISO 3166-1 alpha-2 country codes */
-    private array $euISOs = [
+    private const EU_COUNTRY_CODES = [
         'AT', 'BE', 'BG', 'CY', 'CZ', 'DK', 'EE',
         'FI', 'FR', 'DE', 'GR', 'HU', 'IE', 'IT',
         'LV', 'LT', 'LU', 'MT', 'NL', 'NO', 'PL',
@@ -17,17 +20,17 @@ class Calculator
         'CH', 'GB',
     ];
 
-    private array $pspFeeSettings;
+    readonly private array $pspFeeSettings;
 
     public function __construct(
         array $settings,
         string $psp,
-        private ?string $cardBrand,
-        private ?string $cardCountry,
-        private string $amount,
-        private string $currencyCode,
-        private bool $hasGiftAid, // Whether donation has Gift Aid *and* a fee is to be charged to claim it.
-        private ?float $feePercentageOverride = null,
+        readonly private ?string $cardBrand,
+        readonly private ?string $cardCountry,
+        readonly private string $amount,
+        readonly private string $currencyCode,
+        readonly private bool $hasGiftAid, // Whether donation has Gift Aid *and* a fee is to be charged to claim it.
+        readonly private ?float $feePercentageOverride = null,
     ) {
         $this->pspFeeSettings = $settings[$psp]['fee'];
     }
@@ -158,6 +161,6 @@ class Calculator
             return true;
         }
 
-        return in_array($cardCountry, $this->euISOs, true);
+        return in_array($cardCountry, self::EU_COUNTRY_CODES, true);
     }
 }

--- a/src/Application/Fees/Calculator.php
+++ b/src/Application/Fees/Calculator.php
@@ -20,6 +20,13 @@ class Calculator
         'CH', 'GB',
     ];
 
+    /**
+     * From https://stripe.com/docs/api/errors#errors-payment_method-card-brand
+     */
+    private const STRIPE_CARD_BRANDS = [
+        'amex', 'diners', 'discover', 'eftpos_au', 'jcb', 'mastercard', 'unionpay', 'visa', 'unknown'
+    ];
+
     readonly private array $pspFeeSettings;
 
     public function __construct(
@@ -33,6 +40,9 @@ class Calculator
         readonly private ?float $feePercentageOverride = null,
     ) {
         $this->pspFeeSettings = $settings[$psp]['fee'];
+        if (! in_array($this->cardBrand, [...self::STRIPE_CARD_BRANDS, null], true)) {
+            throw new \UnexpectedValueException('Unexpected card brand, expected brands are ' . implode(', ', self::STRIPE_CARD_BRANDS));
+        }
     }
 
     public function getCoreFee(): string

--- a/tests/Application/Actions/Donations/ConfirmTest.php
+++ b/tests/Application/Actions/Donations/ConfirmTest.php
@@ -37,7 +37,7 @@ class ConfirmTest extends TestCase
             paymentMethodId: 'PAYMENT_METHOD_ID',
             updatedIntentData: [
             'status' => 'final_intent_status',
-            'next_action' => 'some_next_action',
+            'client_secret' => 'some_client_secret',
             ],
             paymentIntentId: 'PAYMENT_INTENT_ID',
             expectedMetadataUpdate: [
@@ -92,7 +92,7 @@ class ConfirmTest extends TestCase
 
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame(
-            ['paymentIntent' => ['status' => 'final_intent_status', 'next_action' => 'some_next_action']],
+            ['paymentIntent' => ['status' => 'final_intent_status', 'client_secret' => 'some_client_secret']],
             \json_decode($response->getBody()->getContents(), true)
         );
     }

--- a/tests/Application/Actions/Donations/ConfirmTest.php
+++ b/tests/Application/Actions/Donations/ConfirmTest.php
@@ -26,6 +26,12 @@ class ConfirmTest extends TestCase
     public function test_it_confirms_a_card_donation(): void
     {
         // arrange
+
+        // in reality the fee would be calculated according to details of the card etc. The Calculator class is
+        //tested separately. This is just a dummy value.
+        $newCharityFee = "42.00";
+        $newApplicationFeeAmount = 4200;
+
         $stripeClientProphecy = $this->fakeStripeClient(
             cardDetails: ['brand' => 'acme-payment-cards', 'country' => 'some-country'],
             paymentMethodId: 'PAYMENT_METHOD_ID',
@@ -36,11 +42,11 @@ class ConfirmTest extends TestCase
             paymentIntentId: 'PAYMENT_INTENT_ID',
             expectedMetadataUpdate: [
             "metadata" => [
-                "stripeFeeRechargeGross" => "42.00",
-                "stripeFeeRechargeNet" => "42.00",
-                "stripeFeeRechargeVat" => "0.00"
+                "stripeFeeRechargeGross" => $newCharityFee,
+                "stripeFeeRechargeNet" => $newCharityFee,
+                "stripeFeeRechargeVat" => "0.00",
             ],
-            "application_fee_amount" => 4200
+            "application_fee_amount" => $newApplicationFeeAmount,
             ]
         );
 
@@ -54,9 +60,7 @@ class ConfirmTest extends TestCase
 
         $donationRepositoryProphecy->deriveFees($donation, 'acme-payment-cards', 'some-country')
             ->will(
-                // in reality the fee would be calculated according to details of the card etc. The Calculator class is
-                //tested separately. 42 is just a stub value.
-                fn() => $donation->setCharityFee('42.00')
+                fn() => $donation->setCharityFee($newCharityFee)
             );
 
         $donationRepositoryProphecy->findAndLockOneBy(['uuid' => 'DONATION_ID'])->willReturn(

--- a/tests/Application/Actions/Donations/ConfirmTest.php
+++ b/tests/Application/Actions/Donations/ConfirmTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Tests\Application\Actions\Donations;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Laminas\Diactoros\ServerRequest;
+use MatchBot\Application\Actions\Donations\Confirm;
+use MatchBot\Application\HttpModels\DonationCreate;
+use MatchBot\Domain\Campaign;
+use MatchBot\Domain\Donation;
+use MatchBot\Domain\DonationRepository;
+use MatchBot\Tests\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Log\NullLogger;
+use Slim\Psr7\Response;
+use Stripe\PaymentIntent;
+use Stripe\PaymentMethod;
+use Stripe\Service\PaymentIntentService;
+use Stripe\Service\PaymentMethodService;
+use Stripe\StripeClient;
+
+class ConfirmTest extends TestCase
+{
+    public function test_it_confirms_a_card_donation(): void
+    {
+        // arrange
+        $stripeClientProphecy = $this->fakeStripeClient(
+            cardDetails: ['brand' => 'acme-payment-cards', 'country' => 'some-country'],
+            paymentMethodId: 'PAYMENT_METHOD_ID',
+            updatedIntentData: [
+            'status' => 'final_intent_status',
+            'next_action' => 'some_next_action',
+            ],
+            paymentIntentId: 'PAYMENT_INTENT_ID',
+            expectedMetadataUpdate: [
+            "metadata" => [
+                "stripeFeeRechargeGross" => "42.00",
+                "stripeFeeRechargeNet" => "42.00",
+                "stripeFeeRechargeVat" => "0.00"
+            ],
+            "application_fee_amount" => 4200
+            ]
+        );
+
+        $donationRepositoryProphecy = $this->prophesize(DonationRepository::class);
+
+        $donation = Donation::fromApiModel(
+            new DonationCreate(currencyCode: 'GBP', donationAmount: '63.0', projectId: 'doesnt-matter', psp: 'stripe'),
+            new Campaign()
+        );
+        $donation->setTransactionId('PAYMENT_INTENT_ID');
+
+        $donationRepositoryProphecy->deriveFees($donation, 'acme-payment-cards', 'some-country')
+            ->will(
+                // in reality the fee would be calculated according to details of the card etc. The Calculator class is
+                //tested separately. 42 is just a stub value.
+                fn() => $donation->setCharityFee('42.00')
+            );
+
+        $donationRepositoryProphecy->findAndLockOneBy(['uuid' => 'DONATION_ID'])->willReturn(
+            $donation
+        );
+
+        $sut = new Confirm(
+            new NullLogger(),
+            $donationRepositoryProphecy->reveal(),
+            $stripeClientProphecy->reveal(),
+            $this->prophesize(EntityManagerInterface::class)->reveal()
+        );
+
+        // act
+
+        $response = $sut(
+            $this->createRequest(
+                method: 'POST',
+                path: 'doesnt-matter-for-test',
+                bodyString: \json_encode([
+                    'stripePaymentMethodId' => 'PAYMENT_METHOD_ID',
+                ])
+            ),
+            new Response(),
+            ['donationId' => 'DONATION_ID']
+        );
+
+        // assert
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(
+            ['paymentIntent' => ['status' => 'final_intent_status', 'next_action' => 'some_next_action']],
+            \json_decode($response->getBody()->getContents(), true)
+        );
+    }
+
+    /**
+     * @return ObjectProphecy<StripeClient>
+     */
+    public function fakeStripeClient(
+        array $cardDetails,
+        string $paymentMethodId,
+        array $updatedIntentData,
+        string $paymentIntentId,
+        array $expectedMetadataUpdate
+    ): ObjectProphecy {
+        $paymentMethod = (object)[
+            'type' => 'card',
+            'card' => (object)$cardDetails,
+        ];
+        $stripePaymentMethodsProphecy = $this->prophesize(PaymentMethodService::class);
+        $stripePaymentMethodsProphecy->retrieve($paymentMethodId)
+            ->willReturn($paymentMethod);
+
+        $stripePaymentIntentsProphecy = $this->prophesize(PaymentIntentService::class);
+
+        $stripeClientProphecy = $this->prophesize(StripeClient::class);
+        $stripeClientProphecy->paymentMethods = $stripePaymentMethodsProphecy;
+        $stripeClientProphecy->paymentIntents = $stripePaymentIntentsProphecy;
+
+        $stripePaymentIntentsProphecy->retrieve($paymentIntentId)
+            ->willReturn((object)$updatedIntentData);
+
+        $stripePaymentIntentsProphecy->update(
+            $paymentIntentId,
+            $expectedMetadataUpdate
+        )->shouldBeCalled();
+
+        $stripePaymentIntentsProphecy->confirm($paymentIntentId, ["payment_method" => $paymentMethodId])
+            ->shouldBeCalled();
+
+        return $stripeClientProphecy;
+    }
+}

--- a/tests/Application/Fees/CalculatorTest.php
+++ b/tests/Application/Fees/CalculatorTest.php
@@ -12,14 +12,30 @@ class CalculatorTest extends TestCase
 {
     use VatTrait;
 
+    /**
+     * At time of writing this matches the settings in app/settings.php . Copied here to make the test self-contained
+     * and to make it clear which settings are relevant to the calculator and to these tests.
+     */
+    private const SETTINGS_WITHOUT_VAT = [
+        'stripe' => [
+            'fee' => [
+                'fixed' => [
+                    'SEK' => '1.8',
+                    // ... other currencies, EUR, USD etc etc. Not tested here.
+                    'FICTIONAL_CURRENCY_FEE_IGNORED' => '42',
+                    'default' => '0.2'
+                ],
+                'main_percentage_standard' => '1.5',
+                'main_percentage_amex_or_non_uk_eu' => '3.2',
+                'gift_aid_percentage' => '0.75', // 3% of Gift Aid amount.
+            ]
+        ],
+    ];
+
     public function testStripeUKCardGBPDonation(): void
     {
-        $settingsWithVAT = $this->getUKLikeVATSettings(
-            $this->getAppInstance()->getContainer()->get('settings')
-        );
-
         $calculator = new Calculator(
-            $settingsWithVAT,
+            $this->settingsWithVAT(),
             'stripe',
             'visa',
             'GB',
@@ -35,12 +51,8 @@ class CalculatorTest extends TestCase
 
     public function testStripeUKCardGBPDonationWithFeeCover(): void
     {
-        $settingsWithVAT = $this->getUKLikeVATSettings(
-            $this->getAppInstance()->getContainer()->get('settings')
-        );
-
         $calculator = new Calculator(
-            $settingsWithVAT,
+            $this->settingsWithVAT(),
             'stripe',
             'visa',
             'GB',
@@ -58,7 +70,7 @@ class CalculatorTest extends TestCase
     public function testStripeUSCardGBPDonation(): void
     {
         $calculator = new Calculator(
-            $this->getAppInstance()->getContainer()->get('settings'),
+            self::SETTINGS_WITHOUT_VAT,
             'stripe',
             'visa',
             'US',
@@ -74,7 +86,7 @@ class CalculatorTest extends TestCase
     public function testStripeUSCardGBPDonationWithTbgClaimingGiftAid(): void
     {
         $calculator = new Calculator(
-            $this->getAppInstance()->getContainer()->get('settings'),
+            self::SETTINGS_WITHOUT_VAT,
             'stripe',
             'visa',
             'US',
@@ -90,7 +102,7 @@ class CalculatorTest extends TestCase
     public function testStripeUKCardSEKDonation(): void
     {
         $calculator = new Calculator(
-            $this->getAppInstance()->getContainer()->get('settings'),
+            self::SETTINGS_WITHOUT_VAT,
             'stripe',
             'visa',
             'GB',
@@ -106,7 +118,7 @@ class CalculatorTest extends TestCase
     public function testStripeUSCardSEKDonation(): void
     {
         $calculator = new Calculator(
-            $this->getAppInstance()->getContainer()->get('settings'),
+            self::SETTINGS_WITHOUT_VAT,
             'stripe',
             'visa',
             'US',
@@ -124,12 +136,8 @@ class CalculatorTest extends TestCase
      */
     public function testStripeUSCardUSDDonation(): void
     {
-        $settingsWithVAT = $this->getUKLikeVATSettings(
-            $this->getAppInstance()->getContainer()->get('settings')
-        );
-
         $calculator = new Calculator(
-            $settingsWithVAT,
+            $this->settingsWithVAT(),
             'stripe',
             'visa',
             'US',
@@ -145,12 +153,8 @@ class CalculatorTest extends TestCase
 
     public function testStripeUSCardUSDDonationWithFeeCover(): void
     {
-        $settingsWithVAT = $this->getUKLikeVATSettings(
-            $this->getAppInstance()->getContainer()->get('settings')
-        );
-
         $calculator = new Calculator(
-            $settingsWithVAT,
+            $this->settingsWithVAT(),
             'stripe',
             'visa',
             'US',
@@ -166,5 +170,12 @@ class CalculatorTest extends TestCase
         // would be $105.
         $this->assertEquals('5.00', $calculator->getCoreFee());
         $this->assertEquals('0.00', $calculator->getFeeVat());
+    }
+
+    public function settingsWithVAT(): array
+    {
+        return $this->getUKLikeVATSettings(
+            self::SETTINGS_WITHOUT_VAT
+        );
     }
 }


### PR DESCRIPTION
Introduces a new route at `/donations/{donationId:[a-z0-9-]{36}}/confirm`. Frontend should post to this to indicate when a donor is ready to pay, at which point matchbot will pass the message on to Stripe.