### PR TITLE
Refactor: Rename SalesforceReadProxyRepository::pull to updateFromSf …

### DIFF
--- a/src/Application/Actions/Donations/Create.php
+++ b/src/Application/Actions/Donations/Create.php
@@ -152,8 +152,8 @@ class Create extends Action
         if ($donation->getPsp() === 'stripe') {
             if (empty($donation->getCampaign()->getCharity()->getStripeAccountId())) {
                 // Try re-pulling in case charity has very recently onboarded with for Stripe.
-                $campaign = $this->campaignRepository
-                    ->pull($donation->getCampaign());
+                $campaign = $donation->getCampaign();
+                $this->campaignRepository->updateFromSf($campaign);
 
                 // If still empty, error out
                 if (empty($campaign->getCharity()->getStripeAccountId())) {

--- a/src/Application/Commands/UpdateCampaigns.php
+++ b/src/Application/Commands/UpdateCampaigns.php
@@ -110,7 +110,7 @@ EOT
 
     protected function pull(Campaign $campaign, OutputInterface $output): void
     {
-        $this->campaignRepository->pull($campaign);
+        $this->campaignRepository->updateFromSf($campaign);
         $this->fundRepository->pullForCampaign($campaign);
         $output->writeln('Updated campaign ' . $campaign->getSalesforceId());
     }

--- a/src/Domain/CampaignRepository.php
+++ b/src/Domain/CampaignRepository.php
@@ -38,13 +38,22 @@ class CampaignRepository extends SalesforceReadProxyRepository
         return $qb->getQuery()->getResult();
     }
 
+    public function pullNewFromSf(string $salesforceId): Campaign
+    {
+        $campaign = new Campaign(charity: null);
+        $campaign->setSalesforceId($salesforceId);
+
+        $this->updateFromSf($campaign);
+
+        return $campaign;
+    }
+
     /**
      * @param Campaign $campaign
-     * @return Campaign
      * @throws Client\NotFoundException if Campaign not found on Salesforce
      * @throws \Exception if start or end dates' formats are invalid
      */
-    protected function doPull(SalesforceReadProxy $campaign): SalesforceReadProxy
+    protected function doUpdateFromSf(SalesforceReadProxy $campaign): void
     {
         $client = $this->getClient();
         $campaignData = $client->getById($campaign->getSalesforceId());
@@ -76,8 +85,6 @@ class CampaignRepository extends SalesforceReadProxyRepository
         $campaign->setIsMatched($campaignData['isMatched']);
         $campaign->setName($campaignData['title']);
         $campaign->setStartDate(new DateTime($campaignData['startDate']));
-
-        return $campaign;
     }
 
     /**

--- a/src/Domain/DonationRepository.php
+++ b/src/Domain/DonationRepository.php
@@ -134,10 +134,8 @@ class DonationRepository extends SalesforceWriteProxyRepository
         if (!$campaign) {
             // Fetch data for as-yet-unknown campaigns on-demand
             $this->logInfo("Loading unknown campaign ID {$donationData->projectId} on-demand");
-            $campaign = new Campaign(charity: null);
-            $campaign->setSalesforceId($donationData->projectId);
             try {
-                $this->campaignRepository->pull($campaign);
+                $campaign = $this->campaignRepository->pullNewFromSf($donationData->projectId);
             } catch (ClientException $exception) {
                 $this->logError("Pull error for campaign ID {$donationData->projectId}: {$exception->getMessage()}");
                 throw new \UnexpectedValueException('Campaign does not exist');

--- a/src/Domain/FundRepository.php
+++ b/src/Domain/FundRepository.php
@@ -175,15 +175,12 @@ class FundRepository extends SalesforceReadProxyRepository
      * No need to `setSalesforceLastPull()`, or EM `persist()` - just populate the fields specific to the object.
      *
      * @param Fund $fund
-     * @return Fund
      */
-    protected function doPull(SalesforceReadProxy $fund): SalesforceReadProxy
+    protected function doUpdateFromSf(SalesforceReadProxy $fund): void
     {
         $fundData = $this->getClient()->getById($fund->getSalesforceId());
 
         $fund->setAmount($fundData['totalAmount']);
         $fund->setName($fundData['name'] ?? '');
-
-        return $fund;
     }
 }

--- a/src/Domain/SalesforceReadProxyRepository.php
+++ b/src/Domain/SalesforceReadProxyRepository.php
@@ -18,17 +18,15 @@ abstract class SalesforceReadProxyRepository extends SalesforceProxyRepository
      * No need to `setSalesforceLastPull()`, or EM `persist()` - just populate the fields specific to the object.
      *
      * @psalm-param T $proxy
-     * @psalm-return T
      * @throws UniqueConstraintViolationException occasionally if 2 requests try to create the same
      *                                            Salesforce object in parallel.
      */
-    abstract protected function doPull(SalesforceReadProxy $proxy): SalesforceReadProxy;
+    abstract protected function doUpdateFromSf(SalesforceReadProxy $proxy): void;
 
     /**
      * @psalm-param T $proxy
-     * @psalm-return T
      */
-    public function pull(SalesforceReadProxy $proxy, $autoSave = true): SalesforceReadProxy
+    public function updateFromSf(SalesforceReadProxy $proxy, $autoSave = true): void
     {
         // Make sure we update existing object if passed in a partial copy and we already have that Salesforce object
         // persisted, otherwise we'll try to insert a duplicate and get an ORM crash.
@@ -42,7 +40,8 @@ abstract class SalesforceReadProxyRepository extends SalesforceProxyRepository
             $this->logInfo('Creating ' . get_class($proxy) . ' ' . $proxy->getSalesforceId());
         }
 
-        $proxy = $this->doPull($proxy);
+        $this->doUpdateFromSf($proxy);
+
         $proxy->setSalesforceLastPull(new DateTime('now'));
         $this->getEntityManager()->persist($proxy);
         if ($autoSave) {
@@ -50,7 +49,5 @@ abstract class SalesforceReadProxyRepository extends SalesforceProxyRepository
         }
 
         $this->logInfo('Done persisting ' . get_class($proxy) . ' ' . $proxy->getSalesforceId());
-
-        return $proxy;
     }
 }

