### PR TITLE
Revert "MAT-338 – add temporary out of sync funds mode, '2023-11-30-patch'"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -123,10 +123,6 @@
           "Composer\\Config::disableProcessTimeout",
           "php matchbot-cli.php matchbot:handle-out-of-sync-funds check"
         ],
-        "matchbot:check-out-of-sync-funds-2023-11-30-patch": [
-            "Composer\\Config::disableProcessTimeout",
-            "php matchbot-cli.php matchbot:handle-out-of-sync-funds 2023-11-30-patch"
-        ],
         "matchbot:scheduled-out-of-sync-funds-check": [
             "Composer\\Config::disableProcessTimeout",
             "php matchbot-cli.php matchbot:scheduled-out-of-sync-funds-check"

--- a/src/Application/Commands/HandleOutOfSyncFunds.php
+++ b/src/Application/Commands/HandleOutOfSyncFunds.php
@@ -61,8 +61,8 @@ class HandleOutOfSyncFunds extends LockingCommand
     protected function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $mode = $input->getArgument('mode');
-        if (!in_array($mode, ['check', 'fix', '2023-11-30-patch'], true)) {
-            $output->writeln('Please set the mode to "check" or "fix" or "2023-11-30-patch"');
+        if (!in_array($mode, ['check', 'fix'], true)) {
+            $output->writeln('Please set the mode to "check" or "fix"');
             return 1;
         }
 
@@ -74,17 +74,8 @@ class HandleOutOfSyncFunds extends LockingCommand
         $numFundingsCorrect = 0;
         $numFundingsOvermatched = 0;
         $numFundingsUndermatched = 0;
-
-        $problemIds = [];
         /** @var CampaignFunding[] $fundings */
-        if ($mode === '2023-11-30-patch') {
-            $problemIds = [23790, 23791];
-            $output->writeln('Running in 2023-11-30-patch mode');
-            // https://stackoverflow.com/a/52427915/2803757
-            $fundings = $this->campaignFundingRepository->findBy(['id' => $problemIds]);
-        } else {
-            $fundings = $this->campaignFundingRepository->findAll();
-        }
+        $fundings = $this->campaignFundingRepository->findAll();
         $numFundings = count($fundings);
 
         foreach ($fundings as $funding) {
@@ -126,7 +117,7 @@ class HandleOutOfSyncFunds extends LockingCommand
 
             $output->writeln("Funding {$funding->getId()} is under-matched by $undermatchAmount. $details");
 
-            if ($mode === 'fix' || ($mode === '2023-11-30-patch' && in_array($funding->getId(), $problemIds, true))) {
+            if ($mode === 'fix') {
                 $newTotal = $this->matchingAdapter->runTransactionally(
                     function () use ($funding, $undermatchAmount) {
                         return $this->matchingAdapter->addAmount($funding, $undermatchAmount);

--- a/tests/Application/Commands/HandleOutOfSyncFundsTest.php
+++ b/tests/Application/Commands/HandleOutOfSyncFundsTest.php
@@ -105,7 +105,7 @@ class HandleOutOfSyncFundsTest extends TestCase
 
         $expectedOutputLines = [
             'matchbot:handle-out-of-sync-funds starting!',
-            'Please set the mode to "check" or "fix" or "2023-11-30-patch"',
+            'Please set the mode to "check" or "fix"',
             'matchbot:handle-out-of-sync-funds complete!',
         ];
         $this->assertEquals(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());


### PR DESCRIPTION
Reverts thebiggive/matchbot#706 (and connected)

This temporary Command mode has now been used & isn't needed again.