### PR TITLE
CLA-37 [main hotfix] – temporarily check charges up to 2 years for payouts

### DIFF
--- a/src/Application/Messenger/Handler/StripePayoutHandler.php
+++ b/src/Application/Messenger/Handler/StripePayoutHandler.php
@@ -368,10 +368,11 @@ class StripePayoutHandler implements MessageHandlerInterface
         // Payouts' usual scheduled as of 2022 is a 2 week minimum offset (give or take a calendar day)
         // with a fixed day of the week for payouts, making the maximum normal lag 21 days. However we
         // have had edge cases with bank details problems taking a couple of weeks to resolve, so we now
-        // look back up to 60 days in order to still catch charges for status updates if this happens.
+        // look back up to 2 years in order to still catch charges for status updates if this happens.
+        // Once historic donations are reconciled in March 2024, we'll reduce this to 60 days again.
 
         $tz = new \DateTimeZone('Europe/London');
-        $fromDate = $payoutCreated->sub(new \DateInterval('P60D'))->setTimezone($tz);
+        $fromDate = $payoutCreated->sub(new \DateInterval('P2Y'))->setTimezone($tz);
         $toDate = $payoutCreated->add(new \DateInterval('P1D'))->setTimezone($tz);
 
 

--- a/tests/Application/Messenger/Handler/StripePayoutHandlerTest.php
+++ b/tests/Application/Messenger/Handler/StripePayoutHandlerTest.php
@@ -373,7 +373,7 @@ class StripePayoutHandlerTest extends TestCase
         return [
             // Based on the date range from our standard test data payout (donation time -60D and +1D days).
             'created' => [
-                'gt' => 1593351656,
+                'gt' => 1535377256,
                 'lt' => 1598622056,
             ],
             'limit' => 100


### PR DESCRIPTION
(cherry picked from commit 2745d6f11b0da79ed6149375b0d7e3c481092d74)