### PR TITLE
MAT-336 – improve donation Create edge case recovery

### DIFF
--- a/src/Application/Actions/Donations/Create.php
+++ b/src/Application/Actions/Donations/Create.php
@@ -141,7 +141,12 @@ class Create extends Action
 
                 return $this->respond($response, new ActionPayload(503, null, $error));
             } catch (\Throwable $t) {
-                $this->matchingAdapter->releaseNewlyAllocatedFunds();
+                $this->logger->error('Allocation got error: %s', $t->getMessage());
+
+                $this->matchingAdapter->runTransactionally(
+                    fn() => $this->matchingAdapter->releaseNewlyAllocatedFunds(),
+                );
+
                 // we have to also remove the FundingWithdrawls from MySQL - otherwise the redis amount would be reduced again when the donation expires.
                 $this->donationRepository->removeAllFundingWithdrawalsForDonation($donation);
 

--- a/src/Application/Actions/Donations/Create.php
+++ b/src/Application/Actions/Donations/Create.php
@@ -141,7 +141,7 @@ class Create extends Action
 
                 return $this->respond($response, new ActionPayload(503, null, $error));
             } catch (\Throwable $t) {
-                $this->logger->error('Allocation got error: %s', $t->getMessage());
+                $this->logger->error(sprintf('Allocation got error: %s', $t->getMessage()));
 
                 $this->matchingAdapter->runTransactionally(
                     fn() => $this->matchingAdapter->releaseNewlyAllocatedFunds(),


### PR DESCRIPTION
Run match fund release in a new "matching adapter transaction". And also log the original \Throwable message earlier, separately, just in case.