### PR TITLE
BG2-2545 (tangentially related): Disallow updates to any non-pending …

### DIFF
--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -1389,6 +1389,10 @@ class Donation extends SalesforceWriteProxy
         ?bool $championComms = false,
         ?string $donorPostalAddress = null,
     ): void {
+        if ($this->donationStatus !== DonationStatus::Pending) {
+            throw new \UnexpectedValueException("Update only allowed for pending donation");
+        }
+
         if (
             $giftAid &&
             ($donorHomeAddressLine1 === null || trim($donorHomeAddressLine1) === '')

--- a/tests/Application/Actions/Donations/UpdateTest.php
+++ b/tests/Application/Actions/Donations/UpdateTest.php
@@ -941,7 +941,7 @@ class UpdateTest extends TestCase
         /** @var Container $container */
         $container = $app->getContainer();
 
-        $donation = $this->getTestDonation(currencyCode: 'USD');
+        $donation = $this->getTestDonation(currencyCode: 'USD', collected: false);
         $donation->update(
             giftAid: true,
             donorHomeAddressLine1: '99 Updated St',
@@ -1032,7 +1032,7 @@ class UpdateTest extends TestCase
         /** @var Container $container */
         $container = $app->getContainer();
 
-        $donation = $this->getTestDonation(currencyCode: 'USD');
+        $donation = $this->getTestDonation(currencyCode: 'USD', collected: false);
         $donation->update(
             giftAid: true,
             donorHomeAddressLine1: '99 Updated St',
@@ -1126,7 +1126,7 @@ class UpdateTest extends TestCase
         /** @var Container $container */
         $container = $app->getContainer();
 
-        $donation = $this->getTestDonation(currencyCode: 'USD');
+        $donation = $this->getTestDonation(currencyCode: 'USD', collected: false);
 
         $donation->update(
             giftAid: true,
@@ -1231,7 +1231,7 @@ class UpdateTest extends TestCase
         /** @var Container $container */
         $container = $app->getContainer();
 
-        $donation = $this->getTestDonation(currencyCode: 'USD');
+        $donation = $this->getTestDonation(currencyCode: 'USD', collected: false);
 
         $donation->update(
             giftAid: true,
@@ -1329,7 +1329,7 @@ class UpdateTest extends TestCase
         /** @var Container $container */
         $container = $app->getContainer();
 
-        $donation = $this->getTestDonation(currencyCode: 'USD');
+        $donation = $this->getTestDonation(currencyCode: 'USD', collected: false);
 
         $donation->update(
             giftAid: true,
@@ -1431,7 +1431,7 @@ class UpdateTest extends TestCase
         /** @var Container $container */
         $container = $app->getContainer();
 
-        $donation = $this->getTestDonation(currencyCode: 'USD');
+        $donation = $this->getTestDonation(currencyCode: 'USD', collected: false);
         $donation->update(
             giftAid: true,
             donorHomeAddressLine1: '99 Updated St'
@@ -1528,7 +1528,7 @@ class UpdateTest extends TestCase
         /** @var Container $container */
         $container = $app->getContainer();
 
-        $donation = $this->getTestDonation(currencyCode: 'USD');
+        $donation = $this->getTestDonation(currencyCode: 'USD', collected: false);
         $donation->update(
             giftAid: true,
             donorHomeAddressLine1: '99 Updated St'
@@ -1606,7 +1606,7 @@ class UpdateTest extends TestCase
 
         // These two values are unchanged but still returned.
         $this->assertEquals(123.45, $payloadArray['donationAmount']);
-        $this->assertEquals(DonationStatus::Collected->value, $payloadArray['status']);
+        $this->assertEquals(DonationStatus::Pending->value, $payloadArray['status']);
 
         // Remaining properties should be updated.
         $this->assertEquals('US', $payloadArray['countryCode']);
@@ -1894,12 +1894,20 @@ class UpdateTest extends TestCase
         /** @var Container $container */
         $container = $app->getContainer();
 
-        $donation = $this->getTestDonation(pspMethodType: PaymentMethodType::CustomerBalance, tipAmount: '0');
+        $donation = $this->getTestDonation(
+            pspMethodType: PaymentMethodType::CustomerBalance,
+            tipAmount: '0',
+            collected: false,
+        );
 
         $donationRepoProphecy = $this->prophesize(DonationRepository::class);
         // Get a new mock object so DB has old values. Make it explicit that the payment method type is (the
         // unsupported for auto-confirms) "card".
-        $donationInRepo = $this->getTestDonation(pspMethodType: PaymentMethodType::CustomerBalance, tipAmount: '0');
+        $donationInRepo = $this->getTestDonation(
+            pspMethodType: PaymentMethodType::CustomerBalance,
+            tipAmount: '0',
+            collected: false
+        );
 
         $donationRepoProphecy
             ->findAndLockOneBy(['uuid' => '12345678-1234-1234-1234-1234567890ab'])

--- a/tests/Domain/DonationTest.php
+++ b/tests/Domain/DonationTest.php
@@ -664,6 +664,36 @@ class DonationTest extends TestCase
         );
     }
 
+    public function testCannotUpdateADonationAfterCollection(): void
+    {
+        // arrange
+        $donation = Donation::fromApiModel(new DonationCreate(
+            countryCode: 'GB',
+            currencyCode: 'GBP',
+            donationAmount: '1.0',
+            projectId: 'project_id',
+            psp: 'stripe',
+        ), new Campaign(TestCase::someCharity()));
+
+        $donation->collectFromStripeCharge(
+            chargeId: 'irrelevent',
+            transferId: 'irrelevent',
+            cardBrand: 'visa',
+            cardCountry: 'gb',
+            originalFeeFractional: '1',
+            chargeCreationTimestamp: 1,
+        );
+
+        // assert
+        $this->expectExceptionMessage('Update only allowed for pending donation');
+
+        // act
+        $donation->update(
+            giftAid: true,
+            donorHomeAddressLine1: 'Updated home address',
+        );
+    }
+
     /**
      * @return array<array{0: ?string, 1: ?string}>
      */


### PR DESCRIPTION
There's no reason for the browser to send an update for a donation if it's already not pending.

Currently if they tried it would be blocked by an exception generated by the Stripe library, but I don't like the fact that we're relying on stripe to block it.