### PR TITLE
MAT-363 – re-apply work to queue Salesforce pushes, log more, and lock Donations proactively

### DIFF
--- a/app/dependencies.php
+++ b/app/dependencies.php
@@ -12,6 +12,8 @@ use Los\RateLimit\RateLimitOptions;
 use MatchBot\Application\Auth;
 use MatchBot\Application\Auth\IdentityToken;
 use MatchBot\Application\Matching;
+use MatchBot\Application\Messenger\DonationStateUpdated;
+use MatchBot\Application\Messenger\Handler\DonationStateUpdatedHandler;
 use MatchBot\Application\Messenger\Handler\GiftAidResultHandler;
 use MatchBot\Application\Messenger\Handler\StripePayoutHandler;
 use MatchBot\Application\Messenger\StripePayout;
@@ -238,6 +240,7 @@ return function (ContainerBuilder $containerBuilder) {
                 [
                     Messages\Donation::class => [ClaimBotTransport::class],
                     StripePayout::class => [TransportInterface::class],
+                    DonationStateUpdated::class => [TransportInterface::class],
                 ],
                 $c,
             ));
@@ -247,6 +250,7 @@ return function (ContainerBuilder $containerBuilder) {
                 [
                     Messages\Donation::class => [$c->get(GiftAidResultHandler::class)],
                     StripePayout::class => [$c->get(StripePayoutHandler::class)],
+                    DonationStateUpdated::class => [$c->get(DonationStateUpdatedHandler::class)],
                 ],
             ));
             $handleMiddleware->setLogger($logger);
@@ -354,11 +358,18 @@ return function (ContainerBuilder $containerBuilder) {
 
         RoutableMessageBus::class => static function (ContainerInterface $c): RoutableMessageBus {
             $busContainer = new Container();
-            $busContainer->set('claimbot.donation.claim', $c->get(MessageBusInterface::class));
-            $busContainer->set('claimbot.donation.result', $c->get(MessageBusInterface::class));
-            $busContainer->set(\Stripe\Event::PAYOUT_PAID, $c->get(MessageBusInterface::class));
+            $bus = $c->get(MessageBusInterface::class);
 
-            return new RoutableMessageBus($busContainer);
+            /**
+             * Every message defaults to our only bus, so we think these are technically redundant for
+             * now. This also means the list isn't exhaustive – we *know* we don't need
+             * {@see DonationStateUpdated} here. Removing `claimbot` items would require some more testing.
+             */
+            $busContainer->set('claimbot.donation.claim', $bus);
+            $busContainer->set('claimbot.donation.result', $bus);
+            $busContainer->set(\Stripe\Event::PAYOUT_PAID, $bus);
+
+            return new RoutableMessageBus($busContainer, $bus);
         },
 
         SerializerInterface::class => static function (ContainerInterface $c): SerializerInterface {

--- a/consume-messages.sh
+++ b/consume-messages.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# Workaround for not being able to directly invoke commands with arguments from docker-compose for local development
+
+./matchbot messenger:consume

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,25 @@ services:
       - redis
     networks:
       - matchbot
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  app-message-consumer:
+    image: thebiggive/php:dev-8.3
+    platform: linux/amd64
+    command:
+      - './consume-messages.sh'
+    volumes:
+      - .:/var/www/html
+    env_file:
+      - .env
+    depends_on:
+      - db
+      - redis
+    networks:
+      - matchbot
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   db:
     image: mysql:8.0

--- a/matchbot-cli.php
+++ b/matchbot-cli.php
@@ -69,12 +69,7 @@ $commands = [
     ),
     new ExpireMatchFunds($psr11App->get(DonationRepository::class)),
     $psr11App->get(HandleOutOfSyncFunds::class),
-    new RedistributeMatchFunds(
-        $psr11App->get(CampaignFundingRepository::class),
-        $now,
-        $psr11App->get(DonationRepository::class),
-        $psr11App->get(LoggerInterface::class),
-    ),
+    $psr11App->get(RedistributeMatchFunds::class),
     new ScheduledOutOfSyncFundsCheck(
         $psr11App->get(CampaignFundingRepository::class),
         $psr11App->get(FundingWithdrawalRepository::class),
@@ -86,10 +81,7 @@ $commands = [
         $psr11App->get(CampaignFundingRepository::class),
         $psr11App->get(Matching\Adapter::class)
     ),
-    new RetrospectivelyMatch(
-        $psr11App->get(DonationRepository::class),
-        $chatter,
-    ),
+    $psr11App->get(RetrospectivelyMatch::class),
     new UpdateCampaigns(
         $psr11App->get(CampaignRepository::class),
         $psr11App->get(EntityManagerInterface::class),

--- a/phpunit-integration.xml
+++ b/phpunit-integration.xml
@@ -27,6 +27,7 @@
     <env name="STRIPE_API_VERSION" value="2022-08-01" />
     <env name="STRIPE_SECRET_KEY" value="sk_test_unitTestFakeKey" force="true"/>
     <env name="STRIPE_WEBHOOK_SIGNING_SECRET" value="whsec_test_unitTestFakeKey" force="true"/>
+    <env name="MESSENGER_TRANSPORT_DSN" value="redis://127.0.0.1:6379/matchbot-jobs" force="false"/> <!-- 127.0.0.1 is redis host on CI server -->
     <env name="STRIPE_CONNECT_WEBHOOK_SIGNING_SECRET" value="whsec_test_unitTestFakeConnectKey" force="true"/>
     <env name="VAT_PERCENTAGE_OLD" value="0" force="true" />
     <env name="VAT_PERCENTAGE_NEW" value="2" force="true" />

--- a/src/Application/Actions/Donations/Create.php
+++ b/src/Application/Actions/Donations/Create.php
@@ -15,6 +15,7 @@ use MatchBot\Application\Auth\PersonManagementAuthMiddleware;
 use MatchBot\Application\Auth\PersonWithPasswordAuthMiddleware;
 use MatchBot\Application\HttpModels\DonationCreate;
 use MatchBot\Application\HttpModels\DonationCreatedResponse;
+use MatchBot\Application\Messenger\DonationStateUpdated;
 use MatchBot\Domain\DomainException\CampaignNotOpen;
 use MatchBot\Domain\DomainException\CharityAccountLacksNeededCapaiblities;
 use MatchBot\Domain\DomainException\CouldNotMakeStripePaymentIntent;
@@ -24,6 +25,8 @@ use MatchBot\Domain\DonationService;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\RoutableMessageBus;
 use Symfony\Component\Serializer\Exception\UnexpectedValueException;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -33,6 +36,7 @@ class Create extends Action
         private DonationService $donationService,
         private SerializerInterface $serializer,
         LoggerInterface $logger,
+        private RoutableMessageBus $bus,
     ) {
         parent::__construct($logger);
     }
@@ -156,6 +160,8 @@ class Create extends Action
                 ),
             );
         }
