### PR TITLE
MAT-321: Fix bug introduced in commit 037a7cf22

### DIFF
--- a/src/Domain/CampaignRepository.php
+++ b/src/Domain/CampaignRepository.php
@@ -94,7 +94,6 @@ class CampaignRepository extends SalesforceReadProxyRepository
         string $regulator,
         ?string $regulatorNumber,
     ): Charity {
-        $this->logger->info("Searching for charity by sf ID: $salesforceCharityId");
         $charity = $this->getEntityManager()
             ->getRepository(Charity::class)
             ->findOneBy(['salesforceId' => $salesforceCharityId]);

--- a/src/Domain/CampaignRepository.php
+++ b/src/Domain/CampaignRepository.php
@@ -94,11 +94,13 @@ class CampaignRepository extends SalesforceReadProxyRepository
         string $regulator,
         ?string $regulatorNumber,
     ): Charity {
+        $this->logger->info("Searching for charity by sf ID: $salesforceCharityId");
         $charity = $this->getEntityManager()
             ->getRepository(Charity::class)
             ->findOneBy(['salesforceId' => $salesforceCharityId]);
         if (!$charity) {
             $charity = new Charity(
+                salesforceId: $salesforceCharityId,
                 charityName: $charityName,
                 stripeAccountId: $stripeAccountId,
                 hmrcReferenceNumber: $hmrcReferenceNumber,

--- a/src/Domain/Charity.php
+++ b/src/Domain/Charity.php
@@ -88,6 +88,7 @@ class Charity extends SalesforceReadProxy
     private bool $tbgApprovedToClaimGiftAid = false;
 
     public function __construct(
+        string $salesforceId,
         string $charityName,
         ?string $stripeAccountId,
         ?string $hmrcReferenceNumber,
@@ -99,6 +100,7 @@ class Charity extends SalesforceReadProxy
     {
         $this->updatedAt = $time;
         $this->createdAt = $time;
+        $this->setSalesforceId($salesforceId);
 
         // every charity originates as pulled from SF.
         $this->updateFromSfPull(

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -182,6 +182,7 @@ class TestCase extends PHPUnitTestCase
     public static function someCharity(): Charity
     {
         return new Charity(
+            salesforceId: '12CharityId_' .  self::randomHex(3),
             charityName: "Charity Name",
             stripeAccountId: "stripe-account-id-" . self::randomHex(),
             hmrcReferenceNumber: 'H' . self::randomHex(3),


### PR DESCRIPTION
SF ID has to be set for all charities. The DB doesn't enforce this, but if we save a charity with no SF ID then we won't find it when we need it and we'll try to pull it from SF again - and get a constraint violation error on the duplicate Stripe ID.

This bug has not been in production - I found it on my local