### PR TITLE
Fix mutation tests

### DIFF
--- a/tests/Application/Actions/DeletePaymentMethodTest.php
+++ b/tests/Application/Actions/DeletePaymentMethodTest.php
@@ -85,8 +85,10 @@ class DeletePaymentMethodTest extends TestCase
         ObjectProphecy $stripeCustomerServiceProphecy
     ): StripeClient {
         $fakeStripeClient = $this->createStub(StripeClient::class);
-        $fakeStripeClient->paymentMethods = $stripePaymentMethodServiceProphecy->reveal();
-        $fakeStripeClient->customers = $stripeCustomerServiceProphecy->reveal();
+        // supressing deprecation notices for now on setting properties dynamically. Risk is low doing this in test code,
+        // and may get mutation tests working again.
+        @$fakeStripeClient->paymentMethods = $stripePaymentMethodServiceProphecy->reveal();
+        @$fakeStripeClient->customers = $stripeCustomerServiceProphecy->reveal();
 
         return $fakeStripeClient;
     }

--- a/tests/Application/Actions/GetPaymentMethodsTest.php
+++ b/tests/Application/Actions/GetPaymentMethodsTest.php
@@ -35,7 +35,9 @@ class GetPaymentMethodsTest extends TestCase
             ]);
 
         $stripeClientProphecy = $this->prophesize(StripeClient::class);
-        $stripeClientProphecy->customers = $stripeCustomersProphecy->reveal();
+        // supressing deprecation notices for now on setting properties dynamically. Risk is low doing this in test code,
+        // and may get mutation tests working again.
+        @$stripeClientProphecy->customers = $stripeCustomersProphecy->reveal();
 
         $container->set(StripeClient::class, $stripeClientProphecy->reveal());
 

--- a/tests/Application/Actions/Hooks/StripePaymentsUpdateTest.php
+++ b/tests/Application/Actions/Hooks/StripePaymentsUpdateTest.php
@@ -133,7 +133,9 @@ class StripePaymentsUpdateTest extends StripeTest
             ->shouldBeCalledOnce()
             ->willReturn(json_decode($balanceTxnResponse));
         $stripeClientProphecy = $this->prophesize(StripeClient::class);
-        $stripeClientProphecy->balanceTransactions = $stripeBalanceTransactionProphecy->reveal();
+        // supressing deprecation notices for now on setting properties dynamically. Risk is low doing this in test code,
+        // and may get mutation tests working again.
+        @$stripeClientProphecy->balanceTransactions = $stripeBalanceTransactionProphecy->reveal();
 
         $container->set(EntityManagerInterface::class, $entityManagerProphecy->reveal());
         $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
@@ -182,7 +184,7 @@ class StripePaymentsUpdateTest extends StripeTest
             ->shouldBeCalledOnce()
             ->willReturn(json_decode($balanceTxnResponse));
         $stripeClientProphecy = $this->prophesize(StripeClient::class);
-        $stripeClientProphecy->balanceTransactions = $stripeBalanceTransactionProphecy->reveal();
+        @$stripeClientProphecy->balanceTransactions = $stripeBalanceTransactionProphecy->reveal();
 
         $container->set(EntityManagerInterface::class, $entityManagerProphecy->reveal());
         $container->set(DonationRepository::class, $donationRepoProphecy->reveal());

--- a/tests/Application/Actions/UpdatePaymentMethodTest.php
+++ b/tests/Application/Actions/UpdatePaymentMethodTest.php
@@ -97,8 +97,11 @@ use Stripe\StripeClient;
         ObjectProphecy $stripeCustomerServiceProphecy
     ): StripeClient {
         $fakeStripeClient = $this->createStub(StripeClient::class);
-        $fakeStripeClient->paymentMethods = $stripePaymentMethodServiceProphecy->reveal();
-        $fakeStripeClient->customers = $stripeCustomerServiceProphecy->reveal();
+
+        // supressing deprecation notices for now on setting properties dynamically. Risk is low doing this in test code,
+        // and may get mutation tests working again.
+        @$fakeStripeClient->paymentMethods = $stripePaymentMethodServiceProphecy->reveal();
+        @$fakeStripeClient->customers = $stripeCustomerServiceProphecy->reveal();
 
         return $fakeStripeClient;
     }