+
+        $this->bus->dispatch(new Envelope(DonationStateUpdated::fromDonation($donation, isNew: true)));
 
         $data = new DonationCreatedResponse();
         $data->donation = $donation->toApiModel();

--- a/src/Application/Actions/Donations/Update.php
+++ b/src/Application/Actions/Donations/Update.php
@@ -11,6 +11,7 @@ use MatchBot\Application\Actions\Action;
 use MatchBot\Application\Actions\ActionError;
 use MatchBot\Application\Actions\ActionPayload;
 use MatchBot\Application\HttpModels;
+use MatchBot\Application\Messenger\DonationStateUpdated;
 use MatchBot\Client\Stripe;
 use MatchBot\Domain\DomainException\DomainRecordNotFoundException;
 use MatchBot\Domain\Donation;
@@ -27,6 +28,8 @@ use Stripe\Exception\InvalidRequestException;
 use Stripe\Exception\RateLimitException;
 use Stripe\PaymentIntent;
 use Symfony\Component\Clock\ClockInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\RoutableMessageBus;
 use Symfony\Component\Serializer\Exception\UnexpectedValueException;
 use Symfony\Component\Serializer\SerializerInterface;
 use TypeError;
@@ -49,6 +52,7 @@ class Update extends Action
         private Stripe $stripe,
         LoggerInterface $logger,
         private ClockInterface $clock,
+        private RoutableMessageBus $bus,
     ) {
         parent::__construct($logger);
     }
@@ -521,9 +525,7 @@ class Update extends Action
             return;
         }
 
-        // We log if this fails but don't worry the client about it. We'll just re-try
-        // sending the updated status to Salesforce in a future batch sync.
-        $this->donationRepository->push($donation, false);
+        $this->bus->dispatch(new Envelope(DonationStateUpdated::fromDonation($donation)));
     }
 
     /**

--- a/src/Application/Commands/RedistributeMatchFunds.php
+++ b/src/Application/Commands/RedistributeMatchFunds.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 namespace MatchBot\Application\Commands;
 
+use Doctrine\ORM\EntityManagerInterface;
+use MatchBot\Application\Messenger\DonationStateUpdated;
 use MatchBot\Domain\CampaignFundingRepository;
 use MatchBot\Domain\DonationRepository;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\RoutableMessageBus;
 
 /**
  * Redistribute match funding allocations where possible, from lower to higher priority match fund pots.
@@ -19,9 +23,11 @@ class RedistributeMatchFunds extends LockingCommand
 
     public function __construct(
         private CampaignFundingRepository $campaignFundingRepository,
+        private EntityManagerInterface $entityManager,
         private \DateTimeImmutable $now,
         private DonationRepository $donationRepository,
         private LoggerInterface $logger,
+        private RoutableMessageBus $bus,
     ) {
         parent::__construct();
     }
@@ -95,7 +101,8 @@ class RedistributeMatchFunds extends LockingCommand
                 ));
             }
 
-            $this->donationRepository->push($donation, false);
+            $this->entityManager->flush();
+            $this->bus->dispatch(new Envelope(DonationStateUpdated::fromDonation($donation)));
             $donationsAmended++;
         }
 

--- a/src/Application/Commands/RetrospectivelyMatch.php
+++ b/src/Application/Commands/RetrospectivelyMatch.php
@@ -5,10 +5,14 @@ declare(strict_types=1);
 namespace MatchBot\Application\Commands;
 
 use DateTime;
+use Doctrine\ORM\EntityManagerInterface;
+use MatchBot\Application\Messenger\DonationStateUpdated;
 use MatchBot\Domain\DonationRepository;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\RoutableMessageBus;
 use Symfony\Component\Notifier\Bridge\Slack\Block\SlackHeaderBlock;
 use Symfony\Component\Notifier\Bridge\Slack\Block\SlackSectionBlock;
 use Symfony\Component\Notifier\Bridge\Slack\SlackOptions;
@@ -29,6 +33,8 @@ class RetrospectivelyMatch extends LockingCommand
     public function __construct(
         private DonationRepository $donationRepository,
         private ChatterInterface $chatter,
+        private RoutableMessageBus $bus,
+        private EntityManagerInterface $entityManager,
     ) {
         parent::__construct();
     }
@@ -74,7 +80,8 @@ class RetrospectivelyMatch extends LockingCommand
             $amountAllocated = $this->donationRepository->allocateMatchFunds($donation);
 
             if (bccomp($amountAllocated, '0.00', 2) === 1) {
-                $this->donationRepository->push($donation, false);
+                $this->entityManager->flush();
+                $this->bus->dispatch(new Envelope(DonationStateUpdated::fromDonation($donation)));
                 $numWithMatchingAllocated++;
                 $totalNewMatching = bcadd($totalNewMatching, $amountAllocated, 2);
 

--- a/src/Application/Messenger/DonationStateUpdated.php
+++ b/src/Application/Messenger/DonationStateUpdated.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace MatchBot\Application\Messenger;
+
+use MatchBot\Application\Assertion;
+use MatchBot\Domain\Donation;
+
+readonly class DonationStateUpdated
+{
+    private function __construct(
+        public string $donationUUID,
+        public bool $donationIsNew
+    ) {
+        Assertion::uuid($this->donationUUID);
+    }
+
+    public static function fromDonation(Donation $donation, bool $isNew = false): self
+    {
+        return new self($donation->getUuid(), $isNew);
+    }
+}

--- a/src/Application/Messenger/Handler/DonationStateUpdatedHandler.php
+++ b/src/Application/Messenger/Handler/DonationStateUpdatedHandler.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace MatchBot\Application\Messenger\Handler;
+
+use MatchBot\Application\Assertion;
+use MatchBot\Application\Messenger\DonationStateUpdated;
+use MatchBot\Domain\DonationRepository;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Handler\Acknowledger;
+use Symfony\Component\Messenger\Handler\BatchHandlerInterface;
+use Symfony\Component\Messenger\Handler\BatchHandlerTrait;
+
+class DonationStateUpdatedHandler implements BatchHandlerInterface
+{
+    use BatchHandlerTrait;
+
+    public function __construct(
+        private DonationRepository $donationRepository,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(DonationStateUpdated $donationStateUpdated, Acknowledger $ack = null)
+    {
+        return $this->handle($donationStateUpdated, $ack);
+    }
+
+    /**
+     * @param list<array{0: DonationStateUpdated, 1: Acknowledger}> $jobsForThisDonation
+     */
+    private function pushOneDonation(string $donationUUID, array $jobsForThisDonation): void
+    {
+        /** @psalm-suppress MixedPropertyFetch - allSatisfy isn't written with generics */
+        Assertion::allSatisfy(
+            $jobsForThisDonation,
+            static fn(array $job) => $job[0]->donationUUID === $donationUUID
+        );
+
+        $donation = $this->donationRepository->findOneBy(['uuid' => $donationUUID]);
+
+        if ($donation === null) {
+            foreach ($jobsForThisDonation as $job) {
+                $job[1]->nack(new \RuntimeException('Donation not found'));
+            }
+            return;
+        }
+
+        // below can be replaced with array_find when we upgrade to PHP 8.4
+        $donationIsNew = array_reduce(
+            array_map(static fn($job) => $job[0]->donationIsNew, $jobsForThisDonation),
+            static fn(bool $left, bool $right) => $left || $right,
+            false,
+        );
+
+        try {
+            $this->donationRepository->push($donation, $donationIsNew);
+        } catch (\Throwable $exception) {
+            $this->logger->error(sprintf(
+                '%s pushing donation: %s',
+                get_class($exception),
+                $exception->getMessage(),
+            ));
+
+            foreach ($jobsForThisDonation as $job) {
+                $job[1]->nack($exception);
+            }
+            return;
+        }
+
+        foreach ($jobsForThisDonation as $job) {
+            $job[1]->ack();
+        }
+    }
+
+    /**
+     * @psalm-suppress MoreSpecificImplementedParamType - this doesn't need to be LSP compliant with the interface
+     * @param list<array{0: DonationStateUpdated, 1: Acknowledger}> $jobs
+     */
+    private function process(array $jobs): void
+    {
+        $jobsByDonationUUID = [];
+
+        foreach ($jobs as [$message, $ack]) {
+            /**
+             * @psalm-suppress UnnecessaryVarAnnotation - necessary for PHPStorm
+             * @var \MatchBot\Application\Messenger\DonationStateUpdated $message
+             * @var Acknowledger $ack
+             */
+            $jobsByDonationUUID[$message->donationUUID][] = [$message, $ack];
+        }
+
+        foreach ($jobsByDonationUUID as $donationUUID => $jobsForThisDonation) {
+            $this->pushOneDonation($donationUUID, $jobsForThisDonation);
+        }
+    }
+}

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -319,6 +319,9 @@ class Donation extends SalesforceWriteProxy
      */
     private function __construct(string $amount, string $currencyCode, PaymentMethodType $paymentMethodType)
     {
+        // We only fully support GBP, however we have test cases covering the following currencies:
+        Assertion::inArray($currencyCode, ['GBP', 'CAD', 'USD', 'SEK']);
+
         $this->setUuid(Uuid::uuid4());
         $this->fundingWithdrawals = new ArrayCollection();
         $this->currencyCode = $currencyCode;

--- a/src/Domain/DonationService.php
+++ b/src/Domain/DonationService.php
@@ -230,9 +230,6 @@ readonly class DonationService
             );
         }
 
