### PR TITLE
MAT-370 – fix `DonationService::runWithPossibleRetry()` silently swallowing errors

### DIFF
--- a/src/Application/Actions/Donations/Create.php
+++ b/src/Application/Actions/Donations/Create.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace MatchBot\Application\Actions\Donations;
 
+use Doctrine\DBAL\Exception\ServerException as DBALServerException;
+use Doctrine\ORM\Exception\ORMException;
 use MatchBot\Application\Actions\Action;
 use MatchBot\Application\Actions\ActionError;
 use MatchBot\Application\Actions\ActionPayload;
@@ -137,6 +139,19 @@ class Create extends Action
                     new ActionError(
                         ActionError::SERVER_ERROR,
                         'Could not make Stripe Payment Intent (B)'
+                    ),
+                ),
+            );
+        } catch (ORMException | DBALServerException $ex) {
+            // '(D)' errors are DB persistence issues, typically ones that still exist after some retries.
+            return $this->respond(
+                $response,
+                new ActionPayload(
+                    500,
+                    null,
+                    new ActionError(
+                        ActionError::SERVER_ERROR,
+                        'Could not make Stripe Payment Intent (D)'
                     ),
                 ),
             );

--- a/tests/Application/Actions/Donations/CreateTest.php
+++ b/tests/Application/Actions/Donations/CreateTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace MatchBot\Tests\Application\Actions\Donations;
 
 use DI\Container;
+use Doctrine\DBAL\Exception\ServerException as DBALServerException;
 use Los\RateLimit\Exception\MissingRequirement;
 use MatchBot\Application\Actions\ActionPayload;
 use MatchBot\Application\HttpModels\DonationCreate;
-use MatchBot\Application\Notifier\StripeChatterInterface;
 use MatchBot\Application\Persistence\RetrySafeEntityManager;
 use MatchBot\Client\Stripe;
 use MatchBot\Domain\Campaign;
@@ -27,6 +27,8 @@ use Slim\App;
 use Slim\Exception\HttpUnauthorizedException;
 use Stripe\Exception\PermissionException;
 use Stripe\PaymentIntent;
+use Symfony\Component\Clock\ClockInterface;
+use Symfony\Component\Clock\MockClock;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use UnexpectedValueException;
 
@@ -869,6 +871,59 @@ class CreateTest extends TestCase
         $this->assertEquals('1.11', $payloadArray['donation']['tipAmount']);
         $this->assertEquals('567CharitySFID', $payloadArray['donation']['charityId']);
         $this->assertEquals('123CampaignId12345', $payloadArray['donation']['projectId']);
+    }
+
+    public function testErrorWhenAllDbPersistCallsFail(): void
+    {
+        $donation = $this->getTestDonation(true, true, true);
+
+        $app = $this->getAppInstance();
+        $container = $app->getContainer();
+        \assert($container instanceof Container);
+        $donationRepoProphecy = $this->prophesize(DonationRepository::class);
+
+        // Use a custom Prophecy Promise to vary the simulated behaviour.
+        $donationRepoProphecy
+            ->buildFromApiRequest(Argument::type(DonationCreate::class))
+            ->willReturn($donation)
+            ->shouldBeCalledOnce();
+
+        $donationRepoProphecy->push(Argument::type(Donation::class), true)->willReturn(true)->shouldNotBeCalled();
+        // No allocation because earlier persist will throw every time in this test.
+        $donationRepoProphecy->allocateMatchFunds(Argument::type(Donation::class))->shouldNotBeCalled();
+
+        $entityManagerProphecy = $this->prophesize(RetrySafeEntityManager::class);
+        // These are called once after initial ID setup and once after Stripe fields added.
+        $entityManagerProphecy->persistWithoutRetries(Argument::type(Donation::class))
+            ->willThrow($this->prophesize(DBALServerException::class)->reveal())
+            ->shouldBeCalledTimes(3); // DonationService::MAX_RETRY_COUNT
+        $entityManagerProphecy->flush()->shouldNotBeCalled();
+
+        $stripeProphecy = $this->prophesize(Stripe::class);
+        $stripeProphecy->createPaymentIntent(self::$somePaymentIntentArgs)
+            ->shouldNotBeCalled();
+
+        $container->set(ClockInterface::class, new MockClock());
+        $container->set(DonationRepository::class, $donationRepoProphecy->reveal());
+        $container->set(RetrySafeEntityManager::class, $entityManagerProphecy->reveal());
+        $container->set(Stripe::class, $stripeProphecy->reveal());
+
+        $data = $this->encode($donation);
+        $request = $this->createRequest('POST', TestData\Identity::getTestPersonNewDonationEndpoint(), $data);
+        $response = $app->handle($this->addDummyPersonAuth($request));
+
+        $payload = (string) $response->getBody();
+
+        $this->assertJson($payload);
+        $this->assertEquals(500, $response->getStatusCode());
+
+        /** @var array $payloadArray */
+        $payloadArray = json_decode($payload, true);
+
+        $this->assertEquals(['error' => [
+            'type' => 'SERVER_ERROR',
+            'description' => 'Could not make Stripe Payment Intent (D)',
+        ]], $payloadArray);
     }
 
     /**


### PR DESCRIPTION
Prevent problems from donation create actions continuing after persistent errors. And add a test for `Donations\Create` specifically to verify that errors are surfaced in API responses and that exactly the maximum # of attempts are made at persistence before giving up.