### PR TITLE
Let unit test suite run 326% faster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,9 @@ jobs:
 
       - run: composer run integration-test
 
+      - store_test_results:
+          path: reports
+
       - store_artifacts:
           path: reports
 

--- a/app/dependencies.php
+++ b/app/dependencies.php
@@ -38,6 +38,7 @@ use Stripe\StripeClient;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 use Symfony\Component\Cache\Psr16Cache;
+use Symfony\Component\Clock\NativeClock;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\Store\DoctrineDbalStore;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsTransportFactory;
@@ -385,5 +386,7 @@ return function (ContainerBuilder $containerBuilder) {
         Connection::class => static function (ContainerInterface $c): Connection {
             return $c->get(EntityManagerInterface::class)->getConnection();
         },
+
+        \Symfony\Component\Clock\ClockInterface::class => fn() => new NativeClock(),
     ]);
 };

--- a/composer.json
+++ b/composer.json
@@ -168,14 +168,14 @@
             "php matchbot-cli.php messenger:consume -vv --time-limit=7080"
         ],
         "start": "php -S localhost:8080 -t public",
-        "test": "XDEBUG_MODE=coverage phpunit --order-by=random",
+        "test": "XDEBUG_MODE=coverage phpunit --order-by=random --log-junit reports/unit-test.xml",
         "integration-test": [
             "APP_ENV=test doctrine orm:clear-cache:metadata",
             "APP_ENV=test doctrine orm:clear-cache:query",
             "APP_ENV=test doctrine orm:clear-cache:result",
             "APP_ENV=test doctrine-migrations migrate --no-interaction --allow-no-migration",
             "APP_ENV=test doctrine orm:generate-proxies",
-            "XDEBUG_MODE=coverage phpunit --config=phpunit-integration.xml --order-by=random"
+            "XDEBUG_MODE=coverage phpunit --config=phpunit-integration.xml --order-by=random  --log-junit reports/integration-test.xml"
         ],
         "mutation-test": [
             "Composer\\Config::disableProcessTimeout",

--- a/tests/Application/Actions/Donations/UpdateHandlesLockExceptionTest.php
+++ b/tests/Application/Actions/Donations/UpdateHandlesLockExceptionTest.php
@@ -25,6 +25,7 @@ use Ramsey\Uuid\Uuid;
 use Slim\Psr7\Response;
 use Stripe\Service\PaymentIntentService;
 use Stripe\StripeClient;
+use Symfony\Component\Clock\MockClock;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer;
@@ -60,7 +61,8 @@ class UpdateHandlesLockExceptionTest extends TestCase
             $this->entityManagerProphecy->reveal(),
             new Serializer([new ObjectNormalizer()], [new JsonEncoder()]),
             $this->createStub(Stripe::class),
-            new NullLogger()
+            new NullLogger(),
+            new MockClock(),
         );
 
         $request = new ServerRequest(method: 'PUT', uri: '', body: $this->putRequestBody(newStatus: "Pending"));
@@ -89,7 +91,8 @@ class UpdateHandlesLockExceptionTest extends TestCase
             $this->entityManagerProphecy->reveal(),
             new Serializer([new ObjectNormalizer()], [new JsonEncoder()]),
             $this->createStub(Stripe::class),
-            new NullLogger()
+            new NullLogger(),
+            new MockClock(),
         );
 
         $request = new ServerRequest(method: 'PUT', uri: '', body: $this->putRequestBody(newStatus: "Cancelled"));

--- a/tests/Application/Actions/Donations/UpdateTest.php
+++ b/tests/Application/Actions/Donations/UpdateTest.php
@@ -30,6 +30,8 @@ use Stripe\Exception\InvalidRequestException;
 use Stripe\Exception\UnknownApiErrorException;
 use Stripe\PaymentIntent;
 use Stripe\StripeObject;
+use Symfony\Component\Clock\ClockInterface;
+use Symfony\Component\Clock\MockClock;
 
 class UpdateTest extends TestCase
 {
@@ -1290,7 +1292,7 @@ class UpdateTest extends TestCase
                 false
             ));
 
-
+        $container->set(ClockInterface::class, new MockClock());
         $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
         $container->set(EntityManagerInterface::class, $entityManagerProphecy->reveal());
         $container->set(Stripe::class, $stripeProphecy->reveal());
@@ -1387,6 +1389,7 @@ class UpdateTest extends TestCase
                 false,
             ));
 
+        $container->set(ClockInterface::class, new MockClock());
         $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
         $container->set(EntityManagerInterface::class, $entityManagerProphecy->reveal());
         $container->set(Stripe::class, $stripeProphecy->reveal());
@@ -1490,6 +1493,7 @@ class UpdateTest extends TestCase
         $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
         $container->set(EntityManagerInterface::class, $entityManagerProphecy->reveal());
         $container->set(Stripe::class, $stripeProphecy->reveal());
+        $container->set(ClockInterface::class, new MockClock());
 
         $request = $this->createRequest(
             'PUT',

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -21,6 +21,7 @@ use Slim\Psr7\Factory\StreamFactory;
 use Slim\Psr7\Headers;
 use Slim\Psr7\Request as SlimRequest;
 use Slim\Psr7\Uri;
+use Symfony\Component\Clock\ClockInterface;
 
 class TestCase extends PHPUnitTestCase
 {
@@ -81,6 +82,22 @@ class TestCase extends PHPUnitTestCase
 
         // By default, tests don't get a real logger.
         $container->set(LoggerInterface::class, new NullLogger());
+
+        $container->set(ClockInterface::class, new class implements ClockInterface
+        {
+            #[\Override] public function sleep(float|int $seconds): never
+            {
+                throw new \Exception("Please provide fake clock for your test");
+            }
+            #[\Override] public function now(): never
+            {
+                throw new \Exception("Please provide fake clock for your test");
+            }
+            #[\Override] public function withTimeZone(\DateTimeZone|string $timezone): never
+            {
+                throw new \Exception("Please provide fake clock for your test");
+            }
+        });
 
         // Instantiate the app
         AppFactory::setContainer($container);


### PR DESCRIPTION
On my laptop:

Before:

```
vendor/bin/phpunit
PHPUnit 9.6.15 by Sebastian Bergmann and contributors.

Warning:       XDEBUG_MODE=coverage or xdebug.mode=coverage has to be set

...............................................................  63 / 291 ( 21%) ...............................................S............... 126 / 291 ( 43%) ............................................................... 189 / 291 ( 64%) ............................................................... 252 / 291 ( 86%)
.......................................                         291 / 291 (100%)

Time: 00:04.181, Memory: 58.00 MB
```

After:

```
$ vendor/bin/phpunit
PHPUnit 9.6.15 by Sebastian Bergmann and contributors.

Warning:       XDEBUG_MODE=coverage or xdebug.mode=coverage has to be set

...............................................................  63 / 291 ( 21%) ...............................................S............... 126 / 291 ( 43%) ............................................................... 189 / 291 ( 64%) ............................................................... 252 / 291 ( 86%)
.......................................                         291 / 291 (100%)

Time: 00:00.980, Memory: 58.00 MB
```