### PR TITLE
MAT-317: Remove Donation.clientSecret property

### DIFF
--- a/integrationTests/DonationPersistenceTest.php
+++ b/integrationTests/DonationPersistenceTest.php
@@ -77,7 +77,6 @@ class DonationPersistenceTest extends IntegrationTest
             'salesforceId' => NULL,
             'tipAmount' => '0.00',
             'psp' => 'stripe',
-            'clientSecret' => NULL,
             'donorHomeAddressLine1' => NULL,
             'donorHomePostcode' => NULL,
             'tipGiftAid' => NULL,

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2,6 +2,12 @@
 <files psalm-version="5.14.0@b2942cefed8443002bd3f245c4cd0a54193716d8">
   <file src="app/dependencies.php">
     <DeprecatedClass>
+      <code><![CDATA[Setup::createAnnotationMetadataConfiguration(
+                $settings['doctrine']['metadata_dirs'],
+                $settings['doctrine']['dev_mode'],
+                $settings['doctrine']['cache_dir'] . '/proxies',
+                $cache
+            )]]></code>
       <code>new ArrayCache()</code>
       <code>new RedisCache()</code>
     </DeprecatedClass>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2,12 +2,6 @@
 <files psalm-version="5.14.0@b2942cefed8443002bd3f245c4cd0a54193716d8">
   <file src="app/dependencies.php">
     <DeprecatedClass>
-      <code><![CDATA[Setup::createAnnotationMetadataConfiguration(
-                $settings['doctrine']['metadata_dirs'],
-                $settings['doctrine']['dev_mode'],
-                $settings['doctrine']['cache_dir'] . '/proxies',
-                $cache
-            )]]></code>
       <code>new ArrayCache()</code>
       <code>new RedisCache()</code>
     </DeprecatedClass>
@@ -229,7 +223,6 @@
     <PossiblyNullArgument>
       <code><![CDATA[$donation->getCampaign()->getCharity()->getSalesforceId()]]></code>
       <code><![CDATA[$donation->getPspCustomerId()]]></code>
-      <code><![CDATA[$intent->client_secret]]></code>
     </PossiblyNullArgument>
   </file>
   <file src="src/Application/Actions/Donations/Get.php">
@@ -1810,28 +1803,6 @@
       <code>Donation::emptyTestDonation($amount, $paymentMethodType)</code>
       <code><![CDATA[Donation::emptyTestDonation('124.56')]]></code>
     </DeprecatedMethod>
-  </file>
-  <file src="tests/Application/Fees/CalculatorTest.php">
-    <MixedArgument>
-      <code><![CDATA[$this->getAppInstance()->getContainer()->get('settings')]]></code>
-      <code><![CDATA[$this->getAppInstance()->getContainer()->get('settings')]]></code>
-      <code><![CDATA[$this->getAppInstance()->getContainer()->get('settings')]]></code>
-      <code><![CDATA[$this->getAppInstance()->getContainer()->get('settings')]]></code>
-      <code><![CDATA[$this->getAppInstance()->getContainer()->get('settings')]]></code>
-      <code><![CDATA[$this->getAppInstance()->getContainer()->get('settings')]]></code>
-      <code><![CDATA[$this->getAppInstance()->getContainer()->get('settings')]]></code>
-      <code><![CDATA[$this->getAppInstance()->getContainer()->get('settings')]]></code>
-    </MixedArgument>
-    <PossiblyNullReference>
-      <code>get</code>
-      <code>get</code>
-      <code>get</code>
-      <code>get</code>
-      <code>get</code>
-      <code>get</code>
-      <code>get</code>
-      <code>get</code>
-    </PossiblyNullReference>
   </file>
   <file src="tests/Application/Messenger/Handler/GiftAidResultHandlerTest.php">
     <MixedArgument>

--- a/src/Application/Actions/Donations/Create.php
+++ b/src/Application/Actions/Donations/Create.php
@@ -217,7 +217,6 @@ class Create extends Action
                 return $this->respond($response, new ActionPayload(500, null, $error));
             }
 
