### PR TITLE
MAT-306: Add 30 second delay to let Stripe update balance before send…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
         "stripe/stripe-php": "^9.1.0",
         "symfony/amazon-sqs-messenger": "^6.0",
         "symfony/cache": "^6.0",
+        "symfony/clock": "^6.3",
         "symfony/console": "^6.0",
         "symfony/event-dispatcher": "^6.0",
         "symfony/lock": "^6.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "86e62aff9a3d955f4c618462dbc27a62",
+    "content-hash": "b1aaf5beb6f2dd29d0d1026f5efbe6d2",
     "packages": [
         {
             "name": "async-aws/core",
@@ -2746,6 +2746,54 @@
             "time": "2021-02-03T23:26:27+00:00"
         },
         {
+            "name": "psr/clock",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/clock.git",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/clock/zipball/e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Clock\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for reading the clock.",
+            "homepage": "https://github.com/php-fig/clock",
+            "keywords": [
+                "clock",
+                "now",
+                "psr",
+                "psr-20",
+                "time"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/clock/issues",
+                "source": "https://github.com/php-fig/clock/tree/1.0.0"
+            },
+            "time": "2022-11-25T14:36:26+00:00"
+        },
+        {
             "name": "psr/container",
             "version": "1.1.2",
             "source": {
@@ -4034,6 +4082,79 @@
                 }
             ],
             "time": "2022-11-25T10:21:52+00:00"
+        },
+        {
+            "name": "symfony/clock",
+            "version": "v6.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/clock.git",
+                "reference": "a74086d3db70d0f06ffd84480daa556248706e98"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/clock/zipball/a74086d3db70d0f06ffd84480daa556248706e98",
+                "reference": "a74086d3db70d0f06ffd84480daa556248706e98",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/clock": "^1.0"
+            },
+            "provide": {
+                "psr/clock-implementation": "1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/now.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\Clock\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Decouples applications from the system clock",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "clock",
+                "psr20",
+                "time"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/clock/tree/v6.3.4"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-07-31T11:35:03+00:00"
         },
         {
             "name": "symfony/console",

--- a/src/Application/Actions/Hooks/StripePaymentsUpdate.php
+++ b/src/Application/Actions/Hooks/StripePaymentsUpdate.php
@@ -479,7 +479,6 @@ class StripePaymentsUpdate extends Stripe
         $donorAccount = $this->donorAccountRepository->findByStripeIdOrNull($stripeAccountId);
         $currency = Currency::fromIsoCode($webhookObject['currency']);
         $transferAmount = Money::fromPence($webhookObject['net_amount'], $currency);
-        $endingBalance = Money::fromPence($webhookObject['ending_balance'], $currency);
 
         $app_env = getenv('APP_ENV');
         if ($donorAccount === null) {
@@ -495,16 +494,7 @@ class StripePaymentsUpdate extends Stripe
             return $this->respond($response, new ActionPayload(200));
         }
 
-        $this->donationFundsNotifier->notifyRecieptOfAccountFunds($donorAccount, $transferAmount, $endingBalance);
-
-        $donorAccountId = $donorAccount->getId();
-        \assert(is_int($donorAccountId)); // must be an int since it was persisted before.
-        $this->logger->info(
-            'Sent notification of receipt of account funds for Stripe Account: ' . $stripeAccountId->stripeCustomerId .
-            ", transfer Amount" . $transferAmount->format() .
-            ", new balance" . $endingBalance->format() .
-            ", DonorAccount #" . $donorAccountId
-        );
+        $this->donationFundsNotifier->notifyRecieptOfAccountFunds($donorAccount, $transferAmount);
 
         return $this->respond($response, new ActionPayload(200));
     }