-        // Attempt immediate sync. Buffered for a future batch sync if the SF call fails.
-        $this->donationRepository->push($donation, true);
-
         return $donation;
     }
 

--- a/src/Domain/SalesforceWriteProxy.php
+++ b/src/Domain/SalesforceWriteProxy.php
@@ -46,6 +46,17 @@ abstract class SalesforceWriteProxy extends SalesforceProxy
      */
     public const PUSH_STATUS_REMOVED = 'removed';
 
+    public const array POSSIBLE_PUSH_STATUSES = [
+        self::PUSH_STATUS_NOT_SENT,
+        self::PUSH_STATUS_PENDING_CREATE,
+        self::PUSH_STATUS_CREATING,
+        self::PUSH_STATUS_PENDING_UPDATE,
+        self::PUSH_STATUS_PENDING_ADDITIONAL_UPDATE,
+        self::PUSH_STATUS_UPDATING,
+        self::PUSH_STATUS_COMPLETE,
+        self::PUSH_STATUS_REMOVED,
+    ];
+
     /**
      * @return bool Whether the entity has been modified in MatchBot subsequently after its creation.
      */

--- a/src/Domain/SalesforceWriteProxyRepository.php
+++ b/src/Domain/SalesforceWriteProxyRepository.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace MatchBot\Domain;
 
-use DateTime;
-use Doctrine\Common\Collections\Criteria;
+use Doctrine\DBAL\LockMode;
+use MatchBot\Application\Assertion;
 use MatchBot\Application\Commands\PushDonations;
 use MatchBot\Client;
 
@@ -46,7 +46,7 @@ abstract class SalesforceWriteProxyRepository extends SalesforceProxyRepository
              * @see SalesforceWriteProxyRepository::postPush()
              * @see PushDonations
              */
-            $proxy->setSalesforcePushStatus(SalesforceWriteProxy::PUSH_STATUS_PENDING_ADDITIONAL_UPDATE);
+            $this->safelySetPushStatus($proxy, SalesforceWriteProxy::PUSH_STATUS_PENDING_ADDITIONAL_UPDATE, $isNew);
             $this->logInfo('Queued extra update for ' . get_class($proxy) . ' ' . $proxy->getId());
 
             // This is the best we can do in this scenario while awaiting the first Salesforce response,
@@ -58,10 +58,10 @@ abstract class SalesforceWriteProxyRepository extends SalesforceProxyRepository
         $this->logInfo(($isNew ? 'Pushing ' : 'Updating ') . get_class($proxy) . ' ' . $proxy->getId() . '...');
         $this->prePush($proxy, $isNew);
 
-        $proxy->setSalesforcePushStatus(
-            $isNew ? SalesforceWriteProxy::PUSH_STATUS_CREATING : SalesforceWriteProxy::PUSH_STATUS_UPDATING
-        );
-        $this->save($proxy);
+        $status = $isNew
+            ? SalesforceWriteProxy::PUSH_STATUS_CREATING
+            : SalesforceWriteProxy::PUSH_STATUS_UPDATING;
+        $this->safelySetPushStatus($proxy, $status, $isNew);
 
         if ($isNew) {
             $success = $this->doCreate($proxy);
@@ -101,7 +101,7 @@ abstract class SalesforceWriteProxyRepository extends SalesforceProxyRepository
             $success = $this->doUpdate($proxy);
         }
 
