### PR TITLE
MAT-365 – adjust messaging when a donation create attempt is for a Stripe account without capabilities

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 # This file is used only in local dev environments and build servers. It includes services that we
 # do not need in production, like MySQL and the Stripe CLI.
 

--- a/src/Application/Actions/Donations/Create.php
+++ b/src/Application/Actions/Donations/Create.php
@@ -18,27 +18,30 @@ use MatchBot\Application\Auth\PersonWithPasswordAuthMiddleware;
 use MatchBot\Application\HttpModels\DonationCreate;
 use MatchBot\Application\HttpModels\DonationCreatedResponse;
 use MatchBot\Application\Matching\Adapter;
+use MatchBot\Application\Notifier\StripeChatterInterface;
 use MatchBot\Application\Persistence\RetrySafeEntityManager;
 use MatchBot\Client\Stripe;
 use MatchBot\Domain\CampaignRepository;
 use MatchBot\Domain\Charity;
-use MatchBot\Domain\Donation;
 use MatchBot\Domain\DonationRepository;
-use Monolog\Logger;
+use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 use Random\Randomizer;
 use Stripe\Exception\ApiErrorException;
 use Symfony\Component\Clock\ClockInterface;
+use Symfony\Component\Notifier\ChatterInterface;
+use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Serializer\Exception\UnexpectedValueException;
 use Symfony\Component\Serializer\SerializerInterface;
 
 class Create extends Action
 {
     private const MAX_RETRY_COUNT = 4;
+    private ChatterInterface $chatter;
 
-    #[Pure]
     public function __construct(
         private DonationRepository $donationRepository,
         private CampaignRepository $campaignRepository,
@@ -47,8 +50,17 @@ class Create extends Action
         private Stripe $stripe,
         private Adapter $matchingAdapter,
         private ClockInterface $clock,
+        ContainerInterface $container,
         LoggerInterface $logger,
     ) {
+        /**
+         * @var ChatterInterface $chatter
+         * Injecting `StripeChatterInterface` directly doesn't work because `Chatter` itself
+         * is final and does not implement our custom interface.
+         */
+        $chatter = $container->get(StripeChatterInterface::class);
+        $this->chatter = $chatter;
+
         parent::__construct($logger);
     }
 
@@ -238,14 +250,14 @@ class Create extends Action
             } catch (ApiErrorException $exception) {
                 $message = $exception->getMessage();
 
-                $level = str_contains(
+                $accountLacksCapabilities = str_contains(
                     $message,
                     // this message is an issue the charity needs to fix, we can't fix it for them.
+                    // We likely want to let the team know to hide the campaign from prominents views though.
                     'Your destination account needs to have at least one of the following capabilities enabled'
-                ) ?
-                    Logger::WARNING : Logger::ERROR;
+                );
 
-                $this->logger->log($level, sprintf(
+                $failureMessage = sprintf(
                     'Stripe Payment Intent create error on %s, %s [%s]: %s. Charity: %s [%s].',
                     $donation->getUuid(),
                     $exception->getStripeCode() ?? 'unknown',
@@ -253,9 +265,36 @@ class Create extends Action
                     $message,
                     $donation->getCampaign()->getCharity()->getName(),
                     $donation->getCampaign()->getCharity()->getStripeAccountId() ?? 'unknown',
-                ));
-                $error = new ActionError(ActionError::SERVER_ERROR, 'Could not make Stripe Payment Intent (B)');
-                return $this->respond($response, new ActionPayload(500, null, $error));
+                );
+
+                $level = $accountLacksCapabilities ? LogLevel::WARNING : LogLevel::ERROR;
+                $this->logger->log($level, $failureMessage);
+
+                if ($accountLacksCapabilities) {
+                    /** @var string $env */
+                    $env = getenv('APP_ENV');
+                    $failureMessageWithContext = sprintf(
+                        '[%s] %s',
+                        $env,
+                        $failureMessage,
+                    );
+                    $this->chatter->send(new ChatMessage($failureMessageWithContext));
+                }
+
+                $error = new ActionError(
+                    $accountLacksCapabilities ? ActionError::VERIFICATION_ERROR : ActionError::SERVER_ERROR,
+                    'Could not make Stripe Payment Intent (B)'
+                );
+
+                return $this->respond(
+                    $response,
+                    new ActionPayload(
+                        // HTTP 409 Conflict can cover when requests conflicts w/ server configuration.
+                        $accountLacksCapabilities ? 409 : 500,
+                        null,
+                        $error,
+                    ),
+                );
             }
 
             $donation->setTransactionId($intent->id);

