### PR TITLE
MAT-306: Allow money to be zero

### DIFF
--- a/src/Domain/Money.php
+++ b/src/Domain/Money.php
@@ -20,7 +20,7 @@ class Money
     ) {
         Assertion::between(
             $this->amountInPence,
-            1,
+            0,
             20_000_000_00 // this is nearly PHP_INT_MAX on 32 bit systems.
         );
     }


### PR DESCRIPTION
Now that we're using this for balances as well as transfers it's reasonable for it to be zero sometimes.