### PR TITLE
MAT-326: Stop using Roave/infection-static-analysis-plugin, use infec…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ jobs:
     # Working directory must match docker-compose mount / Docker `COPY` for real Doctrine proxy
     # generation-dependent tests to work.
     working_directory: /var/www/html
+    resource_class: large
     docker:
       - image: thebiggive/php:dev-8.1
         auth:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,6 +147,7 @@ workflows:
                 - develop
                 - main
                 - MAT-326-automated-test-suite
+                - MAT-326-no-plugin
 
   deploy-regression:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,13 +135,6 @@ workflows:
             - docker-hub-creds
           requires:
             - test
-          filters:
-            branches:
-              only:
-                - develop
-                - main
-                - MAT-326-automated-test-suite
-                - MAT-326-no-plugin
 
   deploy-regression:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,14 +111,6 @@ jobs:
             - vendor
           key: composer-v1-{{ checksum "composer.lock" }}
 
-      - run: composer run lint:check
-
-      - run: composer run sa:check
-
-      - run: composer run test
-
-      - run: vendor/bin/doctrine-migrations migrate --no-interaction --allow-no-migration --verbose
-
       - run: composer run mutation-test
 
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,7 @@ jobs:
           file: 'coverage-integration.xml'
 
   mutation_coverage:
+    resource_class: large
     working_directory: /var/www/html
     docker:
       - image: thebiggive/php:dev-8.1

--- a/composer.json
+++ b/composer.json
@@ -99,7 +99,7 @@
         "doctrine:migrate:diff": ["@doctrine:cache:clear", "doctrine-migrations diff"],
         "doctrine:migrate:generate": "doctrine-migrations generate",
         "doctrine:validate": ["@doctrine:cache:clear", "doctrine orm:validate-schema"],
-        "sa:check": "vendor/bin/psalm",
+        "sa:check": "vendor/bin/psalm --threads=4",
         "sa:check-with-new-cache": "vendor/bin/psalm --clear-cache; vendor/bin/psalm",
         "lint:check": "phpcs --standard=phpcs.xml -s .",
         "lint:fix": "phpcbf --standard=phpcs.xml -s .",

