### PR TITLE
Refactor - reduce duplication of string literal status names

### DIFF
--- a/integrationTests/DonationPersistenceTest.php
+++ b/integrationTests/DonationPersistenceTest.php
@@ -63,7 +63,7 @@ class DonationPersistenceTest extends IntegrationTest
             'uuid' => Uuid::uuid4(),
             'transactionId' => NULL,
             'amount' => '1.00',
-            'donationStatus' => 'Refunded',
+            'donationStatus' => DonationStatus::Refunded->value,
             'charityComms' => NULL,
             'giftAid' => NULL,
             'tbgComms' => NULL,

--- a/integrationTests/StripeCancelsDonationTest.php
+++ b/integrationTests/StripeCancelsDonationTest.php
@@ -3,6 +3,7 @@
 use GuzzleHttp\Psr7\ServerRequest;
 use MatchBot\Domain\Donation;
 use MatchBot\Domain\DonationRepository;
+use MatchBot\Domain\DonationStatus;
 use MatchBot\IntegrationTests\IntegrationTest;
 use MatchBot\Tests\Application\Actions\Hooks\StripeTest;
 use Prophecy\Argument;
@@ -29,7 +30,7 @@ class StripeCancelsDonationTest extends IntegrationTest
 
         $this->sendCancellationWebhookFromStripe($donation['transactionId']);
 
-        $this->assertSame('Cancelled', $this->db()->fetchOne('SELECT donationStatus from Donation where uuid = ?', [$donation['donationId']]));
+        $this->assertSame(DonationStatus::Cancelled->value, $this->db()->fetchOne('SELECT donationStatus from Donation where uuid = ?', [$donation['donationId']]));
     }
 
     private function sendCancellationWebhookFromStripe(string $transactionId): void

--- a/src/Application/Actions/Donations/Update.php
+++ b/src/Application/Actions/Donations/Update.php
@@ -106,7 +106,7 @@ class Update extends Action
                     throw new DomainRecordNotFoundException('Donation not found');
                 }
 
