### PR TITLE
MAT-306: Allow creating donor accounts

### DIFF
--- a/app/repositories.php
+++ b/app/repositories.php
@@ -14,6 +14,8 @@ use MatchBot\Domain\Charity;
 use MatchBot\Domain\CharityRepository;
 use MatchBot\Domain\Donation;
 use MatchBot\Domain\DonationRepository;
+use MatchBot\Domain\DonorAccount;
+use MatchBot\Domain\DonorAccountRepository;
 use MatchBot\Domain\Fund;
 use MatchBot\Domain\FundingWithdrawal;
 use MatchBot\Domain\FundingWithdrawalRepository;
@@ -65,6 +67,14 @@ return static function (ContainerBuilder $containerBuilder) {
 
         FundingWithdrawalRepository::class => static function (ContainerInterface $c): FundingWithdrawalRepository {
             return $c->get(EntityManagerInterface::class)->getRepository(FundingWithdrawal::class);
-        }
+        },
+
+        DonorAccountRepository::class => static function (ContainerInterface $c): DonorAccountRepository {
+            $em = $c->get(EntityManagerInterface::class);
+            \assert($em instanceof EntityManagerInterface);
+            $repo = $em->getRepository(DonorAccount::class);
+            \assert($repo instanceof DonorAccountRepository);
+            return $repo;
+        },
     ]);
 };

--- a/app/routes.php
+++ b/app/routes.php
@@ -43,6 +43,13 @@ return function (App $app) {
         })
             ->add(DonationPublicAuthMiddleware::class);
 
+        $versionGroup->group('/donor-account/', function (RouteCollectorProxy $group) {
+            $group->post('', Donations\Confirm::class);
+        })
+            ->add(PersonWithPasswordAuthMiddleware::class) // Runs last
+            ->add($ipMiddleware)
+            ->add(RateLimitMiddleware::class);
+
         $versionGroup->post('/people/{personId:[a-z0-9-]{36}}/donations', Donations\Create::class)
             ->add(PersonManagementAuthMiddleware::class)
             ->add($ipMiddleware)

--- a/app/routes.php
+++ b/app/routes.php
@@ -44,7 +44,7 @@ return function (App $app) {
         })
             ->add(DonationPublicAuthMiddleware::class);
 
-        $versionGroup->post('/donor-account', DonorAccount\Create::class)
+        $versionGroup->post('/{personId:[a-z0-9-]{36}}/donor-account', DonorAccount\Create::class)
             ->add(PersonWithPasswordAuthMiddleware::class) // Runs last
             ->add($ipMiddleware)
             ->add(RateLimitMiddleware::class);

--- a/app/routes.php
+++ b/app/routes.php
@@ -44,7 +44,7 @@ return function (App $app) {
             ->add(DonationPublicAuthMiddleware::class);
 
         $versionGroup->group('/donor-account/', function (RouteCollectorProxy $group) {
-            $group->post('', Donations\Confirm::class);
+            $group->post('', \MatchBot\Application\Actions\DonorAccount\Create::class);
         })
             ->add(PersonWithPasswordAuthMiddleware::class) // Runs last
             ->add($ipMiddleware)

--- a/app/routes.php
+++ b/app/routes.php
@@ -6,6 +6,7 @@ use LosMiddleware\RateLimit\RateLimitMiddleware;
 use MatchBot\Application\Actions\DeletePaymentMethod;
 use MatchBot\Application\Actions\UpdatePaymentMethod;
 use MatchBot\Application\Actions\Donations;
+use MatchBot\Application\Actions\DonorAccount;
 use MatchBot\Application\Actions\GetPaymentMethods;
 use MatchBot\Application\Actions\Hooks;
 use MatchBot\Application\Actions\Status;
@@ -43,9 +44,7 @@ return function (App $app) {
         })
             ->add(DonationPublicAuthMiddleware::class);
 