-        $this->postPush($success, $proxy);
+        $this->postPush($success, $proxy, $isNew);
 
         return $success;
     }
@@ -170,31 +170,30 @@ abstract class SalesforceWriteProxyRepository extends SalesforceProxyRepository
     protected function prePush(SalesforceWriteProxy $proxy, bool $isNew): void
     {
         if ($isNew || empty($proxy->getSalesforceId())) {
-            $proxy->setSalesforcePushStatus(SalesforceWriteProxy::PUSH_STATUS_PENDING_CREATE);
+            $this->safelySetPushStatus($proxy, SalesforceWriteProxy::PUSH_STATUS_CREATING, $isNew);
         } else {
-            $proxy->setSalesforcePushStatus(SalesforceWriteProxy::PUSH_STATUS_PENDING_UPDATE);
+            $this->safelySetPushStatus($proxy, SalesforceWriteProxy::PUSH_STATUS_UPDATING, $isNew);
         }
     }
 
     /**
      * @psalm-param T $proxy
      */
-    protected function postPush(bool $success, SalesforceWriteProxy $proxy): void
+    protected function postPush(bool $success, SalesforceWriteProxy $proxy, bool $isNew): void
     {
         $shouldRePush = false;
         if ($success) {
-            $proxy->setSalesforceLastPush(new DateTime('now'));
             if (
                 $proxy->getSalesforcePushStatus() === SalesforceWriteProxy::PUSH_STATUS_PENDING_CREATE &&
                 $proxy->hasPostCreateUpdates()
             ) {
-                $proxy->setSalesforcePushStatus(SalesforceWriteProxy::PUSH_STATUS_PENDING_UPDATE);
+                $this->safelySetPushStatus($proxy, SalesforceWriteProxy::PUSH_STATUS_PENDING_UPDATE, $isNew);
                 $shouldRePush = true;
             } elseif (
                 $proxy->getSalesforcePushStatus() ===
                 SalesforceWriteProxy::PUSH_STATUS_PENDING_ADDITIONAL_UPDATE
             ) {
-                $proxy->setSalesforcePushStatus(SalesforceWriteProxy::PUSH_STATUS_PENDING_UPDATE);
+                $this->safelySetPushStatus($proxy, SalesforceWriteProxy::PUSH_STATUS_PENDING_UPDATE, $isNew);
                 $this->logInfo(sprintf(
                     '... marking for additional later push %s %d: SF ID %s',
                     get_class($proxy),
@@ -202,16 +201,22 @@ abstract class SalesforceWriteProxyRepository extends SalesforceProxyRepository
                     $proxy->getSalesforceId(),
                 ));
             } else {
-                $proxy->setSalesforcePushStatus(SalesforceWriteProxy::PUSH_STATUS_COMPLETE);
+                $this->safelySetPushStatus($proxy, SalesforceWriteProxy::PUSH_STATUS_COMPLETE, $isNew);
             }
-            $this->logInfo('... pushed ' . get_class($proxy) . " {$proxy->getId()}: SF ID {$proxy->getSalesforceId()}");
+            $this->logInfo(sprintf(
+                '... %s %s %s : SF ID %s',
+                $isNew ? 'Created' : 'Updated',
+                get_class($proxy),
+                $proxy->getId(),
+                $proxy->getSalesforceId(),
+            ));
 
             if ($shouldRePush) {
                 if ($this->doUpdate($proxy)) { // Make sure *not* to call push() again to avoid doing this recursively!
-                    $proxy->setSalesforcePushStatus(SalesforceWriteProxy::PUSH_STATUS_COMPLETE);
+                    $this->safelySetPushStatus($proxy, SalesforceWriteProxy::PUSH_STATUS_COMPLETE, $isNew);
                     $this->logInfo('... plus interim updates for ' . get_class($proxy) . " {$proxy->getId()}");
                 } else {
-                    $proxy->setSalesforcePushStatus(SalesforceWriteProxy::PUSH_STATUS_PENDING_UPDATE);
+                    $this->safelySetPushStatus($proxy, SalesforceWriteProxy::PUSH_STATUS_PENDING_UPDATE, $isNew);
                     $this->logError(sprintf(
                         '... with error on interim updates for %s %d',
                         get_class($proxy),
@@ -223,16 +228,25 @@ abstract class SalesforceWriteProxyRepository extends SalesforceProxyRepository
             $newStatus = $proxy->getSalesforcePushStatus() === SalesforceWriteProxy::PUSH_STATUS_CREATING
                 ? SalesforceWriteProxy::PUSH_STATUS_PENDING_CREATE
                 : SalesforceWriteProxy::PUSH_STATUS_PENDING_UPDATE;
-            $proxy->setSalesforcePushStatus($newStatus);
+            $this->safelySetPushStatus($proxy, $newStatus, $isNew);
             $this->logWarning('... error pushing ' . get_class($proxy) . ' ' . $proxy->getId());
         }
-
-        $this->save($proxy);
     }
 
-    private function save(SalesforceWriteProxy $proxy): void
+    private function safelySetPushStatus(SalesforceWriteProxy $proxy, string $status, bool $isNew): void
     {
+        Assertion::inArray($status, SalesforceWriteProxy::POSSIBLE_PUSH_STATUSES);
+
+        $this->getEntityManager()->beginTransaction();
+
+        if (!$isNew) {
+            $this->getEntityManager()->refresh($proxy, LockMode::PESSIMISTIC_WRITE);
+        }
+
+        $proxy->setSalesforcePushStatus($status);
+        $proxy->setSalesforceLastPush(new \DateTime('now'));
         $this->getEntityManager()->persist($proxy);
         $this->getEntityManager()->flush();
+        $this->getEntityManager()->commit();
     }
 }

--- a/src/Domain/SalesforceWriteProxyRepository.php
+++ b/src/Domain/SalesforceWriteProxyRepository.php
@@ -132,6 +132,13 @@ abstract class SalesforceWriteProxyRepository extends SalesforceProxyRepository
             self::MAX_PER_BULK_PUSH,
         );
 
+        if ($proxiesToCreate !== []) {
+            $count = count($proxiesToCreate);
+            $this->logger->error(
+                "Found $count pending items to push to SF, suggests push via Symfony Messenger failed"
+            );
+        }
+
         foreach ($proxiesToCreate as $proxy) {
             if ($proxy->getUpdatedDate() > $fiveMinutesAgo) {
                 // fetching the proxy just to skip it here is a bit wasteful but the performance cost is low

--- a/src/Domain/SalesforceWriteProxyRepository.php
+++ b/src/Domain/SalesforceWriteProxyRepository.php
@@ -208,7 +208,7 @@ abstract class SalesforceWriteProxyRepository extends SalesforceProxyRepository
                 $isNew ? 'Created' : 'Updated',
                 get_class($proxy),
                 $proxy->getId(),
-                $proxy->getSalesforceId(),
+                $proxy->getSalesforceId() ?? 'unknown',
             ));
 
             if ($shouldRePush) {
@@ -220,7 +220,7 @@ abstract class SalesforceWriteProxyRepository extends SalesforceProxyRepository
                     $this->logError(sprintf(
                         '... with error on interim updates for %s %d',
                         get_class($proxy),
-                        $proxy->getId(),
+                        $proxy->getId() ?? -1,
                     ));
                 }
             }
@@ -233,6 +233,9 @@ abstract class SalesforceWriteProxyRepository extends SalesforceProxyRepository
         }
     }
 
