### PR TITLE
MAT-322: Set up donation in integration tests as matched, so that int…

### DIFF
--- a/app/dependencies.php
+++ b/app/dependencies.php
@@ -196,7 +196,15 @@ return function (ContainerBuilder $containerBuilder) {
         },
 
         Matching\Adapter::class => static function (ContainerInterface $c): Matching\Adapter {
-            return new Matching\OptimisticRedisAdapter($c->get(Redis::class), $c->get(RetrySafeEntityManager::class));
+            $redis = $c->get(Redis::class);
+            $entityManager = $c->get(RetrySafeEntityManager::class);
+            $logger = $c->get(LoggerInterface::class);
+
+            \assert($redis instanceof Redis);
+            \assert($entityManager instanceof RetrySafeEntityManager);
+            \assert($logger instanceof LoggerInterface);
+
+            return new Matching\OptimisticRedisAdapter($redis, $entityManager, $logger);
         },
 
         MessageBusInterface::class => static function (ContainerInterface $c): MessageBusInterface {

--- a/integrationTests/CreateDonationTest.php
+++ b/integrationTests/CreateDonationTest.php
@@ -18,18 +18,7 @@ class CreateDonationTest extends IntegrationTest
     {
         parent::setUp();
         $this->addCampaignAndCharityToDB($this->randomString());
-
-        /** @var \DI\Container $container */
-        $container = $this->getContainer();
-
-        $donationClientProphecy = $this->prophesize(\MatchBot\Client\Donation::class);
-        $donationClientProphecy->create(Argument::type(Donation::class))->willReturn($this->randomString());
-
-        $container->set(\MatchBot\Client\Donation::class, $donationClientProphecy->reveal());
-
-        $donationRepo = $container->get(DonationRepository::class);
-        assert($donationRepo instanceof DonationRepository);
-        $donationRepo->setClient($donationClientProphecy->reveal());
+        $this->setupFakeDonationClient();
     }
 
     public function testItCreatesADonation(): void
@@ -38,7 +27,7 @@ class CreateDonationTest extends IntegrationTest
         // from the HTTP router to the DB is using our real prod code.
 
         // act
-        $response = $this->createDonation();
+        $response = $this->createDonation(100);
 
         // assert
 

--- a/integrationTests/DonationMatchingTest.php
+++ b/integrationTests/DonationMatchingTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace MatchBot\IntegrationTests;
+
 use MatchBot\Application\Assertion;
 use MatchBot\Application\Matching\Adapter;
 use MatchBot\Application\Matching\OptimisticRedisAdapter;

--- a/integrationTests/DonationMatchingTest.php
+++ b/integrationTests/DonationMatchingTest.php
@@ -3,6 +3,7 @@
 use MatchBot\Application\Assertion;
 use MatchBot\Application\Matching\Adapter;
 use MatchBot\Domain\Campaign;
+use MatchBot\Domain\CampaignFunding;
 use MatchBot\Domain\CampaignFundingRepository;
 
 class DonationMatchingTest extends \MatchBot\IntegrationTests\IntegrationTest
@@ -42,5 +43,77 @@ class DonationMatchingTest extends \MatchBot\IntegrationTests\IntegrationTest
         $amountAvailable = $this->matchingAdapater->getAmountAvailable($campaignFunding);
 
         $this->assertEquals(90, $amountAvailable); // 100 originally in fund - 10 matched to donation.
+    }
+
+    public function testACrashedDonationDoesNotReduceAvailableMatchFunds(): void
+    {
+        // arrange
+        $this->matchingAdapater = $this->makeAdapterThatThrowsAfterSubtractingFunds($this->matchingAdapater);
+        $this->setInContainer(Adapter::class, $this->matchingAdapater);
+        $this->getService(\MatchBot\Domain\DonationRepository::class)->setMatchingAdapter($this->matchingAdapater);
+
+        ['campaignFundingID' => $this->campaignFundingId, 'campaignId' => $campaignId] =
+            $this->addCampaignAndCharityToDB(campaignSfId: $this->randomString(), fundWithAmountInPounds: 100);
+
+        $campaign = $this->getService(\MatchBot\Domain\CampaignRepository::class)->find($campaignId);
+        Assertion::notNull($campaign);
+        $campaignFunding = $this->campaignFundingRepository->find($this->campaignFundingId);
+        Assertion::notNull($campaignFunding);
+
+
+        // act
+        try {
+            $this->createDonation(
+                withPremadeCampaign: false,
+                campaignSfID: $campaign->getSalesforceId(),
+                amountInPounds: 10
+            );
+        } catch (\Exception $e) {
+            $this->assertEquals("Throwing after subtracting funds to test how our system handles the crash", $e->getMessage());
+        }
+
+        // assert
+        $amountAvailable = $this->matchingAdapater->getAmountAvailable($campaignFunding);
+
+        $this->assertEquals(90, $amountAvailable); // reduced
+        // @todo delete above line, fix code and insert following:
+        // $this->assertEquals(100, $amountAvailable); // not reduced
+    }
+
+    private function makeAdapterThatThrowsAfterSubtractingFunds(Adapter $matchingAdapater): Adapter
+    {
+        return new class ($matchingAdapater) extends Adapter {
+            public function __construct(private Adapter $wrappedAdapter)
+            {
+            }
+
+            public function getAmountAvailable(CampaignFunding $funding): string
+            {
+                return $this->wrappedAdapter->getAmountAvailable($funding);
+            }
+
+            public function delete(CampaignFunding $funding): void
+            {
+                $this->wrappedAdapter->delete($funding);
+            }
+
+            protected function doRunTransactionally(callable $function)
+            {
+                // call to runTransactionally not doRunTransactionally because the wrappedAdapater has to know that its in a transaction.
+                return $this->wrappedAdapter->runTransactionally($function);
+            }
+
+            protected function doAddAmount(CampaignFunding $funding, string $amount): string
+            {
+                return $this->wrappedAdapter->doAddAmount($funding, $amount);
+            }
+
+            protected function doSubtractAmount(CampaignFunding $funding, string $amount): string
+            {
+                $this->wrappedAdapter->subtractAmount($funding, $amount);
+
+                throw new \Exception("Throwing after subtracting funds to test how our system handles the crash");
+            }
+        };
     }
 }

