### PR TITLE
MAT-331: Increase scope for patching incorrect donation data

### DIFF
--- a/src/Application/Commands/PatchHistoricNonDefaultFeeDonations.php
+++ b/src/Application/Commands/PatchHistoricNonDefaultFeeDonations.php
@@ -37,7 +37,7 @@ class PatchHistoricNonDefaultFeeDonations extends Command
                              WHERE donationStatus in ('Paid', 'Collected')
                                  AND paymentMethodType = 'card'
                                  AND createdAt > '2023-09-22' -- commit 5860113 of this date introduced buggy confirm function
-                                 AND createdAt < '2023-11-20' -- hopefully the bug will have been fixed before that date.
+                                 AND createdAt < '2023-11-23' -- hopefully the bug will have been fixed before that date.
                                  AND id > :idOfLastDonationPatched 
                                  ORDER BY id
                                  LIMIT 500",


### PR DESCRIPTION
The bugfix for new donations is not yet deployed, so we'll need the patch script to include donations created today and up until the point we fully deploy the bugfix. Hoping that will be before Thursday.

Having the scope extend a little beyond the time the fix is deployed is not a problem.