--- a/src/Client/Stripe.php
+++ b/src/Client/Stripe.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace MatchBot\Client;
+
+use MatchBot\Domain\Currency;
+use MatchBot\Domain\Money;
+use MatchBot\Domain\StripeCustomerId;
+use Stripe\StripeClient;
+
+class Stripe
+{
+    public function __construct(private StripeClient $stripeClient)
+    {
+    }
+
+    public function fetchBalance(StripeCustomerId $stripeCustomerId, Currency $currency): Money
+    {
+        $stripeCustomer = $this->stripeClient->customers->retrieve($stripeCustomerId->stripeCustomerId, [
+            'expand' => ['cash_balance'],
+        ]);
+
+        $balanceIsApplicable = (
+            property_exists($stripeCustomer, 'cash_balance') && $stripeCustomer->cash_balance &&
+            $stripeCustomer->cash_balance->available !== null &&
+            $stripeCustomer->cash_balance->settings->reconciliation_mode === 'automatic'
+        );
+
+        if ($balanceIsApplicable) {
+            /** @var array<string, int> $allBalances */
+            $allBalances = $stripeCustomer->cash_balance->available->toArray();
+            foreach ($allBalances as $currencyCode => $balance) {
+                if (strtoupper($currencyCode) === $currency->isoCode()) {
+                    return Money::fromPence($balance, $currency);
+                }
+            }
+        }
+
+        return Money::fromPence(0, $currency);
+    }
+}

--- a/src/Domain/Currency.php
+++ b/src/Domain/Currency.php
@@ -27,4 +27,13 @@ enum Currency
             self::GBP => '£',
         };
     }
+
+    /**
+     * @return string 3 Letter upper case ISO code, e.g. 'GBP'
+     */
+    public function isoCode(): string{
+        return match ($this) {
+            self::GBP => 'GBP',
+        };
+    }
 }

--- a/src/Domain/DonationFundsNotifier.php
+++ b/src/Domain/DonationFundsNotifier.php
@@ -3,23 +3,57 @@
 namespace MatchBot\Domain;
 
 use MatchBot\Client\Mailer;
+use MatchBot\Client\Stripe;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Clock\Clock;
+use Symfony\Component\Clock\ClockInterface;
 
 class DonationFundsNotifier
 {
-    public function __construct(private Mailer $mailer)
+    public function __construct(private Mailer $mailer, private Stripe $stripe, private ClockInterface $clock, private LoggerInterface $logger)
     {
     }
 
-    public function notifyRecieptOfAccountFunds(DonorAccount $donorAccount, Money $transferAmount, Money $newBalance): void
+    public function notifyRecieptOfAccountFunds(DonorAccount $donorAccount, Money $transferAmount): void
     {
+        $stripeAccountId = $donorAccount->stripeCustomerId;
+
+        $this->waitForAnyTipToBeAutomaticallyPaidOut();
+        $balance = $this->stripe->fetchBalance($stripeAccountId, $transferAmount->currency);
+
         $this->mailer->sendEmail([
             'templateKey' => 'donor-funds-thanks',
             'recipientEmailAddress' => $donorAccount->emailAddress->email,
             'params' => [
                 'donorFirstName' => $donorAccount->donorName->first,
                 'transferAmount' => $transferAmount->format(),
-                'newBalance' => $newBalance->format(),
+                'newBalance' => $balance->format(),
             ],
         ]);
+
+        $id = $donorAccount->getId();
+        \assert($id !== null);
+
+        $this->logger->info(
+            'Sent notification of receipt of account funds for Stripe Account: ' . $stripeAccountId->stripeCustomerId .
+            ", transfer Amount" . $transferAmount->format() .
+            ", new balance" . $balance->format() .
+            ", DonorAccount #" . $id
+        );
+    }
+
+    /**
+     * A donor may have chosen to give us a tip when setting up their donation funds account. If it was a new account,
+     * or an existing account but without sufficient fudns to complete that donation to us, then the donation would
+     * not be taken out of their balance until they had enough available funds to cover it. As we know they just now
+     * made a bank transfer to their account that time is likely to be now, so we wait for that donation to
+     * complete to get an up-to-date account balance.
+     *
+     * Otherwise, we would tell them that they have x amount available, and then they would look at their account
+     * seconds later and see that there is only x minus tip amount available, which could be confusing.
+     */
+    private function waitForAnyTipToBeAutomaticallyPaidOut(): void
+    {
+        $this->clock->sleep(seconds: 30);
     }
 }

