### PR TITLE
Mat 326: More tests for Donation class

### DIFF
--- a/tests/Domain/DonationTest.php
+++ b/tests/Domain/DonationTest.php
@@ -423,7 +423,7 @@ class DonationTest extends TestCase
     /**
      * @return array<array{0: ?string, 1: string}>
      */
-    public function namesAndSFSafeNames()
+    public function namesAndSFSafeLastNames()
     {
         return [
             ['Flintstone', 'Flintstone'],
@@ -442,14 +442,47 @@ class DonationTest extends TestCase
     }
 
     /**
-     * @dataProvider namesAndSFSafeNames
+     * @return array<array{0: ?string, 1: ?string}>
      */
-    public function testItMakesDonorNameSafeForSalesforce(?string $originalName, string $expecteSafeName): void
+    public function namesAndSFSafeFirstNames()
+    {
+        return [
+            // same as last name except we have null not 'N/A'.
+            ['Flintstone', 'Flintstone'],
+            [null, null],
+            ['', null],
+            [' ', null],
+            ['王', '王'], // most common Chinese surname
+            [str_repeat('王', 41), str_repeat('王', 40)],
+            [str_repeat('a', 41), str_repeat('a', 40)],
+            ['👍', '👍'],
+            [str_repeat('👍', 41), str_repeat('👍', 40)],
+            [str_repeat('👩‍👩‍👧‍👧', 10), '👩‍👩‍👧‍👧👩‍👩‍👧‍👧👩‍👩‍👧‍👧👩‍👩‍👧‍👧👩‍👩‍👧‍👧👩‍👩‍👧'],
+            [str_repeat('👩‍👩‍👧‍👧', 41), '👩‍👩‍👧‍👧👩‍👩‍👧‍👧👩‍👩‍👧‍👧👩‍👩‍👧‍👧👩‍👩‍👧‍👧👩‍👩‍👧'],
+            [str_repeat('👩‍👩‍👧‍👧', 401), '👩‍👩‍👧‍👧👩‍👩‍👧‍👧👩‍👩‍👧‍👧👩‍👩‍👧‍👧👩‍👩‍👧‍👧👩‍👩‍👧'],
+        ];
+    }
+
+    /**
+     * @dataProvider namesAndSFSafeLastNames
+     */
+    public function testItMakesDonorLastNameSafeForSalesforce(?string $originalName, string $expecteSafeName): void
     {
         $donation = $this->getTestDonation();
         $donation->setDonorLastName($originalName);
 
         $this->assertSame($expecteSafeName, $donation->getDonorLastName(true));
+    }
+
+    /**
+     * @dataProvider namesAndSFSafeFirstNames
+     */
+    public function testItMakesDonorFirstNameSafeForSalesforce(?string $originalName, ?string $expecteSafeName): void
+    {
+        $donation = $this->getTestDonation();
+        $donation->setDonorFirstName($originalName);
+
+        $this->assertSame($expecteSafeName, $donation->getDonorFirstName(true));
     }
 
     public function testCanCancelPendingDonation(): void

--- a/tests/Domain/DonationTest.php
+++ b/tests/Domain/DonationTest.php
@@ -612,4 +612,29 @@ class DonationTest extends TestCase
         ];
         $donation->preUpdate(new PreUpdateEventArgs($donation, $this->createStub(EntityManagerInterface::class), $changeset));
     }
+
+    /**
+     * @dataProvider namesEnoughForSalesForce
+     */
+    public function testItHasEnoughDataForSalesforceOnlyIffBothNamesAreNonEmpty(string $firstName, string $lastName, bool $isEnoughForSalesforce): void
+    {
+        $donation = $this->getTestDonation();
+        $donation->setDonorFirstName($firstName);
+        $donation->setDonorLastName($lastName);
+        $this->assertSame($isEnoughForSalesforce, $donation->hasEnoughDataForSalesforce());
+    }
+
+    /**
+     * @return list<array{0: string, 1: string, 2: bool}>
+     */
+    public function namesEnoughForSalesForce(): array
+    {
+        return [
+            // first name, last name, is it enough for SF?
+            ['', '', false],
+            ['', 'nonempty', false],
+            ['nonempty', '', false],
+            ['nonempty', 'nonempty', true],
+        ];
+    }
 }

--- a/tests/Domain/DonationTest.php
+++ b/tests/Domain/DonationTest.php
@@ -78,6 +78,17 @@ class DonationTest extends TestCase
         $this->getTestDonation('0.99');
     }
 
+    public function testAmountVerySlightlyTooLowNotPersisted(): void
+    {
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('Amount must be 1-25000 GBP');
+
+        // PHP floating point math doesn't distinguish between this and 1, but as we use BC Math we can reject it as too small:
+        // See https://3v4l.org/#live
+        $justLessThanOne = '0.99999999999999999';
+        $this->getTestDonation($justLessThanOne);
+    }
+
     public function testAmountTooHighNotPersisted(): void
     {
         $this->expectException(\UnexpectedValueException::class);


### PR DESCRIPTION
I think this is probably enough tests for now in the Donation class. Although there are still quite a few mutants none seem to be in particularly complicated code, and some will naturally be dealt with if we test other classes that depend on Donation.

Only test file changed so no way for this to affect prod directly.

Mutation results as at commit 7abad : https://output.circle-artifacts.com/output/job/c37c9b14-91a2-476e-9804-e8e070b5c380/artifacts/0/reports/infection.html#mutant/Domain/Donation.php