-                if ($donationData->status !== 'Cancelled' && $donationData->status !== $donation->getDonationStatus()->value) {
+                if ($donationData->status !== DonationStatus::Cancelled->value && $donationData->status !== $donation->getDonationStatus()->value) {
                     $this->entityManager->rollback();
 
                     return $this->validationError($response,
@@ -130,7 +130,7 @@ class Update extends Action
                     );
                 }
 
-                if ($donationData->status === 'Cancelled') {
+                if ($donationData->status === DonationStatus::Cancelled->value) {
                     return $this->cancel($donation, $response, $args);
                 }
 

--- a/src/Domain/DonationRepository.php
+++ b/src/Domain/DonationRepository.php
@@ -383,7 +383,7 @@ class DonationRepository extends SalesforceWriteProxyRepository
             ->where('d.donationStatus IN (:expireWithStatuses)')
             ->andWhere('d.createdAt < :expireBefore')
             ->groupBy('d.id')
-            ->setParameter('expireWithStatuses', ['Pending', 'Cancelled'])
+            ->setParameter('expireWithStatuses', [DonationStatus::Pending->value, DonationStatus::Cancelled->value])
             ->setParameter('expireBefore', $cutoff)
         ;
 
@@ -428,7 +428,7 @@ class DonationRepository extends SalesforceWriteProxyRepository
             ->andWhere('d.collectedAt < :claimGiftAidForDonationsBefore')
             ->orderBy('charity.id', 'ASC') // group donations for the same charity together in batches
             ->addOrderBy('d.collectedAt', 'ASC')
-            ->setParameter('claimGiftAidWithStatus', 'Paid')
+            ->setParameter('claimGiftAidWithStatus', DonationStatus::Paid->value)
             ->setParameter('claimGiftAidForDonationsBefore', $cutoff);
 
         if (!$withResends) {
@@ -532,7 +532,7 @@ class DonationRepository extends SalesforceWriteProxyRepository
             ->andWhere('d.salesforcePushStatus IN (:pendingSFPushStatuses)')
             ->andWhere('d.createdAt < :twentyMinsAgo')
             ->orderBy('d.createdAt', 'ASC')
-            ->setParameter('cancelledStatus', 'Cancelled')
+            ->setParameter('cancelledStatus', DonationStatus::Cancelled->value)
             ->setParameter('pendingSFPushStatuses', $pendingSFPushStatuses)
             ->setParameter('twentyMinsAgo', $twentyMinsAgo);
 

--- a/src/Domain/DonationStatus.php
+++ b/src/Domain/DonationStatus.php
@@ -18,6 +18,8 @@ enum DonationStatus: string
 
     /**
      * @link https://thebiggive.slack.com/archives/GGQRV08BZ/p1576070168066200?thread_ts=1575655432.161800&cid=GGQRV08BZ
+     * @psalm-suppress DeprecatedConstant - self::Chargedback is never set but we do still need to check it here for now
+     * in case we're looking at an old donation.
      */
     public function isReversed(): bool
     {
@@ -83,6 +85,7 @@ enum DonationStatus: string
      * Exists in database entries from 2020 only. There is now no code that can set this status.
      * We may want to see if eventually these can be archived and moved out of the live DB, and then this case can be
      * removed.
+     * @deprecated
      */
     case Chargedback = 'Chargedback';
 }

--- a/tests/Application/Actions/Donations/CreateTest.php
+++ b/tests/Application/Actions/Donations/CreateTest.php
@@ -383,7 +383,7 @@ class CreateTest extends TestCase
         $this->assertEquals('1.11', $payloadArray['donation']['tipAmount']);
         $this->assertEquals('567CharitySFID', $payloadArray['donation']['charityId']);
         $this->assertEquals('123CampaignId', $payloadArray['donation']['projectId']);
-        $this->assertEquals('Pending', $payloadArray['donation']['status']);
+        $this->assertEquals(DonationStatus::Pending->value, $payloadArray['donation']['status']);
         $this->assertEquals('stripe', $payloadArray['donation']['psp']);
         $this->assertEquals('pi_dummyIntent456_id', $payloadArray['donation']['transactionId']);
     }
@@ -497,7 +497,7 @@ class CreateTest extends TestCase
         $this->assertEquals('1.11', $payloadArray['donation']['tipAmount']);
         $this->assertEquals('567CharitySFID', $payloadArray['donation']['charityId']);
         $this->assertEquals('123CampaignId', $payloadArray['donation']['projectId']);
-        $this->assertEquals('Pending', $payloadArray['donation']['status']);
+        $this->assertEquals(DonationStatus::Pending->value, $payloadArray['donation']['status']);
         $this->assertEquals('stripe', $payloadArray['donation']['psp']);
         $this->assertEquals('pi_dummyIntent_id', $payloadArray['donation']['transactionId']);
     }
@@ -615,7 +615,7 @@ class CreateTest extends TestCase
         $this->assertEquals('567CharitySFID', $payloadArray['donation']['charityId']);
         $this->assertEquals('123CampaignId', $payloadArray['donation']['projectId']);
         $this->assertEquals('cus_aaaaaaaaaaaa11', $payloadArray['donation']['pspCustomerId']);
-        $this->assertEquals('Pending', $payloadArray['donation']['status']);
+        $this->assertEquals(DonationStatus::Pending->value, $payloadArray['donation']['status']);
         $this->assertEquals('stripe', $payloadArray['donation']['psp']);
         $this->assertEquals('pi_dummyIntent_id', $payloadArray['donation']['transactionId']);
     }
@@ -838,7 +838,7 @@ class CreateTest extends TestCase
         $this->assertEquals('1.11', $payloadArray['donation']['tipAmount']);
         $this->assertEquals('567CharitySFID', $payloadArray['donation']['charityId']);
         $this->assertEquals('123CampaignId', $payloadArray['donation']['projectId']);
-        $this->assertEquals('Pending', $payloadArray['donation']['status']);
+        $this->assertEquals(DonationStatus::Pending->value, $payloadArray['donation']['status']);
         $this->assertEquals('stripe', $payloadArray['donation']['psp']);
         $this->assertEquals('pi_dummyIntent_id', $payloadArray['donation']['transactionId']);
     }

--- a/tests/Application/Actions/Donations/UpdateTest.php
+++ b/tests/Application/Actions/Donations/UpdateTest.php
@@ -369,7 +369,7 @@ class UpdateTest extends TestCase
         $this->assertEquals(200, $response->getStatusCode());
 
         $payloadArray = json_decode($payload, true);
