### PR TITLE
DON-954: Fix processing of web hoooks for non-card payments

### DIFF
--- a/src/Application/Actions/Hooks/StripePaymentsUpdate.php
+++ b/src/Application/Actions/Hooks/StripePaymentsUpdate.php
@@ -125,9 +125,14 @@ class StripePaymentsUpdate extends Stripe
         // as this is the only event type we're handling right now besides refunds.
         if ($charge->status === 'succeeded') {
             /**
-             * @var Card|null $card
+             * @var array|Card|null $card
              */
-            $card = $charge->payment_method_details?->card;
+            $card = $charge->payment_method_details?->toArray()['card'] ?? null;
+            if (is_array($card)) {
+                /** @var Card $card */
+                $card = (object)$card;
+            }
+
             $cardBrand = $card?->brand;
             $cardCountry = $card?->country;
             $balanceTransaction = (string) $charge->balance_transaction;


### PR DESCRIPTION
This may have been broken recently, but on my local I was getting an exception for non-card (i.e. donation funds) payments:

[2024-01-22T15:24:59.419989+00:00] matchbot.ERROR: Exception: Stripe Notice: Undefined property of Stripe\StripeObject instance: card (etc)

Tested the new version and it works both with cards and non cards - we still capture the full details of the card.