### PR TITLE
Add "Your card does not support this type of purchase." to expected p…

### DIFF
--- a/src/Application/Actions/UpdatePaymentMethod.php
+++ b/src/Application/Actions/UpdatePaymentMethod.php
@@ -17,6 +17,7 @@ class UpdatePaymentMethod extends Action
     public const EXPECTED_STRIPE_NEW_CARD_MESSAGES = [
         "Your card's security code is incorrect.",
         'Your card was declined.',
+        'Your card does not support this type of purchase.',
     ];
 
     #[Pure]


### PR DESCRIPTION
…ayment messages

See https://support.stripe.com/questions/your-card-does-not-support-this-type-of-purchase-error-when-processing-payment?locale=en-GB