### PR TITLE
MAT-321: Prevent persisting any Campaign without a Charity ID

### DIFF
--- a/src/Domain/Campaign.php
+++ b/src/Domain/Campaign.php
@@ -24,6 +24,7 @@ class Campaign extends SalesforceReadProxy
 
     /**
      * @ORM\ManyToOne(targetEntity="Charity", cascade={"persist"})
+     * @ORM\JoinColumn(name="charity_id", referencedColumnName="id", nullable=false)
      * @var Charity
      */
     protected Charity $charity;

--- a/src/Migrations/Version20231010105436.php
+++ b/src/Migrations/Version20231010105436.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+final class Version20231010105436 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE Campaign CHANGE charity_id charity_id INT UNSIGNED NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE Campaign CHANGE charity_id charity_id INT UNSIGNED DEFAULT NULL');
+    }
+}


### PR DESCRIPTION
Having a campaign without a charity might be the cause of a crash on attempt to persist a donation. This may bring any crash earlier and make it easier to understand deal with.

I have checked the production database, there are currently no campaigns without charities, i.e. the following returns the empty relation:

```
   SELECT * from Campaign where Campaign.charity_id IS NULL;
```