-        $versionGroup->group('/donor-account/', function (RouteCollectorProxy $group) {
-            $group->post('', \MatchBot\Application\Actions\DonorAccount\Create::class);
-        })
+        $versionGroup->post('/donor-account', DonorAccount\Create::class)
             ->add(PersonWithPasswordAuthMiddleware::class) // Runs last
             ->add($ipMiddleware)
             ->add(RateLimitMiddleware::class);

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "ext-pdo": "*",
         "ext-pdo_mysql": "*",
         "ext-redis": "*",
+        "beberlei/assert": "^3.3",
         "doctrine/annotations": "^1.13",
         "doctrine/cache": "^1.11.3",
         "doctrine/migrations": "^3.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c49841c95eb231c9a21415ea3487fc30",
+    "content-hash": "86e62aff9a3d955f4c618462dbc27a62",
     "packages": [
         {
             "name": "async-aws/core",
@@ -130,6 +130,73 @@
                 }
             ],
             "time": "2021-12-20T13:18:18+00:00"
+        },
+        {
+            "name": "beberlei/assert",
+            "version": "v3.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/beberlei/assert.git",
+                "reference": "cb70015c04be1baee6f5f5c953703347c0ac1655"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/beberlei/assert/zipball/cb70015c04be1baee6f5f5c953703347c0ac1655",
+                "reference": "cb70015c04be1baee6f5f5c953703347c0ac1655",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "ext-simplexml": "*",
+                "php": "^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "*",
+                "phpstan/phpstan": "*",
+                "phpunit/phpunit": ">=6.0.0",
+                "yoast/phpunit-polyfills": "^0.1.0"
+            },
+            "suggest": {
+                "ext-intl": "Needed to allow Assertion::count(), Assertion::isCountable(), Assertion::minCount(), and Assertion::maxCount() to operate on ResourceBundles"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/Assert/functions.php"
+                ],
+                "psr-4": {
+                    "Assert\\": "lib/Assert"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Richard Quadling",
+                    "email": "rquadling@gmail.com",
+                    "role": "Collaborator"
+                }
+            ],
+            "description": "Thin assertion library for input validation in business models.",
+            "keywords": [
+                "assert",
+                "assertion",
+                "validation"
+            ],
+            "support": {
+                "issues": "https://github.com/beberlei/assert/issues",
+                "source": "https://github.com/beberlei/assert/tree/v3.3.2"
+            },
+            "time": "2021-12-16T21:41:27+00:00"
         },
         {
             "name": "brick/math",

--- a/integrationTests/CreateDonorAccountTest.php
+++ b/integrationTests/CreateDonorAccountTest.php
@@ -36,14 +36,14 @@ class CreateDonorAccountTest extends IntegrationTest
         $this->assertSame(201, $response->getStatusCode());
 
         $donationFetchedFromDB = $this->db()->fetchAssociative(
-            "SELECT emailAddress, stripeCustomerId from DonorAccount WHERE stripeCustomerID = ?",
+            "SELECT email, stripeCustomerId from DonorAccount WHERE stripeCustomerID = ?",
             [$stripeID]
         );
         assert(is_array($donationFetchedFromDB));
 
         $this->assertSame(
             [
-                'emailAddress' => $emailAddress,
+                'email' => $emailAddress,
                 'stripeCustomerId' => $stripeID,
             ],
             $donationFetchedFromDB

--- a/integrationTests/CreateDonorAccountTest.php
+++ b/integrationTests/CreateDonorAccountTest.php
@@ -1,0 +1,69 @@
+<?php
+
+use GuzzleHttp\Psr7\ServerRequest;
+use MatchBot\Application\Auth\PersonManagementAuthMiddleware;
+use MatchBot\Domain\Donation;
+use MatchBot\Domain\DonationRepository;
+use MatchBot\IntegrationTests\IntegrationTest;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use Ramsey\Uuid\Uuid;
+use Stripe\PaymentIntent;
+use Stripe\StripeClient;
+use MatchBot\Application\Actions\DonorAccount;
+
+class CreateDonorAccountTest extends IntegrationTest
+{
+    use \Prophecy\PhpUnit\ProphecyTrait;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    public function testItcreatesADonorAccount(): void
+    {
+        $stripeID = "cus_" . random_int(1000, 9999);
+        $emailAddress = 'donor' . random_int(1000, 9999) . '@eamil-for-generous-people.com';
+
+        $response = $this->requestFromController(
+            body: json_encode([
+                'emailAddress' => $emailAddress,
+                ]),
+            stripeID: $stripeID
+        );
+
+        $this->assertSame(201, $response->getStatusCode());
+
+        $donationFetchedFromDB = $this->db()->fetchAssociative(
+            "SELECT emailAddress, stripeCustomerId from DonorAccount WHERE stripeCustomerID = ?",
+            [$stripeID]
+        );
+        assert(is_array($donationFetchedFromDB));
+
+        $this->assertSame(
+            [
+                'emailAddress' => $emailAddress,
+                'stripeCustomerId' => $stripeID,
+            ],
+            $donationFetchedFromDB
+        );
+    }
+
+    public function requestFromController(string $body, string $stripeID): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->getService(DonorAccount\Create::class)->__invoke(
+            (new ServerRequest(
+                method: 'POST',
+                uri: '',
+                serverParams: ['REMOTE_ADDR' => '127.0.0.1'],
+                body: $body,
+            ))->withAttribute(
+                PersonManagementAuthMiddleware::PSP_ATTRIBUTE_NAME,
+                $stripeID
+            ),
+            new \Slim\Psr7\Response(),
+            []
+        );
+    }
+}

--- a/src/Application/Actions/DonorAccount/Create.php
+++ b/src/Application/Actions/DonorAccount/Create.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Application\Actions\DonorAccount;
+
+use MatchBot\Application\Actions\Action;
+use MatchBot\Application\Auth\PersonManagementAuthMiddleware;
+use MatchBot\Domain\DonorAccountRepository;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Log\LoggerInterface;
+use Slim\Exception\HttpBadRequestException;
+
+/**
+ * Creates a record that a donor has (or intends to have) an account to transfer funds to in advance of donating to
+ * charity. We will need this to email them a confirmation when the funds are recieved.
+ */
+class Create extends Action
+{
+    public function __construct(
+        LoggerInterface $logger,
+        private DonorAccountRepository $donorAccountRepository
+    ) {
+        parent::__construct($logger);
+    }
+
+    protected function action(Request $request, Response $response, array $args): Response
+    {
+        try {
+            $json = $request->getBody()->getContents();
+
+            $requestBody = json_decode(
+                $json,
+                true,
+                512,
+                JSON_THROW_ON_ERROR
+            );
+        } catch (\JsonException) {
+            throw new HttpBadRequestException($request, 'Cannot parse request body as JSON');
+        }
+        \assert(is_array($requestBody));
+
+        $stripeCustomerId = $request->getAttribute(PersonManagementAuthMiddleware::PSP_ATTRIBUTE_NAME);
+
+        $emailAddress = $requestBody['emailAddress'];
+        \assert(is_string($emailAddress) && is_string($stripeCustomerId));
+
+        $donorAccount = new \MatchBot\Domain\DonorAccount($emailAddress, $stripeCustomerId);
+
+        $this->donorAccountRepository->save($donorAccount);
+
+        return new \Slim\Psr7\Response(201);
+    }
+}

--- a/src/Application/Actions/DonorAccount/Create.php
+++ b/src/Application/Actions/DonorAccount/Create.php
@@ -6,7 +6,10 @@ namespace MatchBot\Application\Actions\DonorAccount;
 
 use MatchBot\Application\Actions\Action;
 use MatchBot\Application\Auth\PersonManagementAuthMiddleware;
+use MatchBot\Domain\DonorAccount;
 use MatchBot\Domain\DonorAccountRepository;
+use MatchBot\Domain\EmailAddress;
+use MatchBot\Domain\StripeCustomerId;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Log\LoggerInterface;
@@ -46,7 +49,10 @@ class Create extends Action
         $emailAddress = $requestBody['emailAddress'];
         \assert(is_string($emailAddress) && is_string($stripeCustomerId));
 
-        $donorAccount = new \MatchBot\Domain\DonorAccount($emailAddress, $stripeCustomerId);
+        $donorAccount = new DonorAccount(
+            EmailAddress::of($emailAddress),
+            StripeCustomerId::of($stripeCustomerId)
+        );
 
         $this->donorAccountRepository->save($donorAccount);
 

--- a/src/Application/Assertion.php
+++ b/src/Application/Assertion.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace MatchBot\Application;
+
+use Assert\Assertion as BaseAssertion;
+
+/**
+ * Child class created as recommend at https://github.com/beberlei/assert#your-own-assertion-class. Use this
+ * rather than the parent class. If you need to catch the exception catch our own AssertionFailedException so we can
+ * distinguish between assertion failures from our own code and assertion failures in any libraries that might also use
+ * beberlei/assert
+ *
+ */
+class Assertion extends BaseAssertion
+{
+    protected static $exceptionClass = AssertionFailedException::class;
+}

--- a/src/Application/AssertionFailedException.php
+++ b/src/Application/AssertionFailedException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace MatchBot\Application;
+
+use Assert\InvalidArgumentException;
+
+class AssertionFailedException extends InvalidArgumentException
+{
+
+}

--- a/src/Application/Auth/PersonWithPasswordAuthMiddleware.php
+++ b/src/Application/Auth/PersonWithPasswordAuthMiddleware.php
@@ -13,6 +13,8 @@ use Psr\Http\Message\ServerRequestInterface;
  * Permits only true "complete" value in token claims. Use this for anything that should
  * be returned only to those who've set a password and so expect e.g. their saved payment
  * methods to be available longer term.
+ *
+ * // note use this for making donation funds account.
  */
 class PersonWithPasswordAuthMiddleware extends PersonManagementAuthMiddleware
 {

--- a/src/Application/Auth/PersonWithPasswordAuthMiddleware.php
+++ b/src/Application/Auth/PersonWithPasswordAuthMiddleware.php
@@ -13,8 +13,6 @@ use Psr\Http\Message\ServerRequestInterface;
  * Permits only true "complete" value in token claims. Use this for anything that should
  * be returned only to those who've set a password and so expect e.g. their saved payment
  * methods to be available longer term.
- *
- * // note use this for making donation funds account.
  */
 class PersonWithPasswordAuthMiddleware extends PersonManagementAuthMiddleware
 {

--- a/src/Domain/DonorAccount.php
+++ b/src/Domain/DonorAccount.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace MatchBot\Domain;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * This is new, about to be brought into use.
+ * @psalm-suppress PossiblyUnusedProperty
+ *
+ * Holds details of an account set at Stripe by a donor through our system so that they can transfer funds using a
+ * bank transfer and later donate those funds (or parts of those funds) to charities.
+ *
+ * This class originally created for the use case of mapping from stripe IDs to email addresses and names, so that
+ * we can send out confirmation emails when bank transfers are recieved into the account - but may well grow to support
+ * other related uses.
+ *
+ * I would like to PHP Attributes instead of Annotations (Doctrine's Annotation Driver is deprecated and will be removed
+ * in Doctrine 3 - but we have the ORM configured to read Annotations, and sadly it doesn't seem possible to simply set
+ * it to read both, so using annotations for now. See https://stackoverflow.com/a/69284041/2526181
+ *
+ * @ORM\Entity(repositoryClass="DonorAccountRepository")
+ */
+class DonorAccount extends Model
+{
+    /**
+     * @ORM\Column(type="string", length=256)
+     */
+    public readonly string $emailAddress;
+
+    /**
+     * @ORM\Column(type="string", length=50)
+     */
+    public readonly string $stripeCustomerId;
+
+    public function __construct(string $emailAddress, string $stripeCustomerId)
+    {
+        $this->emailAddress = $emailAddress;
+        $this->stripeCustomerId = $stripeCustomerId;
+    }
+}

--- a/src/Domain/DonorAccount.php
+++ b/src/Domain/DonorAccount.php
@@ -19,10 +19,14 @@ use MatchBot\Application\Assertion;
  * in Doctrine 3 - but we have the ORM configured to read Annotations, and sadly it doesn't seem possible to simply set
  * it to read both, so using annotations for now. See https://stackoverflow.com/a/69284041/2526181
  *
+ * @ORM\HasLifecycleCallbacks
  * @ORM\Entity(repositoryClass="DonorAccountRepository")
+ * @ORM\Table
  */
 class DonorAccount extends Model
 {
+    use TimestampsTrait;
+
     /**
      * @ORM\Embedded(class="EmailAddress", columnPrefix=false)
      * */
@@ -35,6 +39,7 @@ class DonorAccount extends Model
 
     public function __construct(EmailAddress $emailAddress, StripeCustomerId $stripeCustomerId)
     {
+        $this->createdNow();
         $this->emailAddress = $emailAddress;
         $this->stripeCustomerId = $stripeCustomerId;
     }

--- a/src/Domain/DonorAccount.php
+++ b/src/Domain/DonorAccount.php
@@ -2,6 +2,7 @@
 
 namespace MatchBot\Domain;
 use Doctrine\ORM\Mapping as ORM;
+use MatchBot\Application\Assertion;
 
 /**
  * This is new, about to be brought into use.
@@ -23,16 +24,16 @@ use Doctrine\ORM\Mapping as ORM;
 class DonorAccount extends Model
 {
     /**
-     * @ORM\Column(type="string", length=256)
-     */
-    public readonly string $emailAddress;
+     * @ORM\Embedded(class="EmailAddress", columnPrefix=false)
+     * */
+    public readonly EmailAddress $emailAddress;
 
     /**
-     * @ORM\Column(type="string", length=50)
+     * @ORM\Embedded(class="StripeCustomerId", columnPrefix=false)
      */
-    public readonly string $stripeCustomerId;
+    public readonly StripeCustomerId $stripeCustomerId;
 
-    public function __construct(string $emailAddress, string $stripeCustomerId)
+    public function __construct(EmailAddress $emailAddress, StripeCustomerId $stripeCustomerId)
     {
         $this->emailAddress = $emailAddress;
         $this->stripeCustomerId = $stripeCustomerId;

--- a/src/Domain/DonorAccountRepository.php
+++ b/src/Domain/DonorAccountRepository.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace MatchBot\Domain;
+
+use Doctrine\ORM\EntityRepository;
+
+/**
+ * @extends EntityRepository<DonorAccount>
+ */
+class DonorAccountRepository extends EntityRepository
+{
+    public function save(DonorAccount $donorAccount): void
+    {
+        $this->getEntityManager()->persist($donorAccount);
+        $this->getEntityManager()->flush();
+    }
+}

--- a/src/Domain/EmailAddress.php
+++ b/src/Domain/EmailAddress.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace MatchBot\Domain;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
+use MatchBot\Application\Assertion;
+
+/** @Embeddable */
+class EmailAddress
+{
+    /** @Column(type = "string") */
+    public readonly string $email;
+
+    private function __construct(
+        string $value
+    ){
+        $this->email = $value;
+        Assertion::email($this->email);
+    }
+
+    /**
+     * @param string $emailAddress - must be a valid email address.
+     */
+    public static function of(string $emailAddress): self
+    {
+        return new self($emailAddress);
+    }
+}

--- a/src/Domain/EmailAddress.php
+++ b/src/Domain/EmailAddress.php
@@ -6,7 +6,10 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Embeddable;
 use MatchBot\Application\Assertion;
 
-/** @Embeddable */
+/**
+ * @psalm-immutable
+ * @Embeddable
+ */
 class EmailAddress
 {
     /** @Column(type = "string") */

--- a/src/Domain/StripeCustomerId.php
+++ b/src/Domain/StripeCustomerId.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace MatchBot\Domain;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
+use MatchBot\Application\Assertion;
+
+/** @Embeddable */
+class StripeCustomerId
+{
+    /** @Column(type = "string") */
+    public readonly string $stripeCustomerId;
+
+    private function __construct(
+        string $stripeCustomerId
+    ){
+        $this->stripeCustomerId = $stripeCustomerId;
+        Assertion::notEmpty($this->stripeCustomerId);
+        Assertion::maxLength($this->stripeCustomerId, 255);
+        Assertion::regex($this->stripeCustomerId, '/^cus_[a-zA-Z0-9]+$/'); // e.g. cus_df64s36cf
+    }
+
+    /**
+     * @param string $stripeID - must fit the pattern for a Stripe ID.
+     */
+    public static function of(string $stripeID): self
+    {
+        return new self($stripeID);
+    }
+}

--- a/src/Domain/StripeCustomerId.php
+++ b/src/Domain/StripeCustomerId.php
@@ -6,7 +6,10 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Embeddable;
 use MatchBot\Application\Assertion;
 
-/** @Embeddable */
+/**
+ * @psalm-immutable
+ * @Embeddable
+ */
 class StripeCustomerId
 {
     /** @Column(type = "string") */

--- a/src/Domain/TimestampsTrait.php
+++ b/src/Domain/TimestampsTrait.php
@@ -25,6 +25,7 @@ trait TimestampsTrait
     protected DateTime $updatedAt;
 
     /**
+     * @psalm-suppress PossiblyUnusedMethod
      * @ORM\PrePersist Set created + updated timestamps
      */
     public function createdNow(): void
@@ -34,6 +35,7 @@ trait TimestampsTrait
     }
 
     /**
+     * @psalm-suppress PossiblyUnusedMethod
      * @ORM\PreUpdate Set updated timestamp
      */
     public function updatedNow(): void

--- a/src/Migrations/Version20231016113352.php
+++ b/src/Migrations/Version20231016113352.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20231016113352 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Make Campaign.charity_id non-nullable';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE Campaign CHANGE charity_id charity_id INT UNSIGNED NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE Campaign CHANGE charity_id charity_id INT UNSIGNED DEFAULT NULL');
+    }
+}

--- a/src/Migrations/Version20231016115215.php
+++ b/src/Migrations/Version20231016115215.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20231016115215 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE DonorAccount (id INT UNSIGNED AUTO_INCREMENT NOT NULL, emailAddress VARCHAR(256) NOT NULL, stripeCustomerId VARCHAR(50) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP TABLE DonorAccount');
+    }
+}

--- a/src/Migrations/Version20231016141922.php
+++ b/src/Migrations/Version20231016141922.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20231016141922 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE DonorAccount ADD email VARCHAR(255) NOT NULL, DROP emailAddress, CHANGE stripeCustomerId stripeCustomerId VARCHAR(255) NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE DonorAccount ADD emailAddress VARCHAR(256) NOT NULL, DROP email, CHANGE stripeCustomerId stripeCustomerId VARCHAR(50) NOT NULL');
+    }
+}

--- a/src/Migrations/Version20231016160140.php
+++ b/src/Migrations/Version20231016160140.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20231016160140 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add timestamps to DonorAccount talbe';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE DonorAccount ADD createdAt DATETIME NOT NULL, ADD updatedAt DATETIME NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE DonorAccount DROP createdAt, DROP updatedAt');
+    }
+}


### PR DESCRIPTION
Once this is in Matchbot, frontend should be able to call it to create a donor account when required. Then stripe can call matchbot to say cash has been transferred to an account, matchbot will be able to look up the account and finally use mailer to email the account holder.