--- a/tests/Application/Actions/Donations/CreateTest.php
+++ b/tests/Application/Actions/Donations/CreateTest.php
@@ -120,8 +120,7 @@ class CreateTest extends TestCase
 
         $campaignRepoProphecy = $this->prophesize(CampaignRepository::class);
         // No change – campaign still has a charity without a Stripe Account ID.
-        $campaignRepoProphecy->pull(Argument::type(Campaign::class))
-            ->willReturn($donation->getCampaign())
+        $campaignRepoProphecy->updateFromSf(Argument::type(Campaign::class))
             ->shouldBeCalledOnce();
 
         $entityManagerProphecy = $this->prophesize(RetrySafeEntityManager::class);
@@ -256,13 +255,12 @@ class CreateTest extends TestCase
         $charityWhichNowHasStripeAccountID = clone $donation->getCampaign()->getCharity();
         $charityWhichNowHasStripeAccountID
             ->setStripeAccountId('unitTest_newStripeAccount_456');
-        $campaignWithCharityWhichNowHasStripeAccountID = clone  $donation->getCampaign();
-        $campaignWithCharityWhichNowHasStripeAccountID->setCharity($charityWhichNowHasStripeAccountID);
 
         $campaignRepoProphecy = $this->prophesize(CampaignRepository::class);
-        $campaignRepoProphecy->pull(Argument::type(Campaign::class))
-            ->willReturn($campaignWithCharityWhichNowHasStripeAccountID)
-            ->shouldBeCalledOnce();
+        $campaignRepoProphecy->updateFromSf(Argument::type(Campaign::class))
+            ->will(/**
+             * @param array{0: Campaign} $args
+             */ fn (array $args) => $args[0]->setCharity($charityWhichNowHasStripeAccountID));
 
         $entityManagerProphecy = $this->prophesize(RetrySafeEntityManager::class);
         $container->set(CampaignRepository::class, $campaignRepoProphecy->reveal());

--- a/tests/Application/Commands/UpdateCampaignsTest.php
+++ b/tests/Application/Commands/UpdateCampaignsTest.php
@@ -28,7 +28,7 @@ class UpdateCampaignsTest extends TestCase
         $campaignRepoProphecy->findRecentAndLive()
             ->willReturn([$campaign])
             ->shouldBeCalledOnce();
-        $campaignRepoProphecy->pull($campaign)->willReturn($campaign)->shouldBeCalledOnce();
+        $campaignRepoProphecy->updateFromSf($campaign)->shouldBeCalledOnce();
 
         $fundRepoProphecy = $this->prophesize(FundRepository::class);
         $fundRepoProphecy->pullForCampaign($campaign)->shouldbeCalledOnce();
@@ -64,7 +64,7 @@ class UpdateCampaignsTest extends TestCase
         $campaignRepoProphecy->findRecentAndLive()
             ->willReturn([$campaign])
             ->shouldBeCalledOnce();