--- a/integrationTests/DonationMatchingTest.php
+++ b/integrationTests/DonationMatchingTest.php
@@ -10,6 +10,7 @@ use MatchBot\Domain\Campaign;
 use MatchBot\Domain\CampaignFunding;
 use MatchBot\Domain\CampaignFundingRepository;
 use Psr\Log\LoggerInterface;
+use Redis;
 
 class DonationMatchingTest extends \MatchBot\IntegrationTests\IntegrationTest
 {

--- a/integrationTests/DonationMatchingTest.php
+++ b/integrationTests/DonationMatchingTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use MatchBot\Application\Assertion;
+use MatchBot\Application\Matching\Adapter;
+use MatchBot\Domain\Campaign;
+use MatchBot\Domain\CampaignFundingRepository;
+
+class DonationMatchingTest extends \MatchBot\IntegrationTests\IntegrationTest
+{
+    private int $campaignFundingId;
+    private CampaignFundingRepository $campaignFundingRepository;
+    private Adapter $matchingAdapater;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setupFakeDonationClient();
+        $this->campaignFundingRepository = $this->getService(CampaignFundingRepository::class);
+        $this->matchingAdapater = $this->getService(Adapter::class);
+    }
+
+    public function testDonatingReducesAvailableMatchFunds(): void
+    {
+        // arrange
+        ['campaignFundingID' => $this->campaignFundingId, 'campaignId' => $campaignId] =
+            $this->addCampaignAndCharityToDB(campaignSfId: $this->randomString(), fundWithAmountInPounds: 100);
+
+        $campaign = $this->getService(\MatchBot\Domain\CampaignRepository::class)->find($campaignId);
+        Assertion::notNull($campaign);
+        $campaignFunding = $this->campaignFundingRepository->find($this->campaignFundingId);
+        Assertion::notNull($campaignFunding);
+
+        // act
+        $this->createDonation(
+            withPremadeCampaign: false,
+            campaignSfID: $campaign->getSalesforceId(),
+            amountInPounds: 10
+        );
+
+        // assert
+        $amountAvailable = $this->matchingAdapater->getAmountAvailable($campaignFunding);
+
+        $this->assertEquals(90, $amountAvailable); // 100 originally in fund - 10 matched to donation.
+    }
+}

--- a/integrationTests/StripeCancelsDonationTest.php
+++ b/integrationTests/StripeCancelsDonationTest.php
@@ -23,7 +23,7 @@ class StripeCancelsDonationTest extends IntegrationTest
          * @var array<string,string> $donation
          */
         $donation = json_decode(
-            (string)$this->createDonation()->getBody(),
+            (string)$this->createDonation(100)->getBody(),
             true,
             flags: JSON_THROW_ON_ERROR
         )['donation'];

--- a/src/Application/Matching/Adapter.php
+++ b/src/Application/Matching/Adapter.php
@@ -89,4 +89,10 @@ abstract class Adapter
 
         return $this->doSubtractAmount($funding, $amount);
     }
+
+    /**
+     * Only for use in case of a crash. Releases funds allocated by this adapter, i.e. this particular object instance,
+     * so just funds allocated within this particular HTTP request.
+     */
+    public abstract function releaseNewlyAllocatedFunds(): void;
 }


### PR DESCRIPTION
This PR makes matchbot keep track of donation funds allocated *within the current request* when creating a donation. In case the process of creating the donation crashes (e.g. because of a lock wait timeout that we can't recover from), the match funds reduced in redis will be automatically restored.