+    /**
+     * @psalm-param SalesforceWriteProxy::PUSH_STATUS_* $status
+     */
     private function safelySetPushStatus(SalesforceWriteProxy $proxy, string $status, bool $isNew): void
     {
         Assertion::inArray($status, SalesforceWriteProxy::POSSIBLE_PUSH_STATUSES);

--- a/tests/Application/Actions/Donations/ConfirmTest.php
+++ b/tests/Application/Actions/Donations/ConfirmTest.php
@@ -24,13 +24,41 @@ use Stripe\Exception\InvalidRequestException;
 use Stripe\Exception\UnknownApiErrorException;
 use Stripe\PaymentIntent;
 use Stripe\PaymentMethod;
+use Symfony\Component\Messenger\RoutableMessageBus;
 
 class ConfirmTest extends TestCase
 {
+    private Confirm $sut;
+
+    /** @var ObjectProphecy<Stripe>  */
+    private ObjectProphecy $stripeProphecy;
+    private bool $donationIsCancelled = false;
+
+    /** @var ObjectProphecy<EntityManagerInterface>  */
+    private ObjectProphecy $entityManagerProphecy;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->stripeProphecy = $this->prophesize(Stripe::class);
+        $messageBusStub = $this->createStub(RoutableMessageBus::class);
+        $messageBusStub->method('dispatch')->willReturnArgument(0);
+
+        $this->entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
+
+        $this->sut = new Confirm(
+            new NullLogger(),
+            $this->getDonationRepository(),
+            $this->stripeProphecy->reveal(),
+            $this->entityManagerProphecy->reveal(),
+            $messageBusStub,
+        );
+    }
+
     public function testItConfirmsACardDonation(): void
     {
         // arrange
-        $stripeClientProphecy = $this->fakeStripeClient(
+        $this->fakeStripeClient(
             cardDetails: ['brand' => 'discover', 'country' => 'some-country'],
             paymentMethodId: 'PAYMENT_METHOD_ID',
             updatedIntentData: [
@@ -52,20 +80,12 @@ class ConfirmTest extends TestCase
         );
 
         // Make sure the latest fees, based on card type, are saved to the database.
-        $em = $this->prophesize(EntityManagerInterface::class);
-        $em->beginTransaction()->shouldBeCalledOnce();
-        $em->flush()->shouldBeCalledOnce();
-        $em->commit()->shouldBeCalledOnce();
-
-        $sut = new Confirm(
-            new NullLogger(),
-            $this->getDonationRepository(),
-            $stripeClientProphecy->reveal(),
-            $em->reveal(),
-        );
+        $this->entityManagerProphecy->beginTransaction()->shouldBeCalledOnce();
+        $this->entityManagerProphecy->flush()->shouldBeCalledOnce();
+        $this->entityManagerProphecy->commit()->shouldBeCalledOnce();
 
         // act
-        $response = $this->callConfirm($sut);
+        $response = $this->callConfirm($this->sut);
 
         // assert
 
@@ -80,31 +100,25 @@ class ConfirmTest extends TestCase
     {
         // arrange
         $newCharityFee = '42.00';
-        $stripeClientProphecy = $this->successReadyFakeStripeClient(
+        $this->successReadyFakeStripeClient(
             amountInWholeUnits: $newCharityFee,
             confirmCallExpected: false,
         );
-
-        $sut = new Confirm(
-            new NullLogger(),
-            $this->getDonationRepository(donationIsCancelled: true),
-            $stripeClientProphecy->reveal(),
-            $this->prophesize(EntityManagerInterface::class)->reveal()
-        );
+        $this->donationIsCancelled = true;
 
         // assert
         $this->expectException(HttpBadRequestException::class);
         $this->expectExceptionMessage("Donation status is 'Cancelled', must be 'Pending' to confirm payment");
 
         // act
-        $this->callConfirm($sut);
+        $this->callConfirm($this->sut);
     }
 
     public function testItReturns402OnDecline(): void
     {
         // arrange
 
-        $stripeClientProphecy = $this->fakeStripeClient(
+        $this->fakeStripeClient(
             cardDetails: ['brand' => 'discover', 'country' => 'some-country'],
             paymentMethodId: 'PAYMENT_METHOD_ID',
             updatedIntentData: [
@@ -125,15 +139,9 @@ class ConfirmTest extends TestCase
             confirmFailsWithPaymentMethodUsedError: false,
         );
 
-        $sut = new Confirm(
-            new NullLogger(),
-            $this->getDonationRepository(),
-            $stripeClientProphecy->reveal(),
-            $this->prophesize(EntityManagerInterface::class)->reveal()
-        );
 
         // act
-        $response = $this->callConfirm($sut);
+        $response = $this->callConfirm($this->sut);
 
         // assert
 
@@ -159,7 +167,7 @@ class ConfirmTest extends TestCase
         // in reality the fee would be calculated according to details of the card etc. The Calculator class is
         //tested separately. This is just a dummy value.
 
-        $stripeClientProphecy = $this->fakeStripeClient(
+        $this->fakeStripeClient(
             cardDetails: ['brand' => 'discover', 'country' => 'some-country'],
             paymentMethodId: 'PAYMENT_METHOD_ID',
             updatedIntentData: [
@@ -180,15 +188,8 @@ class ConfirmTest extends TestCase
             confirmFailsWithPaymentMethodUsedError: true,
         );
 
-        $sut = new Confirm(
-            new NullLogger(),
-            $this->getDonationRepository(),
-            $stripeClientProphecy->reveal(),
-            $this->prophesize(EntityManagerInterface::class)->reveal()
-        );
-
         // act
-        $response = $this->callConfirm($sut);
+        $response = $this->callConfirm($this->sut);
 
         // assert
 
@@ -205,9 +206,7 @@ class ConfirmTest extends TestCase
     public function testItReturns500OnApiError(): void
     {
         // arrange
-
-
-        $stripeClientProphecy = $this->fakeStripeClient(
+        $this->fakeStripeClient(
             cardDetails: ['brand' => 'discover', 'country' => 'some-country'],
             paymentMethodId: 'PAYMENT_METHOD_ID',
             updatedIntentData: [
@@ -228,15 +227,8 @@ class ConfirmTest extends TestCase
             confirmFailsWithPaymentMethodUsedError: false,
         );
 
-        $sut = new Confirm(
-            new NullLogger(),
-            $this->getDonationRepository(),
-            $stripeClientProphecy->reveal(),
-            $this->prophesize(EntityManagerInterface::class)->reveal()
-        );
-
         // act
-        $response = $this->callConfirm($sut);
+        $response = $this->callConfirm($this->sut);
 
         // assert
 
@@ -250,14 +242,11 @@ class ConfirmTest extends TestCase
         );
     }
 
-    /**
-     * @return ObjectProphecy<Stripe>
-     */
     private function successReadyFakeStripeClient(
         string $amountInWholeUnits,
         bool $confirmCallExpected
-    ): ObjectProphecy {
-        return $this->fakeStripeClient(
+    ): void {
+        $this->fakeStripeClient(
             cardDetails: ['brand' => 'discover', 'country' => 'some-country'],
             paymentMethodId: 'PAYMENT_METHOD_ID',
             updatedIntentData: [
@@ -280,9 +269,6 @@ class ConfirmTest extends TestCase
         );
     }
 
-    /**
-     * @return ObjectProphecy<Stripe>
-     */
     private function fakeStripeClient(
         array $cardDetails,
         string $paymentMethodId,
@@ -293,34 +279,35 @@ class ConfirmTest extends TestCase
         bool $confirmFailsWithApiError,
         bool $confirmFailsWithPaymentMethodUsedError,
         bool $updatePaymentIntentAndConfirmExpected = true,
-    ): ObjectProphecy {
+    ): void {
         $paymentMethod = new PaymentMethod(['id' => 'id-doesnt-matter-for-test']);
         $paymentMethod->type = 'card';
 
         /** @psalm-suppress InvalidPropertyAssignmentValue */
         $paymentMethod->card = $cardDetails;
-        $stripeProphecy = $this->prophesize(Stripe::class);
-        $stripeProphecy->updatePaymentMethodBillingDetail($paymentMethodId, Argument::type(Donation::class))
+        $this->stripeProphecy->updatePaymentMethodBillingDetail($paymentMethodId, Argument::type(Donation::class))
             ->willReturn($paymentMethod);
 
         $updatedPaymentIntent = new PaymentIntent(['id' => 'id-doesnt-matter-for-test', ...$updatedIntentData]);
         $updatedPaymentIntent->status = $updatedIntentData['status'];
         $updatedPaymentIntent->client_secret = $updatedIntentData['client_secret']; // here
 
-        $stripeProphecy->retrievePaymentIntent($paymentIntentId)
+        $this->stripeProphecy->retrievePaymentIntent($paymentIntentId)
             ->willReturn($updatedPaymentIntent);
 
         if (!$updatePaymentIntentAndConfirmExpected) {
-            return $stripeProphecy;
+            return; // $this->stripeProphecy;
         }
 
-        $stripeProphecy->updatePaymentIntent(
+        $this->stripeProphecy->updatePaymentIntent(
             $paymentIntentId,
             $expectedMetadataUpdate
         )->shouldBeCalled();
 
-        $confirmation = $stripeProphecy->confirmPaymentIntent($paymentIntentId, ["payment_method" => $paymentMethodId])
-            ->willReturn($updatedPaymentIntent);
+        $confirmation = $this->stripeProphecy->confirmPaymentIntent(
+            $paymentIntentId,
+            ["payment_method" => $paymentMethodId]
+        )->willReturn($updatedPaymentIntent);
 
         if ($confirmFailsWithCardError) {
             $exception = CardException::factory(
@@ -351,48 +338,43 @@ class ConfirmTest extends TestCase
         }
 
         $confirmation->shouldBeCalled();
-
-        return $stripeProphecy;
     }
 
     /**
      * @return DonationRepository Really an ObjectProphecy<DonationRepository>, but psalm
      *                            complains about that.
      */
-    private function getDonationRepository(bool $donationIsCancelled = false): DonationRepository
+    private function getDonationRepository(): DonationRepository
     {
         $donationRepositoryProphecy = $this->prophesize(DonationRepository::class);
 
-        $donation = Donation::fromApiModel(
-            new DonationCreate(
-                currencyCode: 'GBP',
-                donationAmount: '63.0',
-                projectId: 'doesnt0matter12345',
-                psp: 'stripe',
-                countryCode: 'GB',
-            ),
-            $this->getMinimalCampaign(),
-        );
+        $testCase = $this;
+        $donationRepositoryProphecy->findAndLockOneBy(['uuid' => 'DONATION_ID'])->will(function () use ($testCase) {
+            $donation = Donation::fromApiModel(
+                new DonationCreate(
+                    currencyCode: 'GBP',
+                    donationAmount: '63.0',
+                    projectId: 'doesnt0matter12345',
+                    psp: 'stripe',
+                    countryCode: 'GB',
+                ),
+                $testCase->getMinimalCampaign(),
+            );
 
-        $donation->update(
-            giftAid: false,
-            donorBillingPostcode: 'SW1 1AA',
-            donorName: DonorName::of('Charlie', 'The Charitable'),
-            donorEmailAddress: EmailAddress::of('user@example.com'),
-        );
+            $donation->update(
+                giftAid: false,
+                donorBillingPostcode: 'SW1 1AA',
+                donorName: DonorName::of('Charlie', 'The Charitable'),
+                donorEmailAddress: EmailAddress::of('user@example.com'),
+            );
 
-        $donation->setTransactionId('PAYMENT_INTENT_ID');
-        if ($donationIsCancelled) {
-            $donation->cancel();
-        }
+            $donation->setTransactionId('PAYMENT_INTENT_ID');
+            if ($testCase->donationIsCancelled) {
+                $donation->cancel();
+            }
 
-
-
-        $donationRepositoryProphecy->findAndLockOneBy(['uuid' => 'DONATION_ID'])->willReturn(
-            $donation
-        );
-
-        $donationRepositoryProphecy->push($donation, false)->willReturn(true);
+            return $donation;
+        });
 
         return $donationRepositoryProphecy->reveal();
     }

--- a/tests/Application/Actions/Hooks/StripePaymentsUpdateTest.php
+++ b/tests/Application/Actions/Hooks/StripePaymentsUpdateTest.php
@@ -15,6 +15,8 @@ use MatchBot\Domain\DonorAccountRepository;
 use Prophecy\Argument;
 use Stripe\Service\BalanceTransactionService;
 use Stripe\StripeClient;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\RoutableMessageBus;
 use Symfony\Component\Notifier\Bridge\Slack\Block\SlackHeaderBlock;
 use Symfony\Component\Notifier\Bridge\Slack\Block\SlackSectionBlock;
 use Symfony\Component\Notifier\Bridge\Slack\SlackOptions;
@@ -22,6 +24,17 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 
 class StripePaymentsUpdateTest extends StripeTest
 {
+    public function setUp(): void
+    {
+        $container = $this->getAppInstance()->getContainer();
+        \assert($container instanceof Container);
+
+        $routableMessageBusProphecy = $this->prophesize(RoutableMessageBus::class);
+        $routableMessageBusProphecy->dispatch(Argument::type(Envelope::class))->willReturnArgument();
+
+        $container->set(RoutableMessageBus::class, $routableMessageBusProphecy->reveal());
+    }
+
     public function testUnsupportedAction(): void
     {
         $app = $this->getAppInstance();
@@ -120,10 +133,6 @@ class StripePaymentsUpdateTest extends StripeTest
             ->willReturn($donation)
             ->shouldBeCalledOnce();
 
-        $donationRepoProphecy
-            ->push(Argument::type(Donation::class), false)
-            ->willReturn(true)
-            ->shouldBeCalledOnce();
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
 
@@ -171,10 +180,6 @@ class StripePaymentsUpdateTest extends StripeTest
             ->willReturn($donation)
             ->shouldBeCalledOnce();
 
-        $donationRepoProphecy
-            ->push(Argument::type(Donation::class), false)
-            ->willReturn(true)
-            ->shouldBeCalledOnce();
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
 
@@ -223,10 +228,6 @@ class StripePaymentsUpdateTest extends StripeTest
             ->releaseMatchFunds($donation)
             ->shouldBeCalledOnce();
 
-        $donationRepoProphecy
-            ->push(Argument::type(Donation::class), false)
-            ->willReturn(true)
-            ->shouldBeCalledOnce();
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
 
@@ -353,10 +354,6 @@ class StripePaymentsUpdateTest extends StripeTest
         $donationRepoProphecy
             ->releaseMatchFunds($donation)
             ->shouldBeCalledOnce();
-        $donationRepoProphecy
-            ->push(Argument::type(Donation::class), false)
-            ->willReturn(true)
-            ->shouldBeCalledOnce();
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
 
@@ -449,10 +446,6 @@ class StripePaymentsUpdateTest extends StripeTest
             ->releaseMatchFunds($donation)
             ->shouldBeCalledOnce();
 
-        $donationRepoProphecy
-            ->push(Argument::type(Donation::class), false)
-            ->willReturn(true)
-            ->shouldBeCalledOnce();
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
 
@@ -513,10 +506,6 @@ class StripePaymentsUpdateTest extends StripeTest
             ->releaseMatchFunds($donation)
             ->shouldBeCalledOnce();
 
-        $donationRepoProphecy
-            ->push(Argument::type(Donation::class), false)
-            ->willReturn(true)
-            ->shouldBeCalledOnce();
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
 
@@ -562,16 +551,12 @@ class StripePaymentsUpdateTest extends StripeTest
             ->releaseMatchFunds($donation)
             ->shouldNotBeCalled();
 
-        $donationRepoProphecy
-            ->push(Argument::type(Donation::class), false)
-            ->willReturn(true)
-            ->shouldBeCalledOnce();
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
         $entityManagerProphecy->beginTransaction()->shouldBeCalledOnce();
         $entityManagerProphecy->persist(Argument::type(Donation::class))->shouldBeCalledOnce();
-        $entityManagerProphecy->flush()->shouldBeCalledOnce();
-        $entityManagerProphecy->commit()->shouldBeCalledOnce();
+        $entityManagerProphecy->flush()->shouldBeCalled();
+        $entityManagerProphecy->commit()->shouldBeCalled();
 
         $container->set(EntityManagerInterface::class, $entityManagerProphecy->reveal());
         $container->set(DonationRepository::class, $donationRepoProphecy->reveal());

--- a/tests/Application/Messenger/Handler/DonationStateUpdatedHandlerTest.php
+++ b/tests/Application/Messenger/Handler/DonationStateUpdatedHandlerTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace MatchBot\Tests\Application\Messenger\Handler;
+
+use MatchBot\Application\Messenger\DonationStateUpdated;
+use MatchBot\Application\Messenger\Handler\DonationStateUpdatedHandler;
+use MatchBot\Domain\DonationRepository;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Log\NullLogger;
+use Symfony\Component\Messenger\Handler\Acknowledger;
+
+class DonationStateUpdatedHandlerTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /** @var ObjectProphecy<DonationRepository>  */
+    private ObjectProphecy $donationRepositoryProphecy;
+
+    private bool $acknowledged = true;
+    private ?\Throwable $exceptionFromLastAck;
+
+    public function setUp(): void
+    {
+        $this->donationRepositoryProphecy = $this->prophesize(DonationRepository::class);
+    }
+
+    public function testItPushesOneDonationToSf(): void
+    {
+        $donation = \MatchBot\Tests\TestCase::someDonation();
+        $this->donationRepositoryProphecy->findOneBy(['uuid' => $donation->getUuid()])->willReturn($donation);
+        $this->donationRepositoryProphecy->push($donation, false)->shouldBeCalledOnce();
+
+        $sut = new DonationStateUpdatedHandler($this->donationRepositoryProphecy->reveal(), new NullLogger());
+
+        $message = DonationStateUpdated::fromDonation($donation);
+
+        $sut->__invoke($message, $this->getAcknowledger());
+        $sut->flush(force: true);
+
+        $this->assertTrue($this->acknowledged);
+    }
+
+    public function testItPushesDonationOnceToSfWhenCreatedAndUpdated(): void
+    {
+        $donation = \MatchBot\Tests\TestCase::someDonation();
+        $this->donationRepositoryProphecy->findOneBy(['uuid' => $donation->getUuid()])->willReturn($donation);
+        $this->donationRepositoryProphecy->push($donation, true)->shouldBeCalledOnce();
+        $this->donationRepositoryProphecy->push($donation, false)->shouldNotBeCalled();
+
+        $sut = new DonationStateUpdatedHandler($this->donationRepositoryProphecy->reveal(), new NullLogger());
+
+        $sut->__invoke(DonationStateUpdated::fromDonation($donation, isNew: true), $this->getAcknowledger());
+        $sut->__invoke(DonationStateUpdated::fromDonation($donation), $this->getAcknowledger());
+        $sut->flush(force: true);
+    }
+
+    public function testItNacksMessageIfDonationCannotBeFound(): void
+    {
+        $donation = \MatchBot\Tests\TestCase::someDonation();
+        $this->donationRepositoryProphecy->findOneBy(['uuid' => $donation->getUuid()])->willReturn(null);
+        $sut = new DonationStateUpdatedHandler($this->donationRepositoryProphecy->reveal(), new NullLogger());
+
+        $sut->__invoke(DonationStateUpdated::fromDonation($donation), $this->getAcknowledger());
+        $sut->flush(force: true);
+        $this->assertNotNull($this->exceptionFromLastAck);
+        $this->assertSame('Donation not found', $this->exceptionFromLastAck->getMessage());
+    }
+
+    public function testItNacksMessageIfDonationCannotBePushed(): void
+    {
+        $donation = \MatchBot\Tests\TestCase::someDonation();
+        $this->donationRepositoryProphecy->findOneBy(['uuid' => $donation->getUuid()])->willReturn($donation);
+        $this->donationRepositoryProphecy->push($donation, false)->willThrow(new \Exception('Failed to push to SF'));
+
+        $sut = new DonationStateUpdatedHandler($this->donationRepositoryProphecy->reveal(), new NullLogger());
+
+        $sut->__invoke(DonationStateUpdated::fromDonation($donation), $this->getAcknowledger());
+        $sut->flush(force: true);
+        $this->assertNotNull($this->exceptionFromLastAck);
+        $this->assertSame('Failed to push to SF', $this->exceptionFromLastAck->getMessage());
+    }
+
+
+    public function getAcknowledger(): Acknowledger
+    {
+        return new Acknowledger(DonationStateUpdatedHandler::class, $this->recieveAck(...));
+    }
+
+    private function recieveAck(\Throwable|null $e, mixed $_result = null): void
+    {
+        $this->exceptionFromLastAck = $e;
+        $this->acknowledged = true;
+    }
+}

--- a/tests/Domain/DonationTest.php
+++ b/tests/Domain/DonationTest.php
@@ -429,7 +429,7 @@ class DonationTest extends TestCase
     public function testIsReadyToConfirmWithRequiredFieldsSet(): void
     {
         $donation = Donation::fromApiModel(new DonationCreate(
-            currencyCode: 'GBB',
+            currencyCode: 'GBP',
             donationAmount: '1',
             projectId: '123456789012345678',
             psp: 'stripe',
@@ -453,7 +453,7 @@ class DonationTest extends TestCase
     public function testIsNotReadyToConfirmWithoutBillingPostcode(): void
     {
         $donation = Donation::fromApiModel(new DonationCreate(
-            currencyCode: 'GBB',
+            currencyCode: 'GBP',
             donationAmount: '1',
             projectId: '123456789012345678',
             psp: 'stripe',
@@ -479,7 +479,7 @@ class DonationTest extends TestCase
     public function testIsNotReadyToConfirmWithoutTBGComsPreference(): void
     {
         $donation = Donation::fromApiModel(new DonationCreate(
-            currencyCode: 'GBB',
+            currencyCode: 'GBP',
             donationAmount: '1',
             projectId: '123456789012345678',
             psp: 'stripe',
@@ -506,7 +506,7 @@ class DonationTest extends TestCase
     public function testIsNotReadyToConfirmWithoutCharityComsPreference(): void
     {
         $donation = Donation::fromApiModel(new DonationCreate(
-            currencyCode: 'GBB',
+            currencyCode: 'GBP',
             donationAmount: '1',
             projectId: '123456789012345678',
             psp: 'stripe',
@@ -534,7 +534,7 @@ class DonationTest extends TestCase
     public function testIsNotReadyToConfirmWithoutBillingCountry(): void
     {
         $donation = Donation::fromApiModel(new DonationCreate(
-            currencyCode: 'GBB',
+            currencyCode: 'GBP',
             donationAmount: '1',
             projectId: '123456789012345678',
             psp: 'stripe',
@@ -552,7 +552,7 @@ class DonationTest extends TestCase
     public function testIsNotReadyToConfirmWithoutDonorName(): void
     {
         $donation = Donation::fromApiModel(new DonationCreate(
-            currencyCode: 'GBB',
+            currencyCode: 'GBP',
             donationAmount: '1',
             projectId: '123456789012345678',
             psp: 'stripe',
@@ -570,7 +570,7 @@ class DonationTest extends TestCase
     public function testIsNotReadyToConfirmWithoutDonorEmail(): void
     {
         $donation = Donation::fromApiModel(new DonationCreate(
-            currencyCode: 'GBB',
+            currencyCode: 'GBP',
             donationAmount: '1',
             projectId: '123456789012345678',
             psp: 'stripe',
@@ -587,7 +587,7 @@ class DonationTest extends TestCase
     public function testIsNotReadyToConfirmWhenCancelled(): void
     {
         $donation = Donation::fromApiModel(new DonationCreate(
-            currencyCode: 'GBB',
+            currencyCode: 'GBP',
             donationAmount: '1',
             projectId: '123456789012345678',
             psp: 'stripe',

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,8 +6,10 @@ namespace MatchBot\Tests;
 
 use DI\ContainerBuilder;
 use Exception;
+use MatchBot\Application\HttpModels\DonationCreate;
 use MatchBot\Domain\Campaign;
 use MatchBot\Domain\Charity;
+use MatchBot\Domain\Donation;
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -187,6 +189,20 @@ class TestCase extends PHPUnitTestCase
         $campaign->setEndDate(new \DateTimeImmutable('3000-01-01'));
 
         return $campaign;
+    }
+
+    public static function someDonation(): Donation
+    {
+        return Donation::fromApiModel(new DonationCreate(
+            currencyCode: 'GBP',
+            donationAmount: '1',
+            projectId: '123456789012345678',
+            psp: 'stripe',
+            firstName: null,
+            lastName: null,
+            emailAddress: 'user@example.com',
+            countryCode: 'GB',
+        ), TestCase::someCampaign());
     }
 
     /**


### PR DESCRIPTION
Reverts thebiggive/matchbot#891 and adds a fix.

It's possible that we will see some level of errors from locks not being acquired and will need to add retries, but I think we can try it without first.