--- a/src/Application/Actions/Donations/Create.php
+++ b/src/Application/Actions/Donations/Create.php
@@ -271,8 +271,8 @@ class Create extends Action
                 $this->logger->log($level, $failureMessage);
 
                 if ($accountLacksCapabilities) {
-                    /** @var string $env */
                     $env = getenv('APP_ENV');
+                    \assert(is_string($env));
                     $failureMessageWithContext = sprintf(
                         '[%s] %s',
                         $env,

--- a/tests/Application/Actions/Donations/CreateTest.php
+++ b/tests/Application/Actions/Donations/CreateTest.php
@@ -20,10 +20,10 @@ use MatchBot\Domain\DonationStatus;
 use MatchBot\Domain\FundingWithdrawal;
 use MatchBot\Tests\TestCase;
 use MatchBot\Tests\TestData;
-use PHPUnit\Util\Test;
 use Prophecy\Argument;
 use Psr\Http\Message\ServerRequestInterface;
 use Ramsey\Uuid\Uuid;
+use Slim\App;
 use Slim\Exception\HttpUnauthorizedException;
 use Stripe\Exception\PermissionException;
 use Stripe\PaymentIntent;
@@ -33,6 +33,11 @@ use UnexpectedValueException;
 class CreateTest extends TestCase
 {
     private static array $somePaymentIntentArgs;
+    /**
+     * @var PaymentIntent Mock result, most properites we don't use omitted.
+     * @link https://stripe.com/docs/api/payment_intents/object
+     */
+    private static PaymentIntent $somePaymentIntentResult;
 
     public function setUp(): void
     {
@@ -69,6 +74,15 @@ class CreateTest extends TestCase
                 'destination' => 'unitTest_stripeAccount_123',
             ],
         ];
+
+        static::$somePaymentIntentResult = new PaymentIntent([
+            'id' => 'pi_dummyIntent_id',
+            'object' => 'payment_intent',
+            'amount' => 1311,
+            'client_secret' => 'pi_dummySecret_123',
+            'confirmation_method' => 'automatic',
+            'currency' => 'gbp',
+        ]);
 
         $app = $this->getAppInstance();
 
@@ -272,15 +286,15 @@ class CreateTest extends TestCase
         $donationToReturn->setDonationStatus(DonationStatus::Pending);
         $donationToReturn->addFundingWithdrawal(self::someWithdrawal($donation));
 
-        $app = $this->getAppInstance();
-        /** @var Container $container */
+        $app = $this->getAppWithCommonPersistenceDeps(
+            donationPersisted: true,
+            donationPushed: true,
+            donationMatched: true,
+            donation: $donationToReturn,
+            skipEmExpectations: true,
+        );
         $container = $app->getContainer();
-        $donationRepoProphecy = $this->prophesize(DonationRepository::class);
-        $donationRepoProphecy
-            ->buildFromApiRequest(Argument::type(DonationCreate::class))
-            ->willReturn($donationToReturn);
-        $donationRepoProphecy->push(Argument::type(Donation::class), true)->willReturn(true)->shouldBeCalledOnce();
-        $donationRepoProphecy->allocateMatchFunds(Argument::type(Donation::class))->shouldBeCalledOnce();
+        \assert($container instanceof Container);
 
         // Cloning & use of new objects is necessary here, so we don't set
         // the Stripe value on the copy of the object which is meant to be
@@ -296,9 +310,9 @@ class CreateTest extends TestCase
              */                fn (array $args) => $args[0]->setCharity($charityWhichNowHasStripeAccountID)
             );
 
+        // Need to override stock EM to get campaign repo behaviour
         $entityManagerProphecy = $this->prophesize(RetrySafeEntityManager::class);
         $container->set(CampaignRepository::class, $campaignRepoProphecy->reveal());
-        // These are called once after initial ID setup and once after Stripe fields added.
         $entityManagerProphecy->persistWithoutRetries(Argument::type(Donation::class))->shouldBeCalledTimes(2);
         $entityManagerProphecy->flush()->shouldBeCalledTimes(2);
 
@@ -349,7 +363,6 @@ class CreateTest extends TestCase
             ->willReturn($paymentIntentMockResult)
             ->shouldBeCalledOnce();
 
-        $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
         $container->set(RetrySafeEntityManager::class, $entityManagerProphecy->reveal());
         $container->set(Stripe::class, $stripeProphecy->reveal());
 
@@ -399,20 +412,14 @@ class CreateTest extends TestCase
         $donationToReturn->setDonationStatus(DonationStatus::Pending);
         $donationToReturn->addFundingWithdrawal($fundingWithdrawalForMatch);
 
-        $app = $this->getAppInstance();
-        /** @var Container $container */
+        $app = $this->getAppWithCommonPersistenceDeps(
+            donationPersisted: true,
+            donationPushed: true,
+            donationMatched: true,
+            donation: $donationToReturn,
+        );
         $container = $app->getContainer();
-        $donationRepoProphecy = $this->prophesize(DonationRepository::class);
-        $donationRepoProphecy
-            ->buildFromApiRequest(Argument::type(DonationCreate::class))
-            ->willReturn($donationToReturn);
-        $donationRepoProphecy->push(Argument::type(Donation::class), true)->willReturn(true)->shouldBeCalledOnce();
-        $donationRepoProphecy->allocateMatchFunds(Argument::type(Donation::class))->shouldBeCalledOnce();
-
-        $entityManagerProphecy = $this->prophesize(RetrySafeEntityManager::class);
-        // These are called once after initial ID setup and once after Stripe fields added.
-        $entityManagerProphecy->persistWithoutRetries(Argument::type(Donation::class))->shouldBeCalledTimes(2);
-        $entityManagerProphecy->flush()->shouldBeCalledTimes(2);
+        \assert($container instanceof Container);
 
         $expectedPaymentIntentArgs = [
             'automatic_payment_methods' => [
@@ -445,24 +452,12 @@ class CreateTest extends TestCase
             'customer' => 'cus_aaaaaaaaaaaa11',
             'setup_future_usage' => 'on_session'
         ];
-        // Most properites we don't use omitted.
-        // See https://stripe.com/docs/api/payment_intents/object
-        $paymentIntentMockResult = new PaymentIntent([
-            'id' => 'pi_dummyIntent_id',
-            'object' => 'payment_intent',
-            'amount' => 1311,
-            'client_secret' => 'pi_dummySecret_123',
-            'confirmation_method' => 'automatic',
-            'currency' => 'gbp',
-        ]);
 
         $stripeProphecy = $this->prophesize(Stripe::class);
         $stripeProphecy->createPaymentIntent($expectedPaymentIntentArgs)
-            ->willReturn($paymentIntentMockResult)
+            ->willReturn(self::$somePaymentIntentResult)
             ->shouldBeCalledOnce();
 
-        $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
-        $container->set(RetrySafeEntityManager::class, $entityManagerProphecy->reveal());
         $container->set(Stripe::class, $stripeProphecy->reveal());
 
         $data = $this->encode($donation);
@@ -512,20 +507,14 @@ class CreateTest extends TestCase
         $donationToReturn->setDonationStatus(DonationStatus::Pending);
         $donationToReturn->addFundingWithdrawal(self::someWithdrawal($donation));
 
-        $app = $this->getAppInstance();
-        /** @var Container $container */
+        $app = $this->getAppWithCommonPersistenceDeps(
+            donationPersisted: true,
+            donationPushed: true,
+            donationMatched: true,
+            donation: $donationToReturn,
+        );
         $container = $app->getContainer();
-        $donationRepoProphecy = $this->prophesize(DonationRepository::class);
-        $donationRepoProphecy
-            ->buildFromApiRequest(Argument::type(DonationCreate::class))
-            ->willReturn($donationToReturn);
-        $donationRepoProphecy->push(Argument::type(Donation::class), true)->willReturn(true)->shouldBeCalledOnce();
-        $donationRepoProphecy->allocateMatchFunds(Argument::type(Donation::class))->shouldBeCalledOnce();
-
-        $entityManagerProphecy = $this->prophesize(RetrySafeEntityManager::class);
-        // These are called once after initial ID setup and once after Stripe fields added.
-        $entityManagerProphecy->persistWithoutRetries(Argument::type(Donation::class))->shouldBeCalledTimes(2);
-        $entityManagerProphecy->flush()->shouldBeCalledTimes(2);
+        \assert($container instanceof Container);
 
         $expectedPaymentIntentArgs = [
             'amount' => 1311, // Pence including tip
@@ -558,24 +547,12 @@ class CreateTest extends TestCase
                 'destination' => 'unitTest_stripeAccount_123',
             ],
         ];
-        // Most properites we don't use omitted.
-        // See https://stripe.com/docs/api/payment_intents/object
-        $paymentIntentMockResult = new PaymentIntent([
-            'id' => 'pi_dummyIntent_id',
-            'object' => 'payment_intent',
-            'amount' => 1311,
-            'client_secret' => 'pi_dummySecret_123',
-            'confirmation_method' => 'automatic',
-            'currency' => 'gbp',
-        ]);
 
         $stripeProphecy = $this->prophesize(Stripe::class);
         $stripeProphecy->createPaymentIntent($expectedPaymentIntentArgs)
-            ->willReturn($paymentIntentMockResult)
+            ->willReturn(self::$somePaymentIntentResult)
             ->shouldBeCalledOnce();
 
-        $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
-        $container->set(RetrySafeEntityManager::class, $entityManagerProphecy->reveal());
         $container->set(Stripe::class, $stripeProphecy->reveal());
 
         $request = $this->createRequest(
@@ -627,26 +604,19 @@ class CreateTest extends TestCase
         $donationToReturn->setDonationStatus(DonationStatus::Pending);
         $donationToReturn->addFundingWithdrawal(self::someWithdrawal($donation));
 
-        $app = $this->getAppInstance();
-        /** @var Container $container */
+        $app = $this->getAppWithCommonPersistenceDeps(
+            donationPersisted: false,
+            donationPushed: false,
+            donationMatched: false,
+            donation: $donationToReturn,
+        );
         $container = $app->getContainer();
-        $donationRepoProphecy = $this->prophesize(DonationRepository::class);
-        $donationRepoProphecy
-            ->buildFromApiRequest(Argument::type(DonationCreate::class))
-            ->willReturn($donationToReturn);
-        $donationRepoProphecy->push(Argument::type(Donation::class), true)->willReturn(true)->shouldNotBeCalled();
-        $donationRepoProphecy->allocateMatchFunds(Argument::type(Donation::class))->shouldNotBeCalled();
-
-        $entityManagerProphecy = $this->prophesize(RetrySafeEntityManager::class);
-        $entityManagerProphecy->persistWithoutRetries(Argument::type(Donation::class))->shouldNotBeCalled();
-        $entityManagerProphecy->flush()->shouldNotBeCalled();
+        \assert($container instanceof Container);
 
         $stripeProphecy = $this->prophesize(Stripe::class);
         $stripeProphecy->createPaymentIntent(Argument::type('array'))
             ->shouldNotBeCalled();
 
-        $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
-        $container->set(RetrySafeEntityManager::class, $entityManagerProphecy->reveal());
         $container->set(Stripe::class, $stripeProphecy->reveal());
 
         $data = json_encode($donation->toApiModel(), JSON_THROW_ON_ERROR);
@@ -665,26 +635,19 @@ class CreateTest extends TestCase
         $donationToReturn->setDonationStatus(DonationStatus::Pending);
         $donationToReturn->addFundingWithdrawal(self::someWithdrawal($donation));
 
-        $app = $this->getAppInstance();
-        /** @var Container $container */
+        $app = $this->getAppWithCommonPersistenceDeps(
+            donationPersisted: false,
+            donationPushed: false,
+            donationMatched: false,
+            donation: $donationToReturn,
+        );
         $container = $app->getContainer();
-        $donationRepoProphecy = $this->prophesize(DonationRepository::class);
-        $donationRepoProphecy
-            ->buildFromApiRequest(Argument::type(DonationCreate::class))
-            ->willReturn($donationToReturn);
-        $donationRepoProphecy->push(Argument::type(Donation::class), true)->willReturn(true)->shouldNotBeCalled();
-        $donationRepoProphecy->allocateMatchFunds(Argument::type(Donation::class))->shouldNotBeCalled();
-
-        $entityManagerProphecy = $this->prophesize(RetrySafeEntityManager::class);
-        $entityManagerProphecy->persistWithoutRetries(Argument::type(Donation::class))->shouldNotBeCalled();
-        $entityManagerProphecy->flush()->shouldNotBeCalled();
+        \assert($container instanceof Container);
 
         $stripeProphecy = $this->prophesize(Stripe::class);
         $stripeProphecy->createPaymentIntent(Argument::type('array'))
             ->shouldNotBeCalled();
 
-        $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
-        $container->set(RetrySafeEntityManager::class, $entityManagerProphecy->reveal());
         $container->set(Stripe::class, $stripeProphecy->reveal());
 
         $data = json_encode($donation->toApiModel(), JSON_THROW_ON_ERROR);
@@ -763,20 +726,10 @@ class CreateTest extends TestCase
                 'destination' => 'unitTest_stripeAccount_123',
             ],
         ];