-        $this->assertEquals('Cancelled', $payloadArray['status']);
+        $this->assertEquals(DonationStatus::Cancelled->value, $payloadArray['status']);
         $this->assertEquals('1 Main St, London N1 1AA', $payloadArray['billingPostalAddress']);
         $this->assertTrue($payloadArray['giftAid']);
         $this->assertTrue($payloadArray['optInCharityEmail']);
@@ -444,7 +444,7 @@ class UpdateTest extends TestCase
         $this->assertEquals(200, $response->getStatusCode());
 
         $payloadArray = json_decode($payload, true);
-        $this->assertEquals('Cancelled', $payloadArray['status']);
+        $this->assertEquals(DonationStatus::Cancelled->value, $payloadArray['status']);
         $this->assertEquals('1 Main St, London N1 1AA', $payloadArray['billingPostalAddress']);
         $this->assertTrue($payloadArray['giftAid']);
         $this->assertTrue($payloadArray['optInCharityEmail']);
@@ -594,7 +594,7 @@ class UpdateTest extends TestCase
         $this->assertEquals(200, $response->getStatusCode());
 
         $payloadArray = json_decode($payload, true);
-        $this->assertEquals('Cancelled', $payloadArray['status']);
+        $this->assertEquals(DonationStatus::Cancelled->value, $payloadArray['status']);
     }
 
     public function testCancelSuccessWithChangeFromPendingAnonymousDonation(): void
@@ -654,7 +654,7 @@ class UpdateTest extends TestCase
         $this->assertEquals(200, $response->getStatusCode());
 
         $payloadArray = json_decode($payload, true);
-        $this->assertEquals('Cancelled', $payloadArray['status']);
+        $this->assertEquals(DonationStatus::Cancelled->value, $payloadArray['status']);
         $this->assertNull($payloadArray['giftAid']);
         $this->assertEquals(124.56, $payloadArray['donationAmount']); // Attempt to patch this is ignored
         $this->assertEquals(0, $payloadArray['matchedAmount']);
@@ -1606,7 +1606,7 @@ class UpdateTest extends TestCase
 
         // These two values are unchanged but still returned.
         $this->assertEquals(123.45, $payloadArray['donationAmount']);
-        $this->assertEquals('Collected', $payloadArray['status']);
+        $this->assertEquals(DonationStatus::Collected->value, $payloadArray['status']);
 
         // Remaining properties should be updated.
         $this->assertEquals('US', $payloadArray['countryCode']);
@@ -1691,7 +1691,7 @@ class UpdateTest extends TestCase
         // These values are unchanged but still returned. Confirming alone doesn't change the
         // response payload.
         $this->assertEquals(123.45, $payloadArray['donationAmount']);
-        $this->assertEquals('Collected', $payloadArray['status']);
+        $this->assertEquals(DonationStatus::Collected->value, $payloadArray['status']);
     }
 
     public function testAddDataRejectsAutoconfirmWithCardMethod(): void

--- a/tests/Domain/DonationRepositoryTest.php
+++ b/tests/Domain/DonationRepositoryTest.php
@@ -523,7 +523,7 @@ class DonationRepositoryTest extends TestCase
             ->willReturn($queryBuilderProphecy->reveal());
 
         // 2 param sets.
-        $queryBuilderProphecy->setParameter('claimGiftAidWithStatus', 'Paid')
+        $queryBuilderProphecy->setParameter('claimGiftAidWithStatus', DonationStatus::Paid->value)
             ->shouldBeCalledOnce()->willReturn($queryBuilderProphecy->reveal());
         $queryBuilderProphecy->setParameter('claimGiftAidForDonationsBefore', Argument::type(\DateTime::class))
             ->shouldBeCalledOnce()->willReturn($queryBuilderProphecy->reveal());


### PR DESCRIPTION
By referencing the enum each time instead of repeating the literal we allow static analysers to check that we haven't typo'd, get earlier runtime crashes in case of error, and allow clicking through to read documentation of each status case from anywhere it's referenced.

The one place were I haven't done this is in migration files, as those need to keep the same literal string value even if we change or remove the DonationStatus case in future - migrations are basically write-only files and shouldn't depend on things that we might change.
