### PR TITLE
Stop generating alarm on invalid card expiration month

### DIFF
--- a/src/Application/Actions/UpdatePaymentMethod.php
+++ b/src/Application/Actions/UpdatePaymentMethod.php
@@ -19,6 +19,7 @@ class UpdatePaymentMethod extends Action
         'Your card was declined.',
         'Your card has expired.',
         'Your card does not support this type of purchase.',
+        'Your card\'s expiration month is invalid.',
     ];
 
     #[Pure]

--- a/tests/Application/Matching/AdapterTest.php
+++ b/tests/Application/Matching/AdapterTest.php
@@ -129,8 +129,8 @@ class AdapterTest extends TestCase
          // We initially subtract £30, leaving £20 in fund.
          // Then we try to subtract another £30, leaving £-10 in fund.
          //
-        // Each of the 5 auto retries does the same thing, removing another -10 from the fund. Combined with the 30 removed by the other process that leaves
-        // total of 6*10 + 30 = 100 to release.
+        // Each of the 5 auto retries does the same thing, removing another -10 from the fund. Combined with the 30
+        // removed by the other process that leaves total of 6*10 + 30 = 100 to release.
 
         // As a test I changed the retry limit in Adapter::$maxPartialAllocateTries from 5 to 500.
         // That means it has to release -14950_00 at the end. Actually still sort of confused.


### PR DESCRIPTION
Recently seen in alarms channel, doesn't indicate any general brokennnes.