--- a/tests/Application/Commands/DeleteStalePaymentDetailsTest.php
+++ b/tests/Application/Commands/DeleteStalePaymentDetailsTest.php
@@ -53,8 +53,10 @@ class DeleteStalePaymentDetailsTest extends TestCase
 
         $stripeClientProphecy = $this->prophesize(StripeClient::class);
 
-        $stripeClientProphecy->customers = $stripeCustomersProphecy->reveal();
-        $stripeClientProphecy->paymentMethods = $stripePaymentMethodsProphecy->reveal();
+        // supressing deprecation notices for now on setting properties dynamically. Risk is low doing this in test code,
+        // and may get mutation tests working again.
+        @$stripeClientProphecy->customers = $stripeCustomersProphecy->reveal();
+        @$stripeClientProphecy->paymentMethods = $stripePaymentMethodsProphecy->reveal();
 
         $commandTester = new CommandTester($this->getCommand(
             $stripeClientProphecy,

--- a/tests/Application/Messenger/Handler/StripePayoutHandlerTest.php
+++ b/tests/Application/Messenger/Handler/StripePayoutHandlerTest.php
@@ -97,8 +97,10 @@ class StripePayoutHandlerTest extends TestCase
             ->shouldBeCalledOnce();
 
         $stripeClientProphecy = $this->getStripeClient();
-        $stripeClientProphecy->balanceTransactions = $stripeBalanceTransactionProphecy->reveal();
-        $stripeClientProphecy->charges = $stripeChargeProphecy->reveal();
+        // supressing deprecation notices for now on setting properties dynamically. Risk is low doing this in test code,
+        // and may get mutation tests working again.
+        @$stripeClientProphecy->balanceTransactions = $stripeBalanceTransactionProphecy->reveal();
+        @$stripeClientProphecy->charges = $stripeChargeProphecy->reveal();
 
         $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
         $container->set(EntityManagerInterface::class, $entityManagerProphecy->reveal());
@@ -173,8 +175,8 @@ class StripePayoutHandlerTest extends TestCase
             ->shouldBeCalledOnce();
 
         $stripeClientProphecy = $this->getStripeClient();
-        $stripeClientProphecy->balanceTransactions = $stripeBalanceTransactionProphecy->reveal();
-        $stripeClientProphecy->charges = $stripeChargeProphecy->reveal();
+        @$stripeClientProphecy->balanceTransactions = $stripeBalanceTransactionProphecy->reveal();
+        @$stripeClientProphecy->charges = $stripeChargeProphecy->reveal();
 
         $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
         $container->set(EntityManagerInterface::class, $entityManagerProphecy->reveal());
@@ -252,8 +254,8 @@ class StripePayoutHandlerTest extends TestCase
         $entityManagerProphecy->commit()->shouldBeCalledOnce();
 
         $stripeClientProphecy = $this->getStripeClient();
-        $stripeClientProphecy->balanceTransactions = $stripeBalanceTransactionProphecy->reveal();
-        $stripeClientProphecy->charges = $stripeChargeProphecy->reveal();
+        @$stripeClientProphecy->balanceTransactions = $stripeBalanceTransactionProphecy->reveal();
+        @$stripeClientProphecy->charges = $stripeChargeProphecy->reveal();
 
         $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
         $container->set(EntityManagerInterface::class, $entityManagerProphecy->reveal());
@@ -294,7 +296,9 @@ class StripePayoutHandlerTest extends TestCase
             ->shouldBeCalledOnce()
             ->willReturn(json_decode($this->getStripeHookMock('ApiResponse/po')));
 
-        $stripeClientProphecy->payouts = $stripePayoutProphecy->reveal();
+        // supressing deprecation notices for now on setting properties dynamically. Risk is low doing this in test code,
+        // and may get mutation tests working again.
+        @$stripeClientProphecy->payouts = $stripePayoutProphecy->reveal();
 
         return $stripeClientProphecy;
     }


### PR DESCRIPTION
Looks like these have been erroring due to the deprecation of dynamic properties in PHP 8.2