-        $campaignRepoProphecy->pull($campaign)->willThrow(NotFoundException::class)->shouldBeCalledOnce();
+        $campaignRepoProphecy->updateFromSf($campaign)->willThrow(NotFoundException::class)->shouldBeCalledOnce();
 
         $fundRepoProphecy = $this->prophesize(FundRepository::class);
         $fundRepoProphecy->pullForCampaign($campaign)->shouldNotBeCalled(); // Exception reached before this call
@@ -104,7 +104,7 @@ class UpdateCampaignsTest extends TestCase
         $campaignRepoProphecy->findRecentAndLive()
             ->willReturn([$campaign])
             ->shouldBeCalledOnce();
-        $campaignRepoProphecy->pull($campaign)
+        $campaignRepoProphecy->updateFromSf($campaign)
             ->willThrow($exception)
             ->shouldBeCalledTimes(2);
 
@@ -151,17 +151,17 @@ class UpdateCampaignsTest extends TestCase
 
         $mockBuilder = $this->getMockBuilder(CampaignRepository::class);
         $mockBuilder->setConstructorArgs([$entityManagerProphecy->reveal(), new ClassMetadata(Campaign::class)]);
-        $mockBuilder->onlyMethods(['findRecentAndLive', 'pull']);
+        $mockBuilder->onlyMethods(['findRecentAndLive', 'updateFromSf']);
 
         $campaignRepo = $mockBuilder->getMock();
         $campaignRepo->expects($this->once())
             ->method('findRecentAndLive')
             ->willReturn([$campaign]);
         $campaignRepo->expects($this->exactly(2))
-            ->method('pull')
+            ->method('updateFromSf')
             ->willReturnOnConsecutiveCalls(
                 $this->throwException($exception),
-                $campaign,
+                null,
             );
 
         $fundRepoProphecy = $this->prophesize(FundRepository::class);
@@ -197,7 +197,7 @@ class UpdateCampaignsTest extends TestCase
         $campaignRepoProphecy->findAll()
             ->willReturn([$campaign])
             ->shouldBeCalledOnce();
-        $campaignRepoProphecy->pull($campaign)->willReturn($campaign)->shouldBeCalledOnce();
+        $campaignRepoProphecy->updateFromSf($campaign)->shouldBeCalledOnce();
 
         $fundRepoProphecy = $this->prophesize(FundRepository::class);
         $fundRepoProphecy->pullForCampaign($campaign)->shouldbeCalledOnce();

--- a/tests/Domain/DonationRepositoryTest.php
+++ b/tests/Domain/DonationRepositoryTest.php
@@ -229,19 +229,16 @@ class DonationRepositoryTest extends TestCase
         $fundRepositoryProphecy = $this->prophesize(FundRepository::class);
         $this->entityManagerProphecy->flush()->shouldBeCalled();
 
+        $dummyCampaign = new Campaign(TestCase::someCharity());
+        $dummyCampaign->setCurrencyCode('GBP');
+        $dummyCampaign->setSalesforceId('testProject123');
+
+
         // No change – campaign still has a charity without a Stripe Account ID.
         $campaignRepoProphecy->findOneBy(['salesforceId' => 'testProject123'])
             ->willReturn(null);
-        $campaignRepoProphecy->pull(Argument::type(Campaign::class))->will(/**
-         * @param array<Campaign> $args
-         * @return Campaign
-         */ function (array $args) {
-            $campaign = $args[0];
-            $campaign->setCurrencyCode('GBP');
-            $campaign->setCharity(TestCase::someCharity());
+        $campaignRepoProphecy->pullNewFromSf('testProject123')->willReturn($dummyCampaign);
 
-            return $campaign;
-        });
         $fundRepositoryProphecy->pullForCampaign(Argument::type(Campaign::class))->shouldBeCalled();
 
         $createPayload = new DonationCreate(

--- a/tests/Domain/FundRepositoryTest.php
+++ b/tests/Domain/FundRepositoryTest.php
@@ -46,7 +46,7 @@ class FundRepositoryTest extends TestCase
         // `FundRepository` such that `doPull()` is a real call but `pull()` doesn't try a real DB engine lookup.
         $fund->setSalesforceId('sfFakeId987');
 
-        $fund = $repo->pull($fund, false); // Don't auto-save as non-DB-backed tests can't persist
+        $repo->updateFromSf($fund, false); // Don't auto-save as non-DB-backed tests can't persist
 
         $this->assertEquals('API Fund Name', $fund->getName());
         $this->assertEquals('123.45', $fund->getAmount());


### PR DESCRIPTION
…and make it return void

I think this makes the function quite a bit simpler to understand. For the one and only case where a return value was necassary, I have created a new function CampaignRepository::pullNewFromSf. In all other cases were are updating an existing object that the calling function is already holding a reference to.