-        // Most properites we don't use omitted.
-        // See https://stripe.com/docs/api/payment_intents/object
-        $paymentIntentMockResult = new PaymentIntent([
-            'id' => 'pi_dummyIntent_id',
-            'object' => 'payment_intent',
-            'amount' => 1311,
-            'client_secret' => 'pi_dummySecret_123',
-            'confirmation_method' => 'automatic',
-            'currency' => 'gbp',
-        ]);
 
         $stripeProphecy = $this->prophesize(Stripe::class);
         $stripeProphecy->createPaymentIntent($expectedPaymentIntentArgs)
-            ->willReturn($paymentIntentMockResult)
+            ->willReturn(self::$somePaymentIntentResult)
             ->shouldBeCalledOnce();
 
         $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
@@ -820,41 +773,20 @@ class CreateTest extends TestCase
     {
         $donation = $this->getTestDonation(true, false);
 
-        $app = $this->getAppInstance();
-        /** @var Container $container */
+        $app = $this->getAppWithCommonPersistenceDeps(
+            donationPersisted: true,
+            donationPushed: true,
+            donationMatched: false,
+            donation: $donation,
+        );
         $container = $app->getContainer();
-        $donationRepoProphecy = $this->prophesize(DonationRepository::class);
-        $donationRepoProphecy
-            ->buildFromApiRequest(Argument::type(DonationCreate::class))
-            ->willReturn($donation);
-        $donationRepoProphecy->push(Argument::type(Donation::class), true)->willReturn(true)->shouldBeCalledOnce();
-        $donationRepoProphecy->allocateMatchFunds(Argument::type(Donation::class))->shouldNotBeCalled();
-
-        $entityManagerProphecy = $this->prophesize(RetrySafeEntityManager::class);
-
-        // Persist + flush happens twice. See code by comment "Must persist
-        // before Stripe work to have ID available."
-        $entityManagerProphecy->persistWithoutRetries(Argument::type(Donation::class))->shouldBeCalledTimes(2);
-        $entityManagerProphecy->flush()->shouldBeCalledTimes(2);
-
-        // Most properites we don't use omitted.
-        // See https://stripe.com/docs/api/payment_intents/object
-        $paymentIntentMockResult = new PaymentIntent([
-            'id' => 'pi_dummyIntent_id',
-            'object' => 'payment_intent',
-            'amount' => 1311,
-            'client_secret' => 'pi_dummySecret_123',
-            'confirmation_method' => 'automatic',
-            'currency' => 'gbp',
-        ]);
+        \assert($container instanceof Container);
 
         $stripeProphecy = $this->prophesize(Stripe::class);
         $stripeProphecy->createPaymentIntent(self::$somePaymentIntentArgs)
-            ->willReturn($paymentIntentMockResult)
+            ->willReturn(self::$somePaymentIntentResult)
             ->shouldBeCalledOnce();
 
-        $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
-        $container->set(RetrySafeEntityManager::class, $entityManagerProphecy->reveal());
         $container->set(Stripe::class, $stripeProphecy->reveal());
 
         $data = $this->encode($donation);
@@ -893,42 +825,20 @@ class CreateTest extends TestCase
     public function testSuccessWithMinimalData(): void
     {
         $donation = $this->getTestDonation(true, false, true);
-
-        $app = $this->getAppInstance();
-        /** @var Container $container */
+        $app = $this->getAppWithCommonPersistenceDeps(
+            donationPersisted: true,
+            donationPushed: true,
+            donationMatched: false,
+            donation: $donation,
+        );
         $container = $app->getContainer();
-        $donationRepoProphecy = $this->prophesize(DonationRepository::class);
-        $donationRepoProphecy
-            ->buildFromApiRequest(Argument::type(DonationCreate::class))
-            ->willReturn($donation);
-        $donationRepoProphecy->push(Argument::type(Donation::class), true)->willReturn(true)->shouldBeCalledOnce();
-        $donationRepoProphecy->allocateMatchFunds(Argument::type(Donation::class))->shouldNotBeCalled();
-
-        $entityManagerProphecy = $this->prophesize(RetrySafeEntityManager::class);
-
-        // Persist + flush happens twice. See code by comment "Must persist
-        // before Stripe work to have ID available."
-        $entityManagerProphecy->persistWithoutRetries(Argument::type(Donation::class))->shouldBeCalledTimes(2);
-        $entityManagerProphecy->flush()->shouldBeCalledTimes(2);
-
-        // Most properites we don't use omitted.
-        // See https://stripe.com/docs/api/payment_intents/object
-        $paymentIntentMockResult = new PaymentIntent([
-            'id' => 'pi_dummyIntent_id',
-            'object' => 'payment_intent',
-            'amount' => 1311,
-            'client_secret' => 'pi_dummySecret_123',
-            'confirmation_method' => 'automatic',
-            'currency' => 'gbp',
-        ]);
+        \assert($container instanceof Container);
 
         $stripeProphecy = $this->prophesize(Stripe::class);
         $stripeProphecy->createPaymentIntent(self::$somePaymentIntentArgs)
-            ->willReturn($paymentIntentMockResult)
+            ->willReturn(self::$somePaymentIntentResult)
             ->shouldBeCalledOnce();
 
-        $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
-        $container->set(RetrySafeEntityManager::class, $entityManagerProphecy->reveal());
         $container->set(Stripe::class, $stripeProphecy->reveal());
 
         $data = $this->encode($donation);
@@ -963,39 +873,29 @@ class CreateTest extends TestCase
 
     public function testCharityLackingCapabilities(): void
     {
+        // arrange
         $donation = $this->getTestDonation(true, false, true);
-
-        $app = $this->getAppInstance();
-        /** @var Container $container */
+        $data = $this->encode($donation);
+        $app = $this->getAppWithCommonPersistenceDeps(
+            donationPersisted: true,
+            donationPushed: false,
+            donationMatched: false,
+            donation: $donation,
+        );
         $container = $app->getContainer();
-        $donationRepoProphecy = $this->prophesize(DonationRepository::class);
-        $donationRepoProphecy
-            ->buildFromApiRequest(Argument::type(DonationCreate::class))
-            ->willReturn($donation);
-        $donationRepoProphecy->push(Argument::type(Donation::class), true)->shouldNotBeCalled();
-
-        $chatterProphecy = $this->prophesize(StripeChatterInterface::class);
-        $container->set(StripeChatterInterface::class, $chatterProphecy->reveal());
-
-        $entityManagerProphecy = $this->prophesize(RetrySafeEntityManager::class);
+        \assert($container instanceof Container);
 
         $transfersOffError = new PermissionException(
             'Your destination account needs to have at least one of the following capabilities ' .
             'enabled: transfers, crypto_transfers, legacy_payments'
         );
-
         $stripeProphecy = $this->prophesize(Stripe::class);
         $stripeProphecy->createPaymentIntent(self::$somePaymentIntentArgs)
             ->willThrow($transfersOffError)
             ->shouldBeCalledOnce();
-
-        $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
-        $container->set(RetrySafeEntityManager::class, $entityManagerProphecy->reveal());
         $container->set(Stripe::class, $stripeProphecy->reveal());
 
-        $data = $this->encode($donation);
-        $request = $this->createRequest('POST', TestData\Identity::getTestPersonNewDonationEndpoint(), $data);
-
+        $chatterProphecy = $this->prophesize(StripeChatterInterface::class);
         $chatterProphecy->send(
             new ChatMessage(
                 '[test] Stripe Payment Intent create error on 12345678-1234-1234-1234-1234567890ab' .
@@ -1006,8 +906,13 @@ class CreateTest extends TestCase
             )
         )
             ->shouldBeCalledOnce();
+        $container->set(StripeChatterInterface::class, $chatterProphecy->reveal());
+
+        // act
+        $request = $this->createRequest('POST', TestData\Identity::getTestPersonNewDonationEndpoint(), $data);
         $response = $app->handle($this->addDummyPersonAuth($request));
 
+        // assert
         $payload = (string) $response->getBody();
         $this->assertJson($payload);
         $this->assertEquals(409, $response->getStatusCode());
@@ -1019,6 +924,65 @@ class CreateTest extends TestCase
         $expectedSerialised = json_encode($expectedPayload, JSON_PRETTY_PRINT);
 
         $this->assertEquals($expectedSerialised, $payload);
+    }
+
+    /**
+     * Get app with standard EM & repo set. Callers in this class typically set a prophesised Stripe client
+     * on the container.
+     *
+     * @param bool $skipEmExpectations  Whether to bypass monitoring calls on the entity manager,
+     *                                  e.g. because the test will replace it with a more specific one.
+     */
+    private function getAppWithCommonPersistenceDeps(
+        bool $donationPersisted,
+        bool $donationPushed,
+        bool $donationMatched,
+        Donation $donation,
+        bool $skipEmExpectations = false,
+    ): App {
+        $app = $this->getAppInstance();
+        /** @var Container $container */
+        $container = $app->getContainer();
+        $donationRepoProphecy = $this->prophesize(DonationRepository::class);
+        $donationRepoProphecy
+            ->buildFromApiRequest(Argument::type(DonationCreate::class))
+            ->willReturn($donation);
+
+        if ($donationPushed) {
+            $donationRepoProphecy->push($donation, true)->shouldBeCalledOnce();
+        } else {
+            $donationRepoProphecy->push($donation, true)->shouldNotBeCalled();
+        }
+
+        if ($donationMatched) {
+            $donationRepoProphecy->allocateMatchFunds($donation)->shouldBeCalledOnce();
+        } else {
+            $donationRepoProphecy->allocateMatchFunds($donation)->shouldNotBeCalled();
+        }
+
+        $entityManagerProphecy = $this->prophesize(RetrySafeEntityManager::class);
+
+        if ($donationPersisted) {
+            if (!$skipEmExpectations) {
+                if ($donationPushed) {
+                    // Persist + flush happens twice. See code by comment "Must persist
+                    // before Stripe work to have ID available."
+                    $entityManagerProphecy->persistWithoutRetries($donation)->shouldBeCalledTimes(2);
+                    $entityManagerProphecy->flush()->shouldBeCalledTimes(2);
+                } else {
+                    $entityManagerProphecy->persistWithoutRetries($donation)->shouldBeCalledOnce();
+                    $entityManagerProphecy->flush()->shouldBeCalledOnce();
+                }
+            }
+        } else {
+            $entityManagerProphecy->persistWithoutRetries($donation)->shouldNotBeCalled();
+            $entityManagerProphecy->flush()->shouldNotBeCalled();
+        }
+
+        $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
+        $container->set(RetrySafeEntityManager::class, $entityManagerProphecy->reveal());
+
+        return $app;
     }
 
     private function encode(Donation $donation): string

--- a/tests/Application/Actions/Donations/CreateTest.php
+++ b/tests/Application/Actions/Donations/CreateTest.php
@@ -32,9 +32,43 @@ use UnexpectedValueException;
 
 class CreateTest extends TestCase
 {
+    private static array $somePaymentIntentArgs;
+
     public function setUp(): void
     {
         parent::setUp();
+
+        static::$somePaymentIntentArgs = [
+            'amount' => 1311, // Pence including tip
+            'currency' => 'gbp',
+            'automatic_payment_methods' => [
+                'enabled' => true,
+                'allow_redirects' => 'never',
+            ],
+            'customer' => 'cus_aaaaaaaaaaaa11',
+            'description' => 'Donation 12345678-1234-1234-1234-1234567890ab to Create test charity',
+            'metadata' => [
+                'campaignId' => '123CampaignId12345',
+                'campaignName' => '123CampaignName',
+                'charityId' => '567CharitySFID',
+                'charityName' => 'Create test charity',
+                'donationId' => '12345678-1234-1234-1234-1234567890ab',
+                'environment' => getenv('APP_ENV'),
+                'feeCoverAmount' => '0.00',
+                'matchedAmount' => '0.00',
+                'stripeFeeRechargeGross' => '0.43', // Includes Gift Aid processing fee
+                'stripeFeeRechargeNet' => '0.43',
+                'stripeFeeRechargeVat' => '0.00',
+                'tipAmount' => '1.11',
+            ],
+            'setup_future_usage' => 'on_session',
+            'statement_descriptor' => 'Big Give Create test c',
+            'application_fee_amount' => 154,
+            'on_behalf_of' => 'unitTest_stripeAccount_123',
+            'transfer_data' => [
+                'destination' => 'unitTest_stripeAccount_123',
+            ],
+        ];
 
         $app = $this->getAppInstance();
 
@@ -815,7 +849,7 @@ class CreateTest extends TestCase
         ]);
 
         $stripeProphecy = $this->prophesize(Stripe::class);
-        $stripeProphecy->createPaymentIntent(static::somePaymentIntentArgs())
+        $stripeProphecy->createPaymentIntent(self::$somePaymentIntentArgs)
             ->willReturn($paymentIntentMockResult)
             ->shouldBeCalledOnce();
 
@@ -889,7 +923,7 @@ class CreateTest extends TestCase
         ]);
 
         $stripeProphecy = $this->prophesize(Stripe::class);