--- a/src/Domain/Money.php
+++ b/src/Domain/Money.php
@@ -16,7 +16,7 @@ class Money
      */
     private function __construct(
         private readonly int $amountInPence,
-        private readonly Currency $currency
+        public readonly Currency $currency
     ) {
         Assertion::between(
             $this->amountInPence,

--- a/tests/Domain/DonationFundsNotifierTest.php
+++ b/tests/Domain/DonationFundsNotifierTest.php
@@ -3,6 +3,7 @@
 namespace MatchBot\Tests\Domain;
 
 use MatchBot\Client\Mailer;
+use MatchBot\Client\Stripe;
 use MatchBot\Domain\Currency;
 use MatchBot\Domain\DonationFundsNotifier;
 use MatchBot\Domain\DonorAccount;
@@ -13,25 +14,57 @@ use MatchBot\Domain\StripeCustomerId;
 use MatchBot\Tests\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Psr\Log\NullLogger;
+use Symfony\Component\Clock\ClockInterface;
 
 class DonationFundsNotifierTest extends TestCase
 {
     use ProphecyTrait;
 
+    private Money $currentDonorBalance;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->currentDonorBalance = Money::fromPence(17_000_00, Currency::GBP);
+    }
+
     public function testItSendsAnEmailAboutNewDonationFunds(): void
     {
         //arrange
+        $stripeCustomerId = StripeCustomerId::of('cus_1234');
+
         $donorAccount = new DonorAccount(
             EmailAddress::of('foo@example.com'),
             DonorName::of('Fred', 'Brooks'),
-            StripeCustomerId::of('cus_1234'), // this one doesn't matter for the test.
+            $stripeCustomerId,
         );
+        $donorAccount->setId(1); // required for logging.
 
         $transferAmount = Money::fromPence(52_35, Currency::GBP);
-        $newBalance = Money::fromPence(17_000_00, Currency::GBP);
 
         $mailerProphecy = $this->prophesize(Mailer::class);
-        $sut = new DonationFundsNotifier($mailerProphecy->reveal());
+        $stripeProphecy = $this->prophesize(Stripe::class);
+        $clockProphecy = $this->prophesize(ClockInterface::class);
+
+        // we can't use $this inside closures as Prophecy rebinds the closures to the test doubles.
+        $testObject = $this;
+        $stripeProphecy->fetchBalance($stripeCustomerId, Currency::GBP)->will(function () use ($testObject) {
+            return $testObject->currentDonorBalance;
+        });
+
+        $sut = new DonationFundsNotifier(
+            mailer: $mailerProphecy->reveal(),
+            stripe: $stripeProphecy->reveal(),
+            clock: $clockProphecy->reveal(),
+            logger: new NullLogger(),
+        );
+
+        $clockProphecy->sleep(seconds: 30)->will(function () use ($testObject) {
+            // suppose that during this 30 seconds Stripe automatically deducts 2k from their account as they
+            // had a pending tip to Big Give of 2k and it can now be completed.
+            $testObject->currentDonorBalance = Money::fromPence(15_000_00, Currency::GBP);
+        });
 
         // assert
         $mailerProphecy->sendEmail([
@@ -40,11 +73,11 @@ class DonationFundsNotifierTest extends TestCase
             'params' => [
                 'donorFirstName' => 'Fred',
                 'transferAmount' => "£52.35",
-                'newBalance' => "£17,000.00",
+                'newBalance' => "£15,000.00",
             ],
         ])->shouldBeCalledOnce();
 
         //act
-        $sut->notifyRecieptOfAccountFunds($donorAccount, $transferAmount, $newBalance);
+        $sut->notifyRecieptOfAccountFunds($donorAccount, $transferAmount);
     }
 }


### PR DESCRIPTION
…ing email notification of transferred funds

This may look like a lot of code just to add a 30 second delay. But it's more complicated than that because:

- It's not simply adding a delay before work we were already doing. Currently stripe sends us the transfer amount and the new balance together, and we use both. Now we have to ignore the balance stripe sends us initially, and query stripe for a balance after the delay.
- We definitely don't want to have a real 30 second delay every time we run the automated tests. There are hundreds of tests and we want to run them many times a day so we can't afford even one second per test. Therefore the code that actually does the delay has to be separated from the code we test.