### PR TITLE
MAT-289 – remove a source of Stripe test mode error log noise introduced in Jan

### DIFF
--- a/src/Application/Messenger/Handler/StripePayoutHandler.php
+++ b/src/Application/Messenger/Handler/StripePayoutHandler.php
@@ -80,7 +80,11 @@ class StripePayoutHandler implements MessageHandlerInterface
         );
 
         if ($chargeIds === []) {
-            $this->logger->error(sprintf(
+            // Outside of production we expect Stripe to combine things from multiple test environments
+            // (staging & regtest) into one, so we may get pings re payouts where we don't recognise any
+            // donations.
+            $logLevel = (getenv('APP_ENV') === 'production') ? LogLevel::ERROR : LogLevel::INFO;
+            $this->logger->log($logLevel, sprintf(
                 'Payout: Exited with no original donation charge IDs for Payout ID %s, account %s',
                 $payoutId,
                 $connectAccountId,


### PR DESCRIPTION
I think this can be reviewed without reopening the original issue / new QA as it only affects non-live log levels.