### PR TITLE
MAT-322: Partial spike moving away from using Doctrine associations

### DIFF
--- a/src/Application/Actions/Donations/Create.php
+++ b/src/Application/Actions/Donations/Create.php
@@ -31,9 +31,11 @@ use Symfony\Component\Serializer\SerializerInterface;
 
 class Create extends Action
 {
+
     #[Pure]
     public function __construct(
         private DonationRepository $donationRepository,
+        private CampaignRepository $campaignRepository,
         private EntityManagerInterface $entityManager,
         private SerializerInterface $serializer,
         private StripeClient $stripeClient,
@@ -115,10 +117,10 @@ class Create extends Action
             ));
         }
 
-        if (!$donation->getCampaign()->isOpen()) {
+        if (!$donation->getCampaignId()->isOpen()) {
             return $this->validationError(
                 $response,
-                "Campaign {$donation->getCampaign()->getSalesforceId()} is not open",
+                "Campaign {$donation->getCampaignId()->getSalesforceId()} is not open",
                 null,
                 true, // Reduce to info log as some instances expected on campaign close
             );
@@ -128,7 +130,7 @@ class Create extends Action
         $this->entityManager->persist($donation);
         $this->entityManager->flush();
 
-        if ($donation->getCampaign()->isMatched()) {
+        if ($donation->getCampaignId()->isMatched()) {
             try {
                 $this->donationRepository->allocateMatchFunds($donation);
             } catch (DomainLockContentionException $exception) {
@@ -139,25 +141,26 @@ class Create extends Action
         }
 
         if ($donation->getPsp() === 'stripe') {
-            if (empty($donation->getCampaign()->getCharity()->getStripeAccountId())) {
+            if (empty($donation->getCampaignId()->getCharity()->getStripeAccountId())) {
                 // Try re-pulling in case charity has very recently onboarded with for Stripe.
                 $repository = $this->entityManager->getRepository(Campaign::class);
                 \assert($repository instanceof CampaignRepository);
+                $campaignId = $donation->getCampaignId();
                 $campaign = $repository
-                    ->pull($donation->getCampaign());
+                    ->pull($repository->find($campaignId));
 
                 // If still empty, error out
                 if (empty($campaign->getCharity()->getStripeAccountId())) {
                     $this->logger->error(sprintf(
                         'Stripe Payment Intent create error: Stripe Account ID not set for Account %s',
-                        $donation->getCampaign()->getCharity()->getSalesforceId(),
+                        $donation->getCampaignId()->getCharity()->getSalesforceId(),
                     ));
                     $error = new ActionError(ActionError::SERVER_ERROR, 'Could not make Stripe Payment Intent (A)');
                     return $this->respond($response, new ActionPayload(500, null, $error));
                 }
 
                 // Else we found new Stripe info and can proceed
-                $donation->setCampaign($campaign);
+                $donation->setCampaignId($campaign->getId());
             }
 
             $createPayload = [
@@ -173,10 +176,10 @@ class Create extends Action
                      * Keys like comms opt ins are set only later. See the counterpart
                      * in {@see Update::addData()} too.
                      */
-                    'campaignId' => $donation->getCampaign()->getSalesforceId(),
-                    'campaignName' => $donation->getCampaign()->getCampaignName(),
-                    'charityId' => $donation->getCampaign()->getCharity()->getSalesforceId(),
-                    'charityName' => $donation->getCampaign()->getCharity()->getName(),
+                    'campaignId' => $donation->getCampaignId()->getSalesforceId(),
+                    'campaignName' => $donation->getCampaignId()->getCampaignName(),
+                    'charityId' => $donation->getCampaignId()->getCharity()->getSalesforceId(),
+                    'charityName' => $donation->getCampaignId()->getCharity()->getName(),
                     'donationId' => $donation->getUuid(),
                     'environment' => getenv('APP_ENV'),
                     'feeCoverAmount' => $donation->getFeeCoverAmount(),
@@ -186,11 +189,11 @@ class Create extends Action
                     'stripeFeeRechargeVat' => $donation->getCharityFeeVat(),
                     'tipAmount' => $donation->getTipAmount(),
                 ],
-                'statement_descriptor' => $this->getStatementDescriptor($donation->getCampaign()->getCharity()),
+                'statement_descriptor' => $this->getStatementDescriptor($donation->getCampaignId()->getCharity()),
                 // See https://stripe.com/docs/connect/destination-charges#application-fee
                 'application_fee_amount' => $donation->getAmountToDeductFractional(),
                 'transfer_data' => [
-                    'destination' => $donation->getCampaign()->getCharity()->getStripeAccountId(),
+                    'destination' => $donation->getCampaignId()->getCharity()->getStripeAccountId(),
                 ],
             ];
 
@@ -223,8 +226,8 @@ class Create extends Action
                     $exception->getStripeCode() ?? 'unknown',
                     get_class($exception),
                     $message,
-                    $donation->getCampaign()->getCharity()->getName(),
-                    $donation->getCampaign()->getCharity()->getStripeAccountId() ?? 'unknown',
+                    $donation->getCampaignId()->getCharity()->getName(),
+                    $donation->getCampaignId()->getCharity()->getStripeAccountId() ?? 'unknown',
                 ));
                 $error = new ActionError(ActionError::SERVER_ERROR, 'Could not make Stripe Payment Intent (B)');
                 return $this->respond($response, new ActionPayload(500, null, $error));
@@ -237,7 +240,7 @@ class Create extends Action
         }
 
         $data = new DonationCreatedResponse();
-        $data->donation = $donation->toApiModel();
+        $data->donation = $donation->toApiModel($this->campaignRepository);
         $data->jwt = DonationToken::create($donation->getUuid());
 
         // Attempt immediate sync. Buffered for a future batch sync if the SF call fails.

--- a/src/Application/Actions/Donations/Update.php
+++ b/src/Application/Actions/Donations/Update.php
@@ -263,7 +263,7 @@ class Update extends Action
         // method every time they `addData()`.
         $donation->setGiftAid($donationData->giftAid);
         $donation->setTipGiftAid($donationData->tipGiftAid ?? $donationData->giftAid);
-        $donation->setTbgShouldProcessGiftAid($donation->getCampaign()->getCharity()->isTbgClaimingGiftAid());
+        $donation->setTbgShouldProcessGiftAid($donation->getCampaignId()->getCharity()->isTbgClaimingGiftAid());
         $donation->setDonorHomeAddressLine1($donationData->homeAddress);
         $donation->setDonorHomePostcode($donationData->homePostcode);
         $donation->setDonorFirstName($donationData->firstName);
@@ -380,7 +380,7 @@ class Update extends Action
         // Save & flush early to reduce chance of lock conflicts.
         $this->save($donation);
 
-        if ($donation->getCampaign()->isMatched()) {
+        if ($donation->getCampaignId()->isMatched()) {
             $this->donationRepository->releaseMatchFunds($donation);
         }
 

--- a/src/Application/Actions/Hooks/StripePaymentsUpdate.php
+++ b/src/Application/Actions/Hooks/StripePaymentsUpdate.php
@@ -443,7 +443,7 @@ class StripePaymentsUpdate extends Stripe
         if (
             $isCoreDonationReversed &&
             $donation->getDonationStatus()->isReversed() &&
-            $donation->getCampaign()->isMatched()
+            $donation->getCampaignId()->isMatched()
         ) {
             $this->donationRepository->releaseMatchFunds($donation);
         }

--- a/src/Application/Commands/RetrospectivelyMatch.php
+++ b/src/Application/Commands/RetrospectivelyMatch.php
@@ -78,8 +78,8 @@ class RetrospectivelyMatch extends LockingCommand
                 $numWithMatchingAllocated++;
                 $totalNewMatching = bcadd($totalNewMatching, $amountAllocated, 2);
 
-                if (!in_array($donation->getCampaign()->getId(), $distinctCampaignIds, true)) {
-                    $distinctCampaignIds[] = $donation->getCampaign()->getId();
+                if (!in_array($donation->getCampaignId()->getId(), $distinctCampaignIds, true)) {
+                    $distinctCampaignIds[] = $donation->getCampaignId()->getId();
                 }
             }
         }

--- a/src/Client/Donation.php
+++ b/src/Client/Donation.php
@@ -25,7 +25,7 @@ class Donation extends Common
         try {
             $response = $this->getHttpClient()->post(
                 $this->getSetting('donation', 'baseUri'),
-                ['json' => $donation->toApiModel()]
+                ['json' => $donation->toApiModel($this->campaignRepository)]
             );
         } catch (RequestException $ex) {
             // Sandboxes that 404 on POST may be trying to sync up donations for non-existent campaigns and

--- a/src/Domain/CampaignRepository.php
+++ b/src/Domain/CampaignRepository.php
@@ -38,6 +38,11 @@ class CampaignRepository extends SalesforceReadProxyRepository
         return $qb->getQuery()->getResult();
     }
 
+    public function findOrThrow(int $campaignId): Campaign
+    {
+        return $this->find($campaignId) ?? throw new \Exception('Could not find campaign #' . $campaignId);
+    }
+
     /**
      * @param Campaign $campaign
      * @return Campaign

--- a/src/Domain/DonationRepository.php
+++ b/src/Domain/DonationRepository.php
@@ -195,7 +195,7 @@ class DonationRepository extends SalesforceWriteProxyRepository
                 // Get these without a lock initially
                 $likelyAvailableFunds = $this->getEntityManager()
                     ->getRepository(CampaignFunding::class)
-                    ->getAvailableFundings($donation->getCampaign());
+                    ->getAvailableFundings($donation->getCampaignId());
 
                 foreach ($likelyAvailableFunds as $funding) {
                     if ($funding->getCurrencyCode() !== $donation->getCurrencyCode()) {
@@ -567,7 +567,7 @@ class DonationRepository extends SalesforceWriteProxyRepository
             $donation->getAmount(),
             $donation->getCurrencyCode(),
             $incursGiftAidFee,
-            $donation->getCampaign()->getFeePercentage(),
+            $this->campaignRepository->findOrThrow($donation->getCampaignId())->getFeePercentage(),
         );
         $donation->setCharityFee($structure->getCoreFee());
         $donation->setCharityFeeVat($structure->getFeeVat());

--- a/tests/Application/Actions/Donations/CreateTest.php
+++ b/tests/Application/Actions/Donations/CreateTest.php
@@ -130,7 +130,7 @@ class CreateTest extends TestCase
     {
         $donation = $this->getTestDonation(true, true);
         $donation->setPsp('stripe');
-        $donation->getCampaign()->getCharity()->setStripeAccountId(null);
+        $donation->getCampaignId()->getCharity()->setStripeAccountId(null);
 
         $donationToReturn = $donation;
         $donationToReturn->setDonationStatus(DonationStatus::Pending);
@@ -148,7 +148,7 @@ class CreateTest extends TestCase
         $campaignRepoProphecy = $this->prophesize(CampaignRepository::class);
         // No change – campaign still has a charity without a Stripe Account ID.
         $campaignRepoProphecy->pull(Argument::type(Campaign::class))
-            ->willReturn($donation->getCampaign())
+            ->willReturn($donation->getCampaignId())
             ->shouldBeCalledOnce();
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
@@ -261,7 +261,7 @@ class CreateTest extends TestCase
         $donation = $this->getTestDonation(true, true);
         $donation->setPsp('stripe');
         $donation->setCharityFee('0.38'); // Calculator is tested elsewhere.
-        $donation->getCampaign()->getCharity()->setStripeAccountId(null);
+        $donation->getCampaignId()->getCharity()->setStripeAccountId(null);
 
         $fundingWithdrawalForMatch = new FundingWithdrawal();
         $fundingWithdrawalForMatch->setAmount('8.00'); // Partial match
@@ -284,10 +284,10 @@ class CreateTest extends TestCase
         // Cloning & use of new objects is necessary here, so we don't set
         // the Stripe value on the copy of the object which is meant to be
         // missing it for the test to follow that logic branch.
-        $charityWhichNowHasStripeAccountID = clone $donation->getCampaign()->getCharity();
+        $charityWhichNowHasStripeAccountID = clone $donation->getCampaignId()->getCharity();
         $charityWhichNowHasStripeAccountID
             ->setStripeAccountId('unitTest_newStripeAccount_456');
-        $campaignWithCharityWhichNowHasStripeAccountID = clone  $donation->getCampaign();
+        $campaignWithCharityWhichNowHasStripeAccountID = clone  $donation->getCampaignId();
         $campaignWithCharityWhichNowHasStripeAccountID->setCharity($charityWhichNowHasStripeAccountID);
 
         $campaignRepoProphecy = $this->prophesize(CampaignRepository::class);
@@ -1097,7 +1097,7 @@ class CreateTest extends TestCase
 
         $donation = Donation::emptyTestDonation(amount: '12.00', currencyCode: $currencyCode);
         $donation->createdNow(); // Call same create/update time initialisers as lifecycle hooks
-        $donation->setCampaign($campaign);
+        $donation->setCampaignId($campaign->getId());
         $donation->setPsp('stripe');
         $donation->setUuid(Uuid::fromString('12345678-1234-1234-1234-1234567890ab'));
         $donation->setDonorCountryCode('GB');

--- a/tests/Application/Actions/Donations/UpdateHandlesLockExceptionTest.php
+++ b/tests/Application/Actions/Donations/UpdateHandlesLockExceptionTest.php
@@ -128,7 +128,7 @@ class UpdateHandlesLockExceptionTest extends TestCase
         $donation = Donation::emptyTestDonation('1');
         $donation->createdNow();
         $donation->setDonationStatus(DonationStatus::Pending);
-        $donation->setCampaign($campaign);
+        $donation->setCampaignId($campaign->getId());
         $donation->setPsp('stripe');
         $donation->setUuid(Uuid::uuid4());
         $donation->setDonorFirstName('Donor first name');

--- a/tests/Application/DonationTestDataTrait.php
+++ b/tests/Application/DonationTestDataTrait.php
@@ -43,7 +43,7 @@ trait DonationTestDataTrait
         $donation = Donation::emptyTestDonation(amount: $amount, paymentMethodType: $paymentMethodType, currencyCode: $currencyCode);
         $donation->createdNow(); // Call same create/update time initialisers as lifecycle hooks
         $donation->setCharityFee('2.05');
-        $donation->setCampaign($campaign);
+        $donation->setCampaignId($campaign->getId());
         $donation->setCharityComms(true);
         $donation->setChampionComms(false);
         $donation->setDonationStatus(DonationStatus::Collected);
@@ -83,7 +83,7 @@ trait DonationTestDataTrait
         $donation = Donation::emptyTestDonation('124.56');
         $donation->createdNow(); // Call same create/update time initialisers as lifecycle hooks
         $donation->setCharityFee('2.57');
-        $donation->setCampaign($campaign);
+        $donation->setCampaignId($campaign->getId());
         $donation->setDonationStatus(DonationStatus::Pending);
         $donation->setPsp('stripe');
         $donation->setTransactionId('pi_stripe_pending_123');

--- a/tests/Domain/DonationRepositoryTest.php
+++ b/tests/Domain/DonationRepositoryTest.php
@@ -253,7 +253,7 @@ class DonationRepositoryTest extends TestCase
         $donation->setTipAmount('0.00');
         $donation->setPsp('stripe');
         $donation->setFeeCoverAmount('44.44'); // 4.5% fee, inc. any VAT.
-        $donation->getCampaign()->setFeePercentage(4.5);
+        $donation->getCampaignId()->setFeePercentage(4.5);
         $this->getRepo()->deriveFees($donation, null, null);
 
         // £987.65 * 4.5%   = £ 44.44 (to 2 d.p.)

--- a/tests/Domain/DonationTest.php
+++ b/tests/Domain/DonationTest.php
@@ -228,10 +228,10 @@ class DonationTest extends TestCase
     {
         $donation = $this->getTestDonation();
 
-        $donation->getCampaign()->getCharity()->setTbgClaimingGiftAid(true);
-        $donation->getCampaign()->getCharity()->setHmrcReferenceNumber('AB12345');
-        $donation->getCampaign()->getCharity()->setRegulator('CCEW');
-        $donation->getCampaign()->getCharity()->setRegulatorNumber('12229');
+        $donation->getCampaignId()->getCharity()->setTbgClaimingGiftAid(true);
+        $donation->getCampaignId()->getCharity()->setHmrcReferenceNumber('AB12345');
+        $donation->getCampaignId()->getCharity()->setRegulator('CCEW');
+        $donation->getCampaignId()->getCharity()->setRegulatorNumber('12229');
         $donation->setTbgShouldProcessGiftAid(true);
 
         $claimBotMessage = $donation->toClaimBotModel();
@@ -257,10 +257,10 @@ class DonationTest extends TestCase
         $donation = $this->getTestDonation();
 
         $donation->setDonorHomePostcode('OVERSEAS');
-        $donation->getCampaign()->getCharity()->setTbgClaimingGiftAid(true);
-        $donation->getCampaign()->getCharity()->setHmrcReferenceNumber('AB12345');
-        $donation->getCampaign()->getCharity()->setRegulator(null); // e.g. Exempt.
-        $donation->getCampaign()->getCharity()->setRegulatorNumber('12222');
+        $donation->getCampaignId()->getCharity()->setTbgClaimingGiftAid(true);
+        $donation->getCampaignId()->getCharity()->setHmrcReferenceNumber('AB12345');
+        $donation->getCampaignId()->getCharity()->setRegulator(null); // e.g. Exempt.
+        $donation->getCampaignId()->getCharity()->setRegulatorNumber('12222');
         $donation->setTbgShouldProcessGiftAid(true);
 
         $claimBotMessage = $donation->toClaimBotModel();


### PR DESCRIPTION
We've been seeing errors with saving associated objects in Doctrine, related to replacing the EntityManager in the middle of a request, after some things were flushed to the first object. When it's replaced it the new one wants to save objects found through associations, but if we tell it to try to save them then the actual database generates a duplicate item error.

One alternative is to have ID numbers on entities instead of references to other entities - not allowing the ORM to do either eager or lazy loading of related entities for us writing our own code to fetch them when required.

Started here by replacing Donation#campaign: Campaign with Donation#campaignId: int and fixing Psalm errors. There are a load of Psalm errors showing up still but I think I've fixed enough to illustrate the process