### PR TITLE
MAT-358: Fix Deploying change to Doctrine Entity field name generates…

### DIFF
--- a/.build-commit-id.php
+++ b/.build-commit-id.php
@@ -1,9 +1,0 @@
-<?php
-
-// Returns the commit ID of the git commit
-// used to build the current version. This is used as part of a cache namespace, and in future might also be shown
-// in a custom header or footer or something.
-
-throw new \Exception(
-    'Please ensure save-build-commit-id is run to get the commit id for use in non-local environments.'
-);

--- a/.build-commit-id.php
+++ b/.build-commit-id.php
@@ -1,0 +1,9 @@
+<?php
+
+// Returns the commit ID of the git commit
+// used to build the current version. This is used as part of a cache namespace, and in future might also be shown
+// in a custom header or footer or something.
+
+throw new \Exception(
+    'Please ensure save-build-commit-id is run to get the commit id for use in non-local environments.'
+);

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@
 !/logs/README.md
 /.phpunit.result.cache
 stripe_cli.env
+/.build-commit-id.php
 /reports

--- a/app/dependencies.php
+++ b/app/dependencies.php
@@ -255,6 +255,7 @@ return function (ContainerBuilder $containerBuilder) {
 
         ORM\Configuration::class => static function (ContainerInterface $c): ORM\Configuration {
             $settings = $c->get('settings');
+            $commitId = require __DIR__ . "/../.build-commit-id.php";
 
             // Must be a distinct instance from the one used for fund allocation maths, as Doctrine's PHP serialisation
             // is incompatible with that needed for Redis commands that modify integer values in place. This injected
@@ -263,7 +264,10 @@ return function (ContainerBuilder $containerBuilder) {
             $redis = new Redis();
             try {
                 $redis->connect($settings['redis']['host']);
-                $cacheAdapter = new RedisAdapter(redis: $redis, namespace: "matchbot-{$settings['appEnv']}");
+                $cacheAdapter = new RedisAdapter(
+                    redis: $redis,
+                    namespace: "matchbot-{$settings['appEnv']}-{$commitId}"
+                );
             } catch (RedisException $exception) {
                 // This essentially means Doctrine is not using a cache. `/ping` should fail separately based on
                 // Redis being down whenever this happens, so we should find out without relying on this warning log.

--- a/composer.json
+++ b/composer.json
@@ -163,6 +163,12 @@
             "Composer\\Config::disableProcessTimeout",
             "php matchbot-cli.php messenger:consume -vv --time-limit=7080"
         ],
+        "save-build-commit-id": [
+            "echo '<?php \nreturn \"'`git rev-parse HEAD`'\";\n' > .build-commit-id.php"
+        ],
+        "post-install-cmd": [
+            "composer save-build-commit-id"
+        ],
         "start": "php -S localhost:8080 -t public",
         "test": "XDEBUG_MODE=coverage phpunit --order-by=random --log-junit reports/unit-test.xml",
         "integration-test": [

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -198,13 +198,10 @@ class Donation extends SalesforceWriteProxy
      * May be a post code or equivilent from anywhere in the world,
      * so we allow up to 15 chars which has been enough for all donors in the last 12 months.
      *
-     * @todo when production traffic is low change property name to donorBillingPostcode,
-     * i.e. revert commit 061839c, maybe rename column in DB at same time.
-     *
      * @var string|null
      */
-    #[ORM\Column(type: 'string', nullable: true)]
-    protected ?string $donorPostalAddress = null;
+    #[ORM\Column(type: 'string', nullable: true, name: 'donorPostalAddress')]
+    protected ?string $donorBillingPostcode = null;
 
     /**
      * @var string|null From residential address, if donor is claiming Gift Aid.
@@ -473,7 +470,7 @@ class Donation extends SalesforceWriteProxy
     public function toApiModel(): array
     {
         $data = [
-            'billingPostalAddress' => $this->donorPostalAddress,
+            'billingPostalAddress' => $this->donorBillingPostcode,
             'charityFee' => (float) $this->getCharityFee(),
             'charityFeeVat' => (float) $this->getCharityFeeVat(),
             'charityId' => $this->getCampaign()->getCharity()->getSalesforceId(),
@@ -1435,7 +1432,7 @@ class Donation extends SalesforceWriteProxy
         }
 
         $this->donorHomeAddressLine1 = $donorHomeAddressLine1;
-        $this->donorPostalAddress = $donorBillingPostcode;
+        $this->donorBillingPostcode = $donorBillingPostcode;
 
         $this->setGiftAid($giftAid);
         $this->setTipGiftAid($tipGiftAid);
@@ -1464,7 +1461,7 @@ class Donation extends SalesforceWriteProxy
             ->that($this->donorLastName, 'donorLastName')->notNull('Missing Donor Last Name')
             ->that($this->donorEmailAddress)->notNull('Missing Donor Email Address')
             ->that($this->donorCountryCode)->notNull('Missing Billing Country')
-            ->that($this->donorPostalAddress)->notNull('Missing Billing Postcode')
+            ->that($this->donorBillingPostcode)->notNull('Missing Billing Postcode')
             ->that($this->tbgComms)->notNull('Missing tbgComms preference')
             ->that($this->charityComms)->notNull('Missing charityComms preference')
             ->that($this->donationStatus, 'donationStatus')


### PR DESCRIPTION
… errors

We now store the commit ID into a PHP file, and use that as part of the cache key for the Doctrine metadata in Redis. Therefore after any deploy of a new version of Matchbot the metadata cache will be effectively empty.

Writing the commit ID into a PHP file rather than a plain text file so that its content can be cached by opcache