### PR TITLE
Revert "Only bypass stripe if BYPASS_PSP is 'true' (not 'false')"

### DIFF
--- a/src/Application/PSPStubber.php
+++ b/src/Application/PSPStubber.php
@@ -15,7 +15,7 @@ class PSPStubber
      */
     public static function byPassStripe(): bool
     {
-        return getenv('APP_ENV') !== 'production' && getenv('BYPASS_PSP') === 'true';
+        return getenv('APP_ENV') !== 'production' && getenv('BYPASS_PSP');
     }
 
     public static function randomString(): string


### PR DESCRIPTION
Reverts thebiggive/matchbot#669

We are using '1', and '0', not 'true' and 'false'.