### PR TITLE
BG2-2548: Clear account rep

### DIFF
--- a/src/Application/Commands/DeleteStalePaymentDetails.php
+++ b/src/Application/Commands/DeleteStalePaymentDetails.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MatchBot\Application\Commands;
 
 use Psr\Log\LoggerInterface;
+use Stripe\Person;
 use Stripe\StripeClient;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -93,6 +94,40 @@ class DeleteStalePaymentDetails extends LockingCommand
                 "$customerCount customers. Time Taken: {$timeTaken}s"
         );
 
+        /**
+         * This has nothing to do with deleting stale payment details, but it's convenient to call it here just
+         * because this is a function that runs every couple of hours. It's a bit messy but will be deleted once
+         * it's run once in prod.
+         */
+        $this->clearAccountRep();
+
         return 0;
+    }
+
+    /**
+     * One off tempoary function to clear an account rep for a connected account. Let this run once in production and
+     * then delete. It's not possible to do the same thing without using the API. Doesn't matter if it runs a few times.
+     *
+     * See https://stripe.com/docs/connect/update-verified-information?locale=en-GB#change-the-account-representative
+     */
+    private function clearAccountRep(): void
+    {
+        $relaventAccountId = 'acct_1JKj2g4EM6tmvjBM';
+
+        $peopleOnAccount = $this->stripeClient->accounts->allPersons($relaventAccountId);
+
+        foreach ($peopleOnAccount as $person) {
+            \assert($person instanceof \Stripe\Person);
+
+
+            $person->updateAttributes(
+                ['relationship' => ['representative' => false]]
+            );
+
+            $this->logger->info(
+                "Updated relationship rep to false for person id #{$person->id} " .
+                "on account $relaventAccountId"
+            );
+        }
     }
 }

--- a/tests/Application/Commands/DeleteStalePaymentDetailsTest.php
+++ b/tests/Application/Commands/DeleteStalePaymentDetailsTest.php
@@ -11,6 +11,7 @@ use MatchBot\Tests\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Log\NullLogger;
+use Stripe\Service\AccountService;
 use Stripe\Service\ChargeService;
 use Stripe\Service\CustomerService;
 use Stripe\Service\PaymentMethodService;
@@ -58,6 +59,12 @@ class DeleteStalePaymentDetailsTest extends TestCase
         // code, and may get mutation tests working again.
         @$stripeClientProphecy->customers = $stripeCustomersProphecy->reveal();
         @$stripeClientProphecy->paymentMethods = $stripePaymentMethodsProphecy->reveal();
+
+        /////////// delete when BG2-2548 done
+        $accountService = $this->prophesize(AccountService::class);
+        $accountService->allPersons(Argument::cetera())->willReturn([]);
+        @$stripeClientProphecy->accounts = $accountService->reveal();
+        ///////////
 
         $commandTester = new CommandTester($this->getCommand(
             $stripeClientProphecy,


### PR DESCRIPTION
Tested on my local by running `./matchbot matchbot:delete-stale-payment-details`, which seems to be working to update the test copy of this account. Once this is deployed to prod it should update the real thing, removing any set representative so that we can set a new one manually during the grace period.