-        $stripeProphecy->createPaymentIntent(static::somePaymentIntentArgs())
+        $stripeProphecy->createPaymentIntent(self::$somePaymentIntentArgs)
             ->willReturn($paymentIntentMockResult)
             ->shouldBeCalledOnce();
 
@@ -951,7 +985,7 @@ class CreateTest extends TestCase
         );
 
         $stripeProphecy = $this->prophesize(Stripe::class);
-        $stripeProphecy->createPaymentIntent(static::somePaymentIntentArgs())
+        $stripeProphecy->createPaymentIntent(self::$somePaymentIntentArgs)
             ->willThrow($transfersOffError)
             ->shouldBeCalledOnce();
 
@@ -1070,40 +1104,5 @@ class CreateTest extends TestCase
         $campaignFunding->setCurrencyCode('GBP');
 
         return $campaignFunding;
-    }
-
-    private static function somePaymentIntentArgs(): array
-    {
-        return [
-            'amount' => 1311, // Pence including tip
-            'currency' => 'gbp',
-            'automatic_payment_methods' => [
-                'enabled' => true,
-                'allow_redirects' => 'never',
-            ],
-            'customer' => 'cus_aaaaaaaaaaaa11',
-            'description' => 'Donation 12345678-1234-1234-1234-1234567890ab to Create test charity',
-            'metadata' => [
-                'campaignId' => '123CampaignId12345',
-                'campaignName' => '123CampaignName',
-                'charityId' => '567CharitySFID',
-                'charityName' => 'Create test charity',
-                'donationId' => '12345678-1234-1234-1234-1234567890ab',
-                'environment' => getenv('APP_ENV'),
-                'feeCoverAmount' => '0.00',
-                'matchedAmount' => '0.00',
-                'stripeFeeRechargeGross' => '0.43', // Includes Gift Aid processing fee
-                'stripeFeeRechargeNet' => '0.43',
-                'stripeFeeRechargeVat' => '0.00',
-                'tipAmount' => '1.11',
-            ],
-            'setup_future_usage' => 'on_session',
-            'statement_descriptor' => 'Big Give Create test c',
-            'application_fee_amount' => 154,
-            'on_behalf_of' => 'unitTest_stripeAccount_123',
-            'transfer_data' => [
-                'destination' => 'unitTest_stripeAccount_123',
-            ],
-        ];
     }
 }


### PR DESCRIPTION
* Surface detail directly in Slack #stripe for whole team
* Return a 409 to reduce alarm noise for devs