--- a/composer.json
+++ b/composer.json
@@ -51,11 +51,11 @@
         "thebiggive/messages": "^3.0"
     },
     "require-dev": {
+        "infection/infection": "^0.27.8",
         "jetbrains/phpstorm-attributes": "^1.0",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^9.5",
         "psalm/plugin-phpunit": "^0.18.4",
-        "roave/infection-static-analysis-plugin": "^1.33",
         "roave/security-advisories": "dev-latest",
         "squizlabs/php_codesniffer": "^3.6",
         "vimeo/psalm": "^5.14.0",
@@ -162,7 +162,7 @@
         "integration-test": "XDEBUG_MODE=coverage phpunit --config=phpunit-integration.xml --order-by=random",
         "mutation-test": [
             "Composer\\Config::disableProcessTimeout",
-            "vendor/bin/roave-infection-static-analysis-plugin --psalm-config psalm.xml"
+            "vendor/bin/infection"
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -162,7 +162,7 @@
         "integration-test": "XDEBUG_MODE=coverage phpunit --config=phpunit-integration.xml --order-by=random",
         "mutation-test": [
             "Composer\\Config::disableProcessTimeout",
-            "vendor/bin/infection"
+            "vendor/bin/infection --threads=4"
         ]
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7073990f77d26537e00e1bc95ef4e61f",
+    "content-hash": "0ff803b8de761496e695e1d6bdec3d61",
     "packages": [
         {
             "name": "async-aws/core",
@@ -7272,16 +7272,16 @@
         },
         {
             "name": "infection/infection",
-            "version": "0.27.0",
+            "version": "0.27.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/infection/infection.git",
-                "reference": "a9ff8171577d98b887d7f16428edd81ff69ce887"
+                "reference": "673ce762abf3355fcdc186ca17eb89edf86993bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/infection/infection/zipball/a9ff8171577d98b887d7f16428edd81ff69ce887",
-                "reference": "a9ff8171577d98b887d7f16428edd81ff69ce887",
+                "url": "https://api.github.com/repos/infection/infection/zipball/673ce762abf3355fcdc186ca17eb89edf86993bf",
+                "reference": "673ce762abf3355fcdc186ca17eb89edf86993bf",
                 "shasum": ""
             },
             "require": {
@@ -7292,7 +7292,7 @@
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
-                "fidry/cpu-core-counter": "^0.4.0 || ^0.5.0",
+                "fidry/cpu-core-counter": "^0.4.0 || ^0.5.0 || ^1.0",
                 "infection/abstract-testframework-adapter": "^0.5.0",
                 "infection/extension-installer": "^0.1.0",
                 "infection/include-interceptor": "^0.2.5",
@@ -7303,10 +7303,10 @@
                 "sanmai/later": "^0.1.1",
                 "sanmai/pipeline": "^5.1 || ^6",
                 "sebastian/diff": "^3.0.2 || ^4.0 || ^5.0",
-                "symfony/console": "^5.4 || ^6.0",
-                "symfony/filesystem": "^5.4 || ^6.0",
-                "symfony/finder": "^5.4 || ^6.0",
-                "symfony/process": "^5.4 || ^6.0",
+                "symfony/console": "^5.4 || ^6.0 || ^7.0",
+                "symfony/filesystem": "^5.4 || ^6.0 || ^7.0",
+                "symfony/finder": "^5.4 || ^6.0 || ^7.0",
+                "symfony/process": "^5.4 || ^6.0 || ^7.0",
                 "thecodingmachine/safe": "^2.1.2",
                 "webmozart/assert": "^1.11"
             },
@@ -7316,7 +7316,7 @@
                 "phpunit/php-code-coverage": ">9,<9.1.4 || >9.2.17,<9.2.21"
             },
             "require-dev": {
-                "brianium/paratest": "^6.3",
+                "brianium/paratest": "^6.11",
                 "ext-simplexml": "*",
                 "fidry/makefile": "^0.2.0",
                 "helmich/phpunit-json-assert": "^3.0",
@@ -7327,11 +7327,11 @@
                 "phpstan/phpstan-phpunit": "^1.0.0",
                 "phpstan/phpstan-strict-rules": "^1.1.0",
                 "phpstan/phpstan-webmozart-assert": "^1.0.2",
-                "phpunit/phpunit": "^9.5.5",
+                "phpunit/phpunit": "^9.6",
                 "rector/rector": "^0.16.0",
-                "sidz/phpstan-rules": "^0.2.1",
-                "symfony/phpunit-bridge": "^5.4 || ^6.0",
-                "symfony/yaml": "^5.4 || ^6.0",
+                "sidz/phpstan-rules": "^0.4.0",
+                "symfony/phpunit-bridge": "^5.4 || ^6.0 || ^7.0",
+                "symfony/yaml": "^5.4 || ^6.0 || ^7.0",
                 "thecodingmachine/phpstan-safe-rule": "^1.2.0"
             },
             "bin": [
@@ -7388,7 +7388,7 @@
             ],
             "support": {
                 "issues": "https://github.com/infection/infection/issues",
-                "source": "https://github.com/infection/infection/tree/0.27.0"
+                "source": "https://github.com/infection/infection/tree/0.27.8"
             },
             "funding": [
                 {
@@ -7400,7 +7400,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2023-05-16T05:28:04+00:00"
+            "time": "2023-11-08T14:29:03+00:00"
         },
         {
             "name": "jetbrains/phpstorm-attributes",
@@ -8685,57 +8685,6 @@
                 "source": "https://github.com/psalm/psalm-plugin-phpunit/tree/0.18.4"
             },
             "time": "2022-12-03T07:47:07+00:00"
-        },
-        {
-            "name": "roave/infection-static-analysis-plugin",
-            "version": "1.33.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Roave/infection-static-analysis-plugin.git",
-                "reference": "3dd4ea3d5c4b380bb426c8b943328796a5664587"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Roave/infection-static-analysis-plugin/zipball/3dd4ea3d5c4b380bb426c8b943328796a5664587",
-                "reference": "3dd4ea3d5c4b380bb426c8b943328796a5664587",
-                "shasum": ""
-            },
-            "require": {
-                "composer-runtime-api": "^2.2",
-                "infection/infection": "0.27.0",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
-                "sanmai/later": "^0.1.2",
-                "vimeo/psalm": "^4.30.0 || ^5.15"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^12.0.0",
-                "phpunit/phpunit": "^10.3.4"
-            },
-            "bin": [
-                "bin/roave-infection-static-analysis-plugin"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Roave\\InfectionStaticAnalysis\\": "src/Roave/InfectionStaticAnalysis"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com"
-                }
-            ],
-            "description": "Static analysis on top of mutation testing - prevents escaped mutants from being invalid according to static analysis",
-            "support": {
-                "issues": "https://github.com/Roave/infection-static-analysis-plugin/issues",
-                "source": "https://github.com/Roave/infection-static-analysis-plugin/tree/1.33.0"
-            },
-            "time": "2023-09-15T10:43:53+00:00"
         },
         {
             "name": "roave/security-advisories",

--- a/infection.json5
+++ b/infection.json5
@@ -3,6 +3,9 @@
     "source": {
         "directories": [
             "src"
+        ],
+        "excludes": [
+            "Migrations"
         ]
     },
     "mutators": {


### PR DESCRIPTION
…tion/infection directly instead

I have realised that the Roave plugin is massively overinflating our MSI, making our tests look better than they are, because it thinks Psalm is mutated code when its really just just reporting an issue that already exists in our baseline file.

Infection reports:

Before:
![image](https://github.com/thebiggive/matchbot/assets/159481/ec21bc2c-dfa4-4d01-8b26-90f48c7ffdfa)
https://output.circle-artifacts.com/output/job/29553382-ff6b-4072-992c-614341d5cef8/artifacts/0/reports/infection.html#mutant

----

After:
![image](https://github.com/thebiggive/matchbot/assets/159481/6190479c-6ba3-422e-be93-60fb1c028c36)
https://output.circle-artifacts.com/output/job/50d5d293-e0cc-4ec8-b4bc-f4b50033d1ba/artifacts/0/reports/infection.html#mutant