### PR TITLE
Fix Error: Typed property MatchBot\Domain\SalesforceProxyRepository::…

### DIFF
--- a/src/Application/Actions/Donations/Create.php
+++ b/src/Application/Actions/Donations/Create.php
@@ -16,7 +16,6 @@ use MatchBot\Application\Auth\PersonWithPasswordAuthMiddleware;
 use MatchBot\Application\HttpModels\DonationCreate;
 use MatchBot\Application\HttpModels\DonationCreatedResponse;
 use MatchBot\Application\Matching\Adapter;
-use MatchBot\Domain\Campaign;
 use MatchBot\Domain\CampaignRepository;
 use MatchBot\Domain\Charity;
 use MatchBot\Domain\DomainException\DomainLockContentionException;
@@ -35,6 +34,7 @@ class Create extends Action
     #[Pure]
     public function __construct(
         private DonationRepository $donationRepository,
+        private CampaignRepository $campaignRepository,
         private EntityManagerInterface $entityManager,
         private SerializerInterface $serializer,
         private StripeClient $stripeClient,
@@ -149,9 +149,7 @@ class Create extends Action
         if ($donation->getPsp() === 'stripe') {
             if (empty($donation->getCampaign()->getCharity()->getStripeAccountId())) {
                 // Try re-pulling in case charity has very recently onboarded with for Stripe.
-                $repository = $this->entityManager->getRepository(Campaign::class);
-                \assert($repository instanceof CampaignRepository);
-                $campaign = $repository
+                $campaign = $this->campaignRepository
                     ->pull($donation->getCampaign());
 
                 // If still empty, error out

--- a/src/Domain/SalesforceProxyRepository.php
+++ b/src/Domain/SalesforceProxyRepository.php
@@ -18,35 +18,17 @@ use Psr\Log\LoggerInterface;
 
     protected function logError(string $message): void
     {
-        if ($log = $this->getLogger()) {
-            $log->error($message);
-            return;
-        }
-
-        // Fallback if logger not configured
-        echo "ERROR: $message";
+        $this->logger->error($message);
     }
 
     protected function logWarning(string $message): void
     {
-        if ($log = $this->getLogger()) {
-            $log->warning($message);
-            return;
-        }
-
-        // Fallback if logged not configured
-        echo "WARNING: $message";
+        $this->logger->warning($message);
     }
 
     protected function logInfo(string $message): void
     {
-        if ($log = $this->getLogger()) {
-            $log->info($message);
-            return;
-        }
-
-        // Fallback if logger not configured
-        echo "INFO: $message";
+        $this->logger->info($message);
     }
 
     public function setClient(Client\Common $client): void
@@ -66,10 +48,5 @@ use Psr\Log\LoggerInterface;
         }
 
         return $this->client;
-    }
-
-    protected function getLogger(): ?LoggerInterface
-    {
-        return $this->logger;
     }
 }

--- a/tests/Application/Actions/Donations/CreateTest.php
+++ b/tests/Application/Actions/Donations/CreateTest.php
@@ -28,6 +28,19 @@ use UnexpectedValueException;
 
 class CreateTest extends TestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $app = $this->getAppInstance();
+
+        /** @var Container $container */
+        $container = $app->getContainer();
+
+        $campaignRepositoryProphecy = $this->prophesize(CampaignRepository::class);
+        $container->set(CampaignRepository::class, $campaignRepositoryProphecy->reveal());
+    }
+
     /**
      * While we don't test it separately, we now expect invalid `paymentMethodType` to be caught by the
      * same condition, as the property is now an enum.
@@ -152,9 +165,8 @@ class CreateTest extends TestCase
             ->shouldBeCalledOnce();
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
-        $entityManagerProphecy->getRepository(Campaign::class)
-            ->willReturn($campaignRepoProphecy->reveal())
-            ->shouldBeCalledOnce();
+        $container->set(CampaignRepository::class, $campaignRepoProphecy->reveal());
+
         $entityManagerProphecy->persist(Argument::type(Donation::class))->shouldBeCalledOnce();
         $entityManagerProphecy->flush()->shouldBeCalledOnce();
 
@@ -296,9 +308,7 @@ class CreateTest extends TestCase
             ->shouldBeCalledOnce();
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
-        $entityManagerProphecy->getRepository(Campaign::class)
-            ->willReturn($campaignRepoProphecy->reveal())
-            ->shouldBeCalledOnce();
+        $container->set(CampaignRepository::class, $campaignRepoProphecy->reveal());
         // These are called once after initial ID setup and once after Stripe fields added.
         $entityManagerProphecy->persist(Argument::type(Donation::class))->shouldBeCalledTimes(2);
         $entityManagerProphecy->flush()->shouldBeCalledTimes(2);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -28,11 +28,21 @@ class TestCase extends PHPUnitTestCase
     use ProphecyTrait;
 
     /**
+     * @var array<0|1, ?App> array of app instances with and without real redis. Each one may be initialised up to once per test.
+     */
+    private array $appInstance = [0 => null, 1 => null];
+
+    /**
      * @return App
      * @throws Exception
      */
     protected function getAppInstance(bool $withRealRedis = false): App
     {
+        $memoizedInstance = $this->appInstance[(int)$withRealRedis];
+        if ($memoizedInstance) {
+            return $memoizedInstance;
+        }
+
         // Instantiate PHP-DI ContainerBuilder
         $containerBuilder = new ContainerBuilder();
 
@@ -92,6 +102,7 @@ class TestCase extends PHPUnitTestCase
         $routes($app);
 
         $app->addRoutingMiddleware();
+        $this->appInstance[(int) $withRealRedis] = $app;
 
         return $app;
     }


### PR DESCRIPTION
…$logger must not be accessed before initialization

The EntityManager does not set the logger in repositories, so when we need a repository we have to take it from the DI container which does inject the logger, not the EM.