### PR TITLE
Mat 326 unit test calculator

### DIFF
--- a/tests/Application/Fees/CalculatorTest.php
+++ b/tests/Application/Fees/CalculatorTest.php
@@ -57,7 +57,7 @@ class CalculatorTest extends TestCase
             'visa',
             'GB',
             '123',
-            'GBP', // Comes from Donation so input is uppercase although Stripe is lowercase internally.
+            'GbP', // Case doesn't matter for calculator
             false,
             5, // 5% fee inc. 20% VAT.
         );
@@ -107,7 +107,7 @@ class CalculatorTest extends TestCase
             'visa',
             'GB',
             '123',
-            'SEK', // Comes from Donation so input is uppercase although Stripe is lowercase internally.
+            'sek',
             false,
         );
 

--- a/tests/Application/Fees/CalculatorTest.php
+++ b/tests/Application/Fees/CalculatorTest.php
@@ -67,6 +67,24 @@ class CalculatorTest extends TestCase
         $this->assertEquals('1.02', $calculator->getFeeVat());
     }
 
+    public function testStripeUKCardEURDonationWithFeeCover(): void
+    {
+        $calculator = new Calculator(
+            $this->settingsWithVAT(),
+            'stripe',
+            'visa',
+            'GB',
+            '123',
+            'EUR',
+            false,
+            5, // 5% fee inc. 20% VAT.
+        );
+
+        // £6.15 fee covered, inc. VAT
+        $this->assertEquals('5.13', $calculator->getCoreFee());
+        $this->assertEquals('1.02', $calculator->getFeeVat());
+    }
+
     public function testStripeUSCardGBPDonation(): void
     {
         $calculator = new Calculator(

--- a/tests/Application/Fees/CalculatorTest.php
+++ b/tests/Application/Fees/CalculatorTest.php
@@ -188,8 +188,9 @@ class CalculatorTest extends TestCase
         $settingsFunction = require __DIR__ . '/../../../app/settings.php';
         $settingsFunction($builder);
 
-        $container = $builder->build();
+        $settings = $builder->build()->get('settings');
+        \assert(is_array($settings));
 
-        return $container->get('settings');
+        return $settings;
     }
 }

--- a/tests/Application/Fees/CalculatorTest.php
+++ b/tests/Application/Fees/CalculatorTest.php
@@ -193,4 +193,20 @@ class CalculatorTest extends TestCase
 
         return $settings;
     }
+
+    public function testItRejectsUnexpectedCardBrand(): void
+    {
+        $this->expectExceptionMessage("Unexpected card brand, expected brands are amex, diners, discover, eftpos_au, jcb, mastercard, unionpay, visa, unknown");
+
+        new Calculator(
+            $this->settingsWithVAT(),
+            'stripe',
+            'Card brand that doesnt exist',
+            'GB',
+            '1',
+            'GBP',
+            false,
+        );
+    }
+
 }


### PR DESCRIPTION
Before: https://output.circle-artifacts.com/output/job/4fc0ad64-f1e6-46d9-82f2-556a44616a33/artifacts/0/reports/infection.html#mutant/Application/Fees/Calculator.php

After: https://output.circle-artifacts.com/output/job/53448e1d-41d9-4bb4-a36d-e7dd796178ad/artifacts/0/reports/infection.html#mutant/Application/Fees/Calculator.php

Not as dramatic an increase in mutation score as I'd like - had a bit of trouble seeing how to kill the `BCMath` mutants which is most of them, and thought it's maybe not that important.

Also would like to simplify the class so it needs less tests instead of just adding tests, which we could do by making the settings hard-coded instead of having it pull in settings and also avoid using the environment variables. But that's probably something for outside of the code slush time if we do it.