### PR TITLE
DON-820: Reject attempt to confirm funds donation payment does not im…

### DIFF
--- a/tests/Application/Actions/Donations/UpdateTest.php
+++ b/tests/Application/Actions/Donations/UpdateTest.php
@@ -1890,6 +1890,8 @@ class UpdateTest extends TestCase
      * @throws \MatchBot\Application\Matching\TerminalLockException
      * @throws \MatchBot\Domain\DomainException\DomainLockContentionException
      * @throws \Stripe\Exception\ApiErrorException
+     *
+     * @psalm-param PaymentIntent::STATUS_* $newPaymentIntentStatus
      */
     public function setupTestDoublesForConfirmingPaymentFromDonationFunds(string $newPaymentIntentStatus): array
     {

--- a/tests/Application/Actions/Donations/UpdateTest.php
+++ b/tests/Application/Actions/Donations/UpdateTest.php
@@ -1635,7 +1635,7 @@ class UpdateTest extends TestCase
     public function testAddDataSuccessWithCashBalanceAutoconfirm(): void
     {
         ['app' => $app, 'request' => $request, 'route' => $route, 'donationRepoProphecy' => $donationRepoProphecy, 'entityManagerProphecy' => $entityManagerProphecy] =
-            $this->setupTestDoublesForConfirmingPaymentFromDonationFunds(newPayemtnIntentStatus: PaymentIntent::STATUS_SUCCEEDED);
+            $this->setupTestDoublesForConfirmingPaymentFromDonationFunds(newPaymentIntentStatus: PaymentIntent::STATUS_SUCCEEDED);
 
         $donationRepoProphecy
             ->push(Argument::type(Donation::class), false)
@@ -1661,7 +1661,7 @@ class UpdateTest extends TestCase
     public function testAddDataFailsWithCashBalanceAutoconfirmForDonorWithInsufficentFunds(): void
     {
         ['app' => $app, 'request' => $request, 'route' => $route, 'stripePaymentIntentsProphecy' => $paymentIntentsProphecy, 'entityManagerProphecy' => $entityManagerProphecy] =
-            $this->setupTestDoublesForConfirmingPaymentFromDonationFunds(newPayemtnIntentStatus: PaymentIntent::STATUS_PROCESSING);
+            $this->setupTestDoublesForConfirmingPaymentFromDonationFunds(newPaymentIntentStatus: PaymentIntent::STATUS_PROCESSING);
         try {
             $app->handle($request->withAttribute('route', $route));
             $this->fail("attempt to confirm donation with insufficent funds should have thrown");
@@ -1891,7 +1891,7 @@ class UpdateTest extends TestCase
      * @throws \MatchBot\Domain\DomainException\DomainLockContentionException
      * @throws \Stripe\Exception\ApiErrorException
      */
-    public function setupTestDoublesForConfirmingPaymentFromDonationFunds(string $newPayemtnIntentStatus): array
+    public function setupTestDoublesForConfirmingPaymentFromDonationFunds(string $newPaymentIntentStatus): array
     {
         $app = $this->getAppInstance();
         /** @var Container $container */
@@ -1922,7 +1922,7 @@ class UpdateTest extends TestCase
         $stripePaymentIntentsProphecy->update('pi_externalId_123', Argument::type('array'))
             ->shouldBeCalledOnce();
         $updatedPaymentIntent = new PaymentIntent('pi_externalId_123');
-        $updatedPaymentIntent->status = $newPayemtnIntentStatus;
+        $updatedPaymentIntent->status = $newPaymentIntentStatus;
         $stripePaymentIntentsProphecy->confirm('pi_externalId_123')
             ->shouldBeCalledOnce()
             ->willReturn($updatedPaymentIntent);


### PR DESCRIPTION
…ediatly succeed

We only want to accept a donation from donor funds if the donor already has enough funds in their account, in which case the payment should succeed immediately.

I missed my chance to take a screenshot but I did test manually with real frontend making two donations in two tabs from each using 1k of a 1k donation fund account. The first donation went through as normal, and the second donation resulted in a spinner spinning for a long time on the donation start page and the error message asking the donor to refresh to see their updated balance. Checking in stripe showed that one of the payment intents was cancelled.