### PR TITLE
MAT-306 - improve handling of bad requests

### DIFF
--- a/src/Application/Actions/DonorAccount/Create.php
+++ b/src/Application/Actions/DonorAccount/Create.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MatchBot\Application\Actions\DonorAccount;
 
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use MatchBot\Application\Actions\Action;
 use MatchBot\Application\AssertionFailedException;
 use MatchBot\Application\Auth\PersonManagementAuthMiddleware;
@@ -73,7 +74,14 @@ class Create extends Action
             $stripeCustomerId,
         );
 
-        $this->donorAccountRepository->save($donorAccount);
+        try {
+            $this->donorAccountRepository->save($donorAccount);
+        } catch (UniqueConstraintViolationException $e) {
+            return $this->validationError(
+                $response,
+                "Donor Account already exists for stripe account " . $donorAccount->stripeCustomerId->stripeCustomerId,
+            );
+        }
 
         return new \Slim\Psr7\Response(201);
     }

--- a/src/Application/Assert.php
+++ b/src/Application/Assert.php
@@ -13,5 +13,5 @@ use Assert\Assert as BaseAssert;
  */
 class Assert extends BaseAssert
 {
-    protected static $lazyAssertionExceptionClass = LazyAssertionExceptionAlias::class;
+    protected static $lazyAssertionExceptionClass = LazyAssertionException::class;
 }

--- a/src/Application/LazyAssertionException.php
+++ b/src/Application/LazyAssertionException.php
@@ -4,7 +4,7 @@ namespace MatchBot\Application;
 
 use Assert\LazyAssertionException as BaseLazyAssertionExceptionAlias;
 
-class LazyAssertionExceptionAlias extends BaseLazyAssertionExceptionAlias
+class LazyAssertionException extends BaseLazyAssertionExceptionAlias
 {
 
 }

--- a/src/Domain/DonorAccount.php
+++ b/src/Domain/DonorAccount.php
@@ -21,7 +21,10 @@ use MatchBot\Application\Assertion;
  *
  * @ORM\HasLifecycleCallbacks
  * @ORM\Entity(repositoryClass="DonorAccountRepository")
- * @ORM\Table
+ * @ORM\Table(
+ *     indexes={@ORM\Index(name="UNIQ_STRIPE_ID", fields={"stripeCustomerId"})},
+ *     uniqueConstraints={@ORM\UniqueConstraint(name="UNIQ_STRIPE_ID", columns={"stripeCustomerId"})}
+ *     )
  */
 class DonorAccount extends Model
 {

--- a/src/Domain/DonorAccountRepository.php
+++ b/src/Domain/DonorAccountRepository.php
@@ -2,6 +2,7 @@
 
 namespace MatchBot\Domain;
 
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityRepository;
 
 /**
@@ -9,6 +10,9 @@ use Doctrine\ORM\EntityRepository;
  */
 class DonorAccountRepository extends EntityRepository
 {
+    /**
+     * @throws UniqueConstraintViolationException if we already have a donor account with the same Stripe Customer ID.
+     */
     public function save(DonorAccount $donorAccount): void
     {
         $this->getEntityManager()->persist($donorAccount);

--- a/src/Domain/DonorName.php
+++ b/src/Domain/DonorName.php
@@ -5,6 +5,7 @@ namespace MatchBot\Domain;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Embeddable;
 use MatchBot\Application\Assert;
+use MatchBot\Application\LazyAssertionException;
 
 /**
  * @psalm-immutable
@@ -19,11 +20,10 @@ class DonorName
     private string $last;
 
     /**
-     * @param string $first
-     * @param string $last
      * @psalm-suppress ImpureMethodCall - \Assert\Assert::lazy etc could probably be marked as pure but is not.
+     * @throws LazyAssertionException
      */
-    public function __construct(string $first, string $last)
+    private function __construct(string $first, string $last)
     {
         Assert::lazy()
             ->that($first, 'first')->betweenLength(1, 255)
@@ -34,6 +34,9 @@ class DonorName
         $this->last = $last;
     }
 
+    /**
+     * @throws LazyAssertionException
+     */
     public static function of(string $first, string $last): self
     {
         return new self($first, $last);

--- a/src/Domain/EmailAddress.php
+++ b/src/Domain/EmailAddress.php
@@ -2,6 +2,7 @@
 
 namespace MatchBot\Domain;
 
+use Assert\AssertionFailedException;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Embeddable;
 use MatchBot\Application\Assertion;
@@ -15,15 +16,19 @@ class EmailAddress
     /** @Column(type = "string") */
     public readonly string $email;
 
+    /**
+     * @throws AssertionFailedException
+     */
     private function __construct(
         string $value
-    ){
+    ) {
         $this->email = $value;
         Assertion::email($this->email);
     }
 
     /**
      * @param string $emailAddress - must be a valid email address.
+     * @throws AssertionFailedException
      */
     public static function of(string $emailAddress): self
     {

--- a/src/Migrations/Version20231018104935.php
+++ b/src/Migrations/Version20231018104935.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Hand-written migration. For some reason Doctrine doesn't seem to want to auto generate, despite having annotated
+ * the DonorAccount class with Index and UniqueConstraint - and it generates a migration to reverse this when I run
+ * vendor/bin/doctrine-migrations diff. For now we'll just have to delete that auto generated migration.
+ */
+final class Version20231018104935 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add unique index ON DonorAccount(stripeCustomerId) - for faster lookups + prevent duplicate entries';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_STRIPE_ID ON DonorAccount(stripeCustomerId) ');
+
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX UNIQ_STRIPE_ID ON DonorAccount');
+
+    }
+}


### PR DESCRIPTION
This does two things, both about rejecting unwanted requests for creating donor accounts:

- If we get a request without all required data, we now return a 400 response instead of an alarming 500.
- If we get a request to create a duplicate account (i.e. with a stripe customer ID we've already got an account for) we reject that as well, with a 400, where previously we would have put the dupe into our DB.