### PR TITLE
BG2-2548: Fix stripe update script

### DIFF
--- a/src/Application/Commands/DeleteStalePaymentDetails.php
+++ b/src/Application/Commands/DeleteStalePaymentDetails.php
@@ -119,13 +119,14 @@ class DeleteStalePaymentDetails extends LockingCommand
         foreach ($peopleOnAccount as $person) {
             \assert($person instanceof \Stripe\Person);
 
-
-            $person->updateAttributes(
+            $this->stripeClient->accounts->updatePerson(
+                $relaventAccountId,
+                $person->id,
                 ['relationship' => ['representative' => false]]
             );
 
             $this->logger->info(
-                "Updated relationship rep to false for person id #{$person->id} " .
+                "Updated relationship rep with updatePerson to false for person id #{$person->id} " .
                 "on account $relaventAccountId"
             );
         }


### PR DESCRIPTION
The previous version ran in prod but didn't actually do anything useful I realise now the `updateAttributes` function was just for updating the attributes in the object in memory on the PHP side - it doesn't actually send anything to Stripe. `updatePerson` is what is recommended at
https://stripe.com/docs/connect/update-verified-information?locale=en-GB#change-the-account-representative