### PR TITLE
BG2-2297: Add erroring file and line number to error logs

### DIFF
--- a/src/Application/Handlers/HttpErrorHandler.php
+++ b/src/Application/Handlers/HttpErrorHandler.php
@@ -67,7 +67,7 @@ class HttpErrorHandler extends SlimErrorHandler
 
         if (!($this->exception instanceof HttpException)) {
             $this->logError(sprintf(
-                "%s: %s \n\n %s \n %s",
+                "%s: %s \n#\n %s \n %s",
                 get_class($this->exception),
                 $this->exception->getMessage(),
                 $this->exception->getFile() . ":" . $this->exception->getLine(),

--- a/src/Application/Handlers/HttpErrorHandler.php
+++ b/src/Application/Handlers/HttpErrorHandler.php
@@ -67,7 +67,7 @@ class HttpErrorHandler extends SlimErrorHandler
 
         if (!($this->exception instanceof HttpException)) {
             $this->logError(sprintf(
-                "%s: %s \n %s \n %s",
+                "%s: %s \n\n %s \n %s",
                 get_class($this->exception),
                 $this->exception->getMessage(),
                 $this->exception->getFile() . ":" . $this->exception->getLine(),

--- a/src/Application/Handlers/HttpErrorHandler.php
+++ b/src/Application/Handlers/HttpErrorHandler.php
@@ -67,9 +67,10 @@ class HttpErrorHandler extends SlimErrorHandler
 
         if (!($this->exception instanceof HttpException)) {
             $this->logError(sprintf(
-                '%s: %s - %s',
+                "%s: %s \n %s \n %s",
                 get_class($this->exception),
                 $this->exception->getMessage(),
+                $this->exception->getFile() . ":" . $this->exception->getLine(),
                 $this->exception->getTraceAsString(),
             ));
         }


### PR DESCRIPTION
`getTraceAsString` only gives us all the *previous* stack frames before the one that actually has the `throw` statement. Using `getFile` and `getLine` will tell us exactly where the throw expression is that threw the exception.