### PR TITLE
BG2-2520: Replace PHP 8.2 with 8.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
     parameters:
       php_version:
         type: string
-        default: dev-8.2
+        default: dev-8.3
     docker:
       - image: thebiggive/php:<< parameters.php_version >>
         auth:
@@ -81,7 +81,7 @@ jobs:
     resource_class: large
     working_directory: /var/www/html
     docker:
-      - image: thebiggive/php:dev-8.2
+      - image: thebiggive/php:dev-8.3
         auth:
           username: $DOCKER_HUB_USERNAME
           password: $DOCKER_HUB_ACCESS_TOKEN
@@ -132,7 +132,7 @@ workflows:
             - slack
           matrix:
             parameters:
-              php_version: ["dev-8.2"]
+              php_version: ["dev-8.3"]
           post-steps:
             - jira/notify:
                 job_type: build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,12 +13,8 @@ jobs:
     # generation-dependent tests to work.
     working_directory: /var/www/html
     resource_class: large
-    parameters:
-      php_version:
-        type: string
-        default: dev-8.3
     docker:
-      - image: thebiggive/php:<< parameters.php_version >>
+      - image: thebiggive/php:dev-8.3
         auth:
           username: $DOCKER_HUB_USERNAME
           password: $DOCKER_HUB_ACCESS_TOKEN
@@ -130,9 +126,6 @@ workflows:
             - docker-hub-creds
             - jira
             - slack
-          matrix:
-            parameters:
-              php_version: ["dev-8.3"]
           post-steps:
             - jira/notify:
                 job_type: build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM thebiggive/php:8.2
+FROM thebiggive/php:8.3
 
 # Artifacts are immutable so *never* bother re-checking files - this makes opcache.revalidate_freq irrelevant
 # See https://www.scalingphpbook.com/blog/2014/02/14/best-zend-opcache-settings.html

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "ext-bcmath": "*",
         "ext-json": "*",
         "ext-mbstring": "^8.0",
@@ -67,7 +67,7 @@
         },
         "optimize-autoloader": true,
         "platform": {
-            "php": "8.2.14"
+            "php": "8.3.1"
         },
         "sort-packages": true
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c529c3c0e851958a3a633b6663d479c1",
+    "content-hash": "8f176d838c0c44288475ae50b269aaf6",
     "packages": [
         {
             "name": "async-aws/core",
@@ -10939,7 +10939,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.2",
+        "php": "^8.3",
         "ext-bcmath": "*",
         "ext-json": "*",
         "ext-mbstring": "^8.0",
@@ -10949,7 +10949,7 @@
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "8.2.14"
+        "php": "8.3.1"
     },
     "plugin-api-version": "2.3.0"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ volumes:
 
 services:
   app:
-    image: thebiggive/php:dev-8.2
+    image: thebiggive/php:dev-8.3
     platform: linux/amd64
     ports:
       - "30030:80"

--- a/integrationTests/IntegrationTest.php
+++ b/integrationTests/IntegrationTest.php
@@ -362,9 +362,12 @@ abstract class IntegrationTest extends TestCase
         ObjectProphecy $stripePaymentIntents,
     ): StripeClient {
         $fakeStripeClient = $this->createStub(StripeClient::class);
-        $fakeStripeClient->paymentMethods = $stripePaymentMethodServiceProphecy->reveal();
-        $fakeStripeClient->customers = $stripeCustomerServiceProphecy->reveal();
-        $fakeStripeClient->paymentIntents = $stripePaymentIntents->reveal();
+
+        // Suppressing deprecation warnings with `@` for creation of dynamic properties. Will crash in PHP 9, we can
+        // deal with it then if the code is still there.
+        @$fakeStripeClient->paymentMethods = $stripePaymentMethodServiceProphecy->reveal();
+        @$fakeStripeClient->customers = $stripeCustomerServiceProphecy->reveal();
+        @$fakeStripeClient->paymentIntents = $stripePaymentIntents->reveal();
 
         return $fakeStripeClient;
     }


### PR DESCRIPTION
Since this is deployed as a container with a PHP runtime included it doesn't make sense to try to support multiple PHP versions at the same time as I was doing before the holiday.