-            $donation->setClientSecret($intent->client_secret);
             $donation->setTransactionId($intent->id);
 
             $this->entityManager->persist($donation);

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -68,12 +68,6 @@ class Donation extends SalesforceWriteProxy
     protected ?DateTime $collectedAt = null;
 
     /**
-     * @ORM\Column(type="string", nullable=true)
-     * @var string  Token for the client to complete payment, set by PSPs like Stripe for Payment Intents.
-     */
-    protected ?string $clientSecret = null;
-
-    /**
      * @ORM\Column(type="string", unique=true, nullable=true)
      * @var string|null PSP's transaction ID assigned on their processing.
      *
@@ -411,7 +405,6 @@ class Donation extends SalesforceWriteProxy
         $data['refundedTime'] = $this->refundedAt?->format(DateTimeInterface::ATOM);
 
         unset(
-            $data['clientSecret'],
             $data['charityName'],
             $data['donationId'],
             $data['matchReservedAmount'],
@@ -427,7 +420,6 @@ class Donation extends SalesforceWriteProxy
     {
         $data = [
             'billingPostalAddress' => $this->getDonorBillingAddress(),
-            'clientSecret' => $this->getClientSecret(),
             'charityFee' => (float) $this->getCharityFee(),
             'charityFeeVat' => (float) $this->getCharityFeeVat(),
             'charityId' => $this->getCampaign()->getCharity()->getSalesforceId(),
@@ -823,22 +815,6 @@ class Donation extends SalesforceWriteProxy
         }
 
         $this->psp = $psp;
-    }
-
-    /**
-     * @return string
-     */
-    public function getClientSecret(): ?string
-    {
-        return $this->clientSecret;
-    }
-
-    /**
-     * @param string $clientSecret
-     */
-    public function setClientSecret(string $clientSecret): void
-    {
-        $this->clientSecret = $clientSecret;
     }
 
     /**

--- a/src/Migrations/Version20230925121435.php
+++ b/src/Migrations/Version20230925121435.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20230925121435 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Remove Donation.clientSecret property';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE Donation DROP clientSecret');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE Donation ADD clientSecret VARCHAR(255) DEFAULT NULL');
+    }
+}

--- a/tests/Application/Actions/Donations/CreateTest.php
+++ b/tests/Application/Actions/Donations/CreateTest.php
@@ -387,7 +387,6 @@ class CreateTest extends TestCase
         $this->assertEquals('Pending', $payloadArray['donation']['status']);
         $this->assertEquals('stripe', $payloadArray['donation']['psp']);
         $this->assertEquals('pi_dummyIntent456_id', $payloadArray['donation']['transactionId']);
-        $this->assertEquals('pi_dummySecret_456', $payloadArray['donation']['clientSecret']);
     }
 
     public function testSuccessWithMatchedCampaign(): void
@@ -502,7 +501,6 @@ class CreateTest extends TestCase
         $this->assertEquals('Pending', $payloadArray['donation']['status']);
         $this->assertEquals('stripe', $payloadArray['donation']['psp']);
         $this->assertEquals('pi_dummyIntent_id', $payloadArray['donation']['transactionId']);
-        $this->assertEquals('pi_dummySecret_123', $payloadArray['donation']['clientSecret']);
     }
 
     public function testSuccessWithMatchedCampaignAndPspCustomerId(): void
@@ -621,7 +619,6 @@ class CreateTest extends TestCase
         $this->assertEquals('Pending', $payloadArray['donation']['status']);
         $this->assertEquals('stripe', $payloadArray['donation']['psp']);
         $this->assertEquals('pi_dummyIntent_id', $payloadArray['donation']['transactionId']);
-        $this->assertEquals('pi_dummySecret_123', $payloadArray['donation']['clientSecret']);
     }
 
     public function testMatchedCampaignAndPspCustomerIdButWrongPersonInRoute(): void
@@ -845,7 +842,6 @@ class CreateTest extends TestCase
         $this->assertEquals('Pending', $payloadArray['donation']['status']);
         $this->assertEquals('stripe', $payloadArray['donation']['psp']);
         $this->assertEquals('pi_dummyIntent_id', $payloadArray['donation']['transactionId']);
-        $this->assertEquals('pi_dummySecret_123', $payloadArray['donation']['clientSecret']);
     }
 
     public function testSuccessWithUnmatchedCampaign(): void

--- a/tests/Domain/DonationTest.php
+++ b/tests/Domain/DonationTest.php
@@ -26,7 +26,6 @@ class DonationTest extends TestCase
         $this->assertEquals('not-sent', $donation->getSalesforcePushStatus());
         $this->assertNull($donation->getSalesforceLastPush());
         $this->assertNull($donation->getSalesforceId());
-        $this->assertNull($donation->getClientSecret());
         $this->assertNull($donation->hasGiftAid());
         $this->assertNull($donation->getCharityComms());
         $this->assertNull($donation->getTbgComms());


### PR DESCRIPTION
Not needed in future when donations are always confirmed from matchbot not from the client

** DO NOT MERGE UNTIL AFTER https://github.com/thebiggive/donate-frontend/pull/1302 IS DEPLOYED TO PROD **