### PR TITLE
MAT-369 – revert one-time parts of command changes

### DIFF
--- a/matchbot-cli.php
+++ b/matchbot-cli.php
@@ -77,7 +77,6 @@ $commands = [
     ),
     new ScheduledOutOfSyncFundsCheck(
         $psr11App->get(CampaignFundingRepository::class),
-        $psr11App->get(EntityManagerInterface::class),
         $psr11App->get(FundingWithdrawalRepository::class),
         $psr11App->get(Matching\Adapter::class),
         $chatter,

--- a/src/Application/Commands/HandleOutOfSyncFunds.php
+++ b/src/Application/Commands/HandleOutOfSyncFunds.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace MatchBot\Application\Commands;
 
-use Doctrine\ORM\EntityManagerInterface;
-use MatchBot\Application\Assertion;
 use MatchBot\Application\Matching;
 use MatchBot\Domain\CampaignFunding;
 use MatchBot\Domain\CampaignFundingRepository;
 use MatchBot\Domain\FundingWithdrawalRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -33,14 +32,16 @@ use Symfony\Component\Console\Output\OutputInterface;
  * taking action based on a reported mismatch, run the command a second time and check the same funds and amounts
  * are listed as the first time.
  */
+#[AsCommand(
+    name: 'matchbot:handle-out-of-sync-funds',
+    description: "Tries to match every fund's amount available to its FundingWithdrawals' total",
+)]
 class HandleOutOfSyncFunds extends LockingCommand
 {
     protected bool $outOfSyncFundFound = false;
-    protected static $defaultName = 'matchbot:handle-out-of-sync-funds';
 
     public function __construct(
         private CampaignFundingRepository $campaignFundingRepository,
-        private EntityManagerInterface $entityManager,
         private FundingWithdrawalRepository $fundingWithdrawalRepository,
         private Matching\Adapter $matchingAdapter
     ) {
@@ -49,7 +50,6 @@ class HandleOutOfSyncFunds extends LockingCommand
 
     protected function configure(): void
     {
-        $this->setDescription("Tries to match every fund's amount available to its FundingWithdrawals' total");
         $this->addArgument(
             'mode',
             InputArgument::REQUIRED,
@@ -64,8 +64,8 @@ class HandleOutOfSyncFunds extends LockingCommand
     protected function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $mode = $input->getArgument('mode');
-        if (!in_array($mode, ['check', 'fix', '2024-06-05-patch'], true)) {
-            $output->writeln('Please set the mode to "check" or "fix" or "2024-06-05-patch"');
+        if (!in_array($mode, ['check', 'fix'], true)) {
+            $output->writeln('Please set the mode to "check" or "fix"');
             return 1;
         }
 
@@ -77,17 +77,8 @@ class HandleOutOfSyncFunds extends LockingCommand
         $numFundingsCorrect = 0;
         $numFundingsOvermatched = 0;
         $numFundingsUndermatched = 0;
-
-        $problemIds = [];
         /** @var CampaignFunding[] $fundings */
-        if ($mode === '2024-06-05-patch') {
-            $problemIds = [29822];
-            $output->writeln('Running in 2024-06-05-patch mode');
-            // https://stackoverflow.com/a/52427915/2803757
-            $fundings = $this->campaignFundingRepository->findBy(['id' => $problemIds]);
-        } else {
-            $fundings = $this->campaignFundingRepository->findAll();
-        }
+        $fundings = $this->campaignFundingRepository->findAll();
         $numFundings = count($fundings);
 
         foreach ($fundings as $funding) {
@@ -117,26 +108,6 @@ class HandleOutOfSyncFunds extends LockingCommand
                 $numFundingsOvermatched++;
                 $overmatchAmount = bcsub($fundingWithdrawalTotal, $campaignFundingAllocated, 2);
                 $output->writeln("Funding {$funding->getId()} is over-matched by $overmatchAmount. $details");
-
-                if ($mode === '2024-06-05-patch' && in_array($funding->getId(), $problemIds, true)) {
-                    // Over match expected to be £300 but safest to drive it from live data and also assert.
-                    Assertion::eq(bccomp($overmatchAmount, '300.00', 2), 0);
-
-                    // This adapter fn already modifies the Doctrine $funding too, via `setAmountAvailable()`,
-                    // just without flushing.
-                    $newTotal = $this->matchingAdapter->subtractAmountWithoutSavingToDB($funding, $overmatchAmount);
-                    $output->writeln(
-                        "PATCH: Released {$overmatchAmount} to funding ID {$funding->getId()}. New total: $newTotal"
-                    );
-
-                    // Funding withdrawals were already correct. `$funding` available balance change is handled
-                    // by matching adapter above. Just need to persist the change.
-                    $this->entityManager->persist($funding);
-                    $this->entityManager->flush();
-
-                    $output->writeln("PATCH: Persisted changes to funding ID {$funding->getId()}");
-                }
-
                 continue;
             }
 

--- a/src/Application/Commands/ScheduledOutOfSyncFundsCheck.php
+++ b/src/Application/Commands/ScheduledOutOfSyncFundsCheck.php
@@ -2,10 +2,10 @@
 
 namespace MatchBot\Application\Commands;
 
-use Doctrine\ORM\EntityManagerInterface;
 use MatchBot\Application\Matching;
 use MatchBot\Domain\CampaignFundingRepository;
 use MatchBot\Domain\FundingWithdrawalRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
@@ -18,24 +18,25 @@ use Symfony\Component\Notifier\Bridge\Slack\SlackOptions;
 use Symfony\Component\Notifier\ChatterInterface;
 use Symfony\Component\Notifier\Message\ChatMessage;
 
+#[AsCommand(
+    name: 'matchbot:scheduled-out-of-sync-funds-check',
+    description: "For running via a cron job. Checks for out of sync funds but doesn't " .
+        "attempt to fix them. Sends output to Slack"
+)]
 class ScheduledOutOfSyncFundsCheck extends HandleOutOfSyncFunds
 {
     public function __construct(
         CampaignFundingRepository $campaignFundingRepository,
-        EntityManagerInterface $entityManager,
         FundingWithdrawalRepository $fundingWithdrawalRepository,
         Matching\Adapter $matchingAdapter,
         private ChatterInterface $chatter,
     ) {
-        parent::__construct($campaignFundingRepository, $entityManager, $fundingWithdrawalRepository, $matchingAdapter);
+        parent::__construct($campaignFundingRepository, $fundingWithdrawalRepository, $matchingAdapter);
     }
-
-    protected static $defaultName = 'matchbot:scheduled-out-of-sync-funds-check';
 
     protected function configure(): void
     {
-        $this->setDescription("For running via a cron job. Checks for out of sync funds but doesn't " .
-            "attempt to fix them. Sends output to Slack");
+        // Don't call parent which would add the `mode` argument.
     }
 
     protected function doExecute(InputInterface $input, OutputInterface $output): int

--- a/tests/Application/Commands/HandleOutOfSyncFundsTest.php
+++ b/tests/Application/Commands/HandleOutOfSyncFundsTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MatchBot\Tests\Application\Commands;
 
-use Doctrine\ORM\EntityManagerInterface;
 use MatchBot\Application\Commands\HandleOutOfSyncFunds;
 use MatchBot\Application\Matching\Adapter;
 use MatchBot\Domain\CampaignFunding;
@@ -88,7 +87,7 @@ class HandleOutOfSyncFundsTest extends TestCase
 
         $expectedOutputLines = [
             'matchbot:handle-out-of-sync-funds starting!',
-            'Please set the mode to "check" or "fix" or "2024-06-05-patch"',
+            'Please set the mode to "check" or "fix"',
             'matchbot:handle-out-of-sync-funds complete!',
         ];
         $this->assertEquals(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
@@ -251,7 +250,6 @@ class HandleOutOfSyncFundsTest extends TestCase
 
         $command = new HandleOutOfSyncFunds(
             $campaignRepo,
-            $this->prophesize(EntityManagerInterface::class)->reveal(),
             $withdrawalRepo,
             $adapter,
         );


### PR DESCRIPTION
Also move commands we're editing to the faster, non-deprecated attribute definition approach