### PR TITLE
MAT-363 – retry SF queueing again

### DIFF
--- a/app/dependencies.php
+++ b/app/dependencies.php
@@ -12,6 +12,8 @@ use Los\RateLimit\RateLimitOptions;
 use MatchBot\Application\Auth;
 use MatchBot\Application\Auth\IdentityToken;
 use MatchBot\Application\Matching;
+use MatchBot\Application\Messenger\DonationStateUpdated;
+use MatchBot\Application\Messenger\Handler\DonationStateUpdatedHandler;
 use MatchBot\Application\Messenger\Handler\GiftAidResultHandler;
 use MatchBot\Application\Messenger\Handler\StripePayoutHandler;
 use MatchBot\Application\Messenger\StripePayout;
@@ -254,6 +256,7 @@ return function (ContainerBuilder $containerBuilder) {
                 [
                     Messages\Donation::class => [ClaimBotTransport::class],
                     StripePayout::class => [TransportInterface::class],
+                    DonationStateUpdated::class => [TransportInterface::class],
                 ],
                 $c,
             ));
@@ -263,6 +266,7 @@ return function (ContainerBuilder $containerBuilder) {
                 [
                     Messages\Donation::class => [$c->get(GiftAidResultHandler::class)],
                     StripePayout::class => [$c->get(StripePayoutHandler::class)],
+                    DonationStateUpdated::class => [$c->get(DonationStateUpdatedHandler::class)],
                 ],
             ));
             $handleMiddleware->setLogger($logger);
@@ -373,11 +377,18 @@ return function (ContainerBuilder $containerBuilder) {
 
         RoutableMessageBus::class => static function (ContainerInterface $c): RoutableMessageBus {
             $busContainer = new Container();
-            $busContainer->set('claimbot.donation.claim', $c->get(MessageBusInterface::class));
-            $busContainer->set('claimbot.donation.result', $c->get(MessageBusInterface::class));
-            $busContainer->set(\Stripe\Event::PAYOUT_PAID, $c->get(MessageBusInterface::class));
+            $bus = $c->get(MessageBusInterface::class);
 
-            return new RoutableMessageBus($busContainer);
+            /**
+             * Every message defaults to our only bus, so we think these are technically redundant for
+             * now. This also means the list isn't exhaustive – we *know* we don't need
+             * {@see DonationStateUpdated} here. Removing `claimbot` items would require some more testing.
+             */
+            $busContainer->set('claimbot.donation.claim', $bus);
+            $busContainer->set('claimbot.donation.result', $bus);
+            $busContainer->set(\Stripe\Event::PAYOUT_PAID, $bus);
+
+            return new RoutableMessageBus($busContainer, $bus);
         },
 
         SerializerInterface::class => static function (ContainerInterface $c): SerializerInterface {

--- a/consume-messages.sh
+++ b/consume-messages.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# Workaround for not being able to directly invoke commands with arguments from docker-compose for local development
+
+./matchbot messenger:consume

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,25 @@ services:
       - redis
     networks:
       - matchbot
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  app-message-consumer:
+    image: thebiggive/php:dev-8.3
+    platform: linux/amd64
+    command:
+      - './consume-messages.sh'
+    volumes:
+      - .:/var/www/html
+    env_file:
+      - .env
+    depends_on:
+      - db
+      - redis
+    networks:
+      - matchbot
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   db:
     image: mysql:8.0

--- a/integrationTests/RedistributeMatchingCommandTest.php
+++ b/integrationTests/RedistributeMatchingCommandTest.php
@@ -19,11 +19,14 @@ use MatchBot\Domain\FundingWithdrawal;
 use MatchBot\Domain\PaymentMethodType;
 use MatchBot\Domain\Pledge;
 use MatchBot\Tests\Application\Commands\AlwaysAvailableLockStore;
+use Prophecy\Argument;
 use Psr\Log\LoggerInterface;
 use Random\Randomizer;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\RoutableMessageBus;
 
 class RedistributeMatchingCommandTest extends IntegrationTest
 {
@@ -32,6 +35,7 @@ class RedistributeMatchingCommandTest extends IntegrationTest
     private Campaign $closedCampaign;
     private CampaignFunding $openCampaignChampionFunding;
     private CampaignFunding $closedCampaignChampionFunding;
+    private RedistributeMatchFunds $command;
 
     public function setUp(): void
     {
@@ -42,6 +46,21 @@ class RedistributeMatchingCommandTest extends IntegrationTest
 
         [$this->openCampaign, $this->openCampaignChampionFunding] = $this->prepareCampaign(true);
         [$this->closedCampaign, $this->closedCampaignChampionFunding] = $this->prepareCampaign(false);
+
+
+        $messageBusProphecy = $this->prophesize(RoutableMessageBus::class);
+        $messageBusProphecy->dispatch(Argument::type(Envelope::class), Argument::cetera())
+            ->willReturnArgument();
+
+        $this->command = new RedistributeMatchFunds(
+            $this->campaignFundingRepository,
+            $this->createStub(EntityManagerInterface::class),
+            new \DateTimeImmutable('now'),
+            $this->getService(DonationRepository::class),
+            $this->getService(LoggerInterface::class),
+            $messageBusProphecy->reveal(),
+        );
+        $this->command->setLockFactory(new LockFactory(new AlwaysAvailableLockStore()));
     }
 
     public function testCommandRedistributesMatchingToUsePledges(): void
@@ -59,14 +78,7 @@ class RedistributeMatchingCommandTest extends IntegrationTest
         $output = new BufferedOutput();
 
         // act
-        $command = new RedistributeMatchFunds(
-            $this->campaignFundingRepository,
-            new \DateTimeImmutable('now'),
-            $this->getService(DonationRepository::class),
-            $this->getService(LoggerInterface::class)
-        );
-        $command->setLockFactory(new LockFactory(new AlwaysAvailableLockStore()));
-        $command->run(new ArrayInput([]), $output);
+        $this->command->run(new ArrayInput([]), $output);
 
         // assert
         $updatedDonation = $this->getService(DonationRepository::class)->find($donation->getId());
@@ -103,14 +115,7 @@ class RedistributeMatchingCommandTest extends IntegrationTest
         $output = new BufferedOutput();
 
         // act
-        $command = new RedistributeMatchFunds(
-            $this->campaignFundingRepository,
-            new \DateTimeImmutable('now'),
-            $this->getService(DonationRepository::class),
-            $this->getService(LoggerInterface::class)
-        );
-        $command->setLockFactory(new LockFactory(new AlwaysAvailableLockStore()));
-        $command->run(new ArrayInput([]), $output);
+        $this->command->run(new ArrayInput([]), $output);
 
         // assert
         $updatedDonation = $this->getService(DonationRepository::class)->find($donation->getId());

--- a/matchbot-cli.php
+++ b/matchbot-cli.php
@@ -69,12 +69,7 @@ $commands = [
     ),
     new ExpireMatchFunds($psr11App->get(DonationRepository::class)),
     $psr11App->get(HandleOutOfSyncFunds::class),
-    new RedistributeMatchFunds(
-        $psr11App->get(CampaignFundingRepository::class),
-        $now,
-        $psr11App->get(DonationRepository::class),
-        $psr11App->get(LoggerInterface::class),
-    ),
+    $psr11App->get(RedistributeMatchFunds::class),
     new ScheduledOutOfSyncFundsCheck(
         $psr11App->get(CampaignFundingRepository::class),
         $psr11App->get(FundingWithdrawalRepository::class),
@@ -86,10 +81,7 @@ $commands = [
         $psr11App->get(CampaignFundingRepository::class),
         $psr11App->get(Matching\Adapter::class)
     ),
-    new RetrospectivelyMatch(
-        $psr11App->get(DonationRepository::class),
-        $chatter,
-    ),
+    $psr11App->get(RetrospectivelyMatch::class),
     new UpdateCampaigns(
         $psr11App->get(CampaignRepository::class),
         $psr11App->get(EntityManagerInterface::class),

--- a/phpunit-integration.xml
+++ b/phpunit-integration.xml
@@ -27,6 +27,7 @@
     <env name="STRIPE_API_VERSION" value="2022-08-01" />
     <env name="STRIPE_SECRET_KEY" value="sk_test_unitTestFakeKey" force="true"/>
     <env name="STRIPE_WEBHOOK_SIGNING_SECRET" value="whsec_test_unitTestFakeKey" force="true"/>
+    <env name="MESSENGER_TRANSPORT_DSN" value="redis://127.0.0.1:6379/matchbot-jobs" force="false"/> <!-- 127.0.0.1 is redis host on CI server -->
     <env name="STRIPE_CONNECT_WEBHOOK_SIGNING_SECRET" value="whsec_test_unitTestFakeConnectKey" force="true"/>
     <env name="VAT_PERCENTAGE_OLD" value="0" force="true" />
     <env name="VAT_PERCENTAGE_NEW" value="2" force="true" />

--- a/src/Application/Actions/Donations/Confirm.php
+++ b/src/Application/Actions/Donations/Confirm.php
@@ -7,6 +7,7 @@ use Laminas\Diactoros\Response\JsonResponse;
 use MatchBot\Application\Actions\Action;
 use MatchBot\Application\Fees\Calculator;
 use MatchBot\Application\LazyAssertionException;
+use MatchBot\Application\Messenger\DonationStateUpdated;
 use MatchBot\Client\NotFoundException;
 use MatchBot\Client\Stripe;
 use MatchBot\Domain\Donation;
@@ -16,9 +17,13 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\Uuid;
 use Slim\Exception\HttpBadRequestException;
+use Stripe\Event;
 use Stripe\Exception\ApiErrorException;
 use Stripe\Exception\CardException;
 use Stripe\Exception\InvalidRequestException;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\RoutableMessageBus;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
 
 class Confirm extends Action
 {
@@ -41,6 +46,7 @@ class Confirm extends Action
         private DonationRepository $donationRepository,
         private Stripe $stripe,
         private EntityManagerInterface $entityManager,
+        private RoutableMessageBus $bus,
     ) {
         parent::__construct($logger);
     }
@@ -268,9 +274,12 @@ EOF
         $this->entityManager->flush();
         $this->entityManager->commit();
 
-        // Outside the main txn, tell Salesforce about the latest fee too. We log if this fails but don't worry the
-        // client about it. We'll re-try sending the updated status to Salesforce in a future batch sync.
-        $this->donationRepository->push($donation, false);
+        $this->bus->dispatch(
+            new Envelope(
+                DonationStateUpdated::fromDonation($donation),
+                [new DelayStamp(delay: 3_000 /*3 seconds */)]
+            ),
+        );
 
         return new JsonResponse([
             'paymentIntent' => [

--- a/src/Application/Actions/Donations/Create.php
+++ b/src/Application/Actions/Donations/Create.php
@@ -15,6 +15,7 @@ use MatchBot\Application\Auth\PersonManagementAuthMiddleware;
 use MatchBot\Application\Auth\PersonWithPasswordAuthMiddleware;
 use MatchBot\Application\HttpModels\DonationCreate;
 use MatchBot\Application\HttpModels\DonationCreatedResponse;
+use MatchBot\Application\Messenger\DonationStateUpdated;
 use MatchBot\Domain\DomainException\CampaignNotOpen;
 use MatchBot\Domain\DomainException\CharityAccountLacksNeededCapaiblities;
 use MatchBot\Domain\DomainException\CouldNotMakeStripePaymentIntent;
@@ -24,6 +25,9 @@ use MatchBot\Domain\DonationService;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\RoutableMessageBus;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
 use Symfony\Component\Serializer\Exception\UnexpectedValueException;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -33,6 +37,7 @@ class Create extends Action
         private DonationService $donationService,
         private SerializerInterface $serializer,
         LoggerInterface $logger,
+        private RoutableMessageBus $bus,
     ) {
         parent::__construct($logger);
     }
@@ -156,6 +161,15 @@ class Create extends Action
                 ),
             );
         }
+
+        $this->bus->dispatch(
+            new Envelope(
+                DonationStateUpdated::fromDonation($donation, isNew: true),
+                // Delaying the message because we saw that the donation is sometimes not in the DB quickly enough
+                // when message received. Don't understand how that's possible though.
+                [new DelayStamp(delay: 3_000 /*3 seconds */)]
+            )
+        );
 
         $data = new DonationCreatedResponse();
         $data->donation = $donation->toApiModel();

--- a/src/Application/Actions/Donations/Update.php
+++ b/src/Application/Actions/Donations/Update.php
@@ -11,6 +11,7 @@ use MatchBot\Application\Actions\Action;
 use MatchBot\Application\Actions\ActionError;
 use MatchBot\Application\Actions\ActionPayload;
 use MatchBot\Application\HttpModels;
+use MatchBot\Application\Messenger\DonationStateUpdated;
 use MatchBot\Client\Stripe;
 use MatchBot\Domain\DomainException\DomainRecordNotFoundException;
 use MatchBot\Domain\Donation;
@@ -27,6 +28,9 @@ use Stripe\Exception\InvalidRequestException;
 use Stripe\Exception\RateLimitException;
 use Stripe\PaymentIntent;
 use Symfony\Component\Clock\ClockInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\RoutableMessageBus;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
 use Symfony\Component\Serializer\Exception\UnexpectedValueException;
 use Symfony\Component\Serializer\SerializerInterface;
 use TypeError;
@@ -49,6 +53,7 @@ class Update extends Action
         private Stripe $stripe,
         LoggerInterface $logger,
         private ClockInterface $clock,
+        private RoutableMessageBus $bus,
     ) {
         parent::__construct($logger);
     }
@@ -521,9 +526,10 @@ class Update extends Action
             return;
         }
 
-        // We log if this fails but don't worry the client about it. We'll just re-try
-        // sending the updated status to Salesforce in a future batch sync.
-        $this->donationRepository->push($donation, false);
+        $this->bus->dispatch(new Envelope(
+            DonationStateUpdated::fromDonation($donation),
+            [new DelayStamp(delay: 3_000 /*3 seconds */)],
+        ));
     }
 
     /**

--- a/src/Application/Actions/Hooks/StripePaymentsUpdate.php
+++ b/src/Application/Actions/Hooks/StripePaymentsUpdate.php
@@ -8,6 +8,7 @@ use Assert\Assertion;
 use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use MatchBot\Application\Actions\ActionPayload;
+use MatchBot\Application\Messenger\DonationStateUpdated;
 use MatchBot\Application\Notifier\StripeChatterInterface;
 use MatchBot\Domain\Currency;
 use MatchBot\Domain\Donation;
@@ -27,6 +28,9 @@ use Stripe\Dispute;
 use Stripe\Event;
 use Stripe\PaymentIntent;
 use Stripe\StripeClient;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\RoutableMessageBus;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
 use Symfony\Component\Notifier\Bridge\Slack\Block\SlackHeaderBlock;
 use Symfony\Component\Notifier\Bridge\Slack\Block\SlackSectionBlock;
 use Symfony\Component\Notifier\Bridge\Slack\SlackOptions;
@@ -51,6 +55,7 @@ class StripePaymentsUpdate extends Stripe
         private DonationFundsNotifier $donationFundsNotifier,
         ContainerInterface $container,
         LoggerInterface $logger,
+        private RoutableMessageBus $bus,
     ) {
         /**
          * @var ChatterInterface $chatter
@@ -177,11 +182,12 @@ class StripePaymentsUpdate extends Stripe
 
         $this->entityManager->persist($donation);
         $this->entityManager->commit();
+        $this->entityManager->flush();
+        $this->bus->dispatch(new Envelope(
+            DonationStateUpdated::fromDonation($donation),
+            [new DelayStamp(delay: 3_000 /*3 seconds */)],
+        ));
 
-        // We log if this fails but don't worry the webhook-sending payment client
-        // about it. We'll re-try sending the updated status to Salesforce in a future
-        // batch sync.
-        $this->donationRepository->push($donation, false); // Attempt immediate sync to Salesforce
 
         return $this->respondWithData($response, $charge);
     }
@@ -384,7 +390,10 @@ class StripePaymentsUpdate extends Stripe
         }
 
         $this->entityManager->flush();
-        $this->donationRepository->push($donation, false); // Attempt immediate sync to Salesforce
+        $this->bus->dispatch(new Envelope(
+            DonationStateUpdated::fromDonation($donation),
+            [new DelayStamp(delay: 3_000 /*3 seconds */)],
+        ));
 
         return $this->respond($response, new ActionPayload(200));
     }
@@ -480,7 +489,13 @@ class StripePaymentsUpdate extends Stripe
             $this->donationRepository->releaseMatchFunds($donation);
         }
 
-        $this->donationRepository->push($donation, false); // Attempt immediate sync to Salesforce
+        $this->entityManager->flush();
+        $this->bus->dispatch(
+            new Envelope(
+                DonationStateUpdated::fromDonation($donation)
+            ),
+            [new DelayStamp(delay: 3_000 /*3 seconds */)],
+        );
     }
 
     private function handleCashBalanceUpdate(Event $event, Response $response): Response

--- a/src/Application/Commands/PushDonations.php
+++ b/src/Application/Commands/PushDonations.php
@@ -5,23 +5,21 @@ declare(strict_types=1);
 namespace MatchBot\Application\Commands;
 
 use MatchBot\Domain\DonationRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'matchbot:push-donations',
+    description: 'Pushes details of any new or updated donations not yet synced to Salesforce'
+)]
 class PushDonations extends LockingCommand
 {
-    protected static $defaultName = 'matchbot:push-donations';
-
     public function __construct(
         private \DateTimeImmutable $now,
         private DonationRepository $donationRepository
     ) {
         parent::__construct();
-    }
-
-    protected function configure(): void
-    {
-        $this->setDescription('Pushes details of any new or updated donations not yet synced to Salesforce');
     }
 
     protected function doExecute(InputInterface $input, OutputInterface $output): int

--- a/src/Application/Commands/ResetMatching.php
+++ b/src/Application/Commands/ResetMatching.php
@@ -7,6 +7,7 @@ namespace MatchBot\Application\Commands;
 use Doctrine\DBAL\Exception\TableNotFoundException;
 use MatchBot\Application\Matching;
 use MatchBot\Domain\CampaignFundingRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -14,20 +15,17 @@ use Symfony\Component\Console\Output\OutputInterface;
  * Delete all fund data from the matching adapter. Typically called immediately prior to a full
  * Doctrine database reset, via the Composer `matchbot:reset` script.
  */
+#[AsCommand(
+    name: 'matchbot:reset-matching',
+    description: 'Delete fund balance data from the matching adapter'
+)]
 class ResetMatching extends LockingCommand
 {
-    protected static $defaultName = 'matchbot:reset-matching';
-
     public function __construct(
         private CampaignFundingRepository $campaignFundingRepository,
         private Matching\Adapter $matchingAdapter
     ) {
         parent::__construct();
-    }
-
-    protected function configure(): void
-    {
-        $this->setDescription('Delete fund balance data from the matching adapter');
     }
 
     protected function doExecute(InputInterface $input, OutputInterface $output): int

--- a/src/Application/Messenger/DonationStateUpdated.php
+++ b/src/Application/Messenger/DonationStateUpdated.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace MatchBot\Application\Messenger;
+
+use MatchBot\Application\Assertion;
+use MatchBot\Domain\Donation;
+
+readonly class DonationStateUpdated
+{
+    private function __construct(
+        public string $donationUUID,
+        public bool $donationIsNew
+    ) {
+        Assertion::uuid($this->donationUUID);
+    }
+
+    public static function fromDonation(Donation $donation, bool $isNew = false): self
+    {
+        return new self($donation->getUuid(), $isNew);
+    }
+}

--- a/src/Application/Messenger/Handler/DonationStateUpdatedHandler.php
+++ b/src/Application/Messenger/Handler/DonationStateUpdatedHandler.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace MatchBot\Application\Messenger\Handler;
+
+use MatchBot\Application\Assertion;
+use MatchBot\Application\Messenger\DonationStateUpdated;
+use MatchBot\Application\Persistence\RetrySafeEntityManager;
+use MatchBot\Domain\DonationRepository;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+class DonationStateUpdatedHandler
+{
+    public function __construct(
+        private DonationRepository $donationRepository,
+        private RetrySafeEntityManager $em,
+        private LoggerInterface $logger
+    ) {
+    }
+
+    public function __invoke(DonationStateUpdated $donationStateUpdated)
+    {
+        $donationUUID = $donationStateUpdated->donationUUID;
+
+        Assertion::uuid($donationUUID, 'Expected donationUUID to be a valid UUID');
+
+        $this->logger->info("DSUH invoked for UUID: $donationUUID");
+        if (! $this->em->isOpen()) {
+            // We assume this same EM is in use by the donation repository, so needs resetting to allow that to work.
+            $this->em->resetManager();
+        }
+
+        $donation = $this->donationRepository->findOneBy(['uuid' => $donationUUID]);
+
+        if ($donation === null) {
+            $this->logger->info("DSUH: Null Donation found for UUID: " . $donationUUID);
+            throw new \RuntimeException('Donation not found');
+        }
+
+        $this->logger->info("DSUH: Real Donation found for UUID: " . $donationUUID);
+
+        try {
+            $this->donationRepository->push($donation, $donationStateUpdated->donationIsNew);
+        } catch (\Throwable $exception) {
+            // getId() works on proxy object, does not trigger lazy loading
+            $campaginID = $donation->getCampaign()->getId();
+            $this->logger->error(
+                "DSUH: Exception on attempt to push donation $donationUUID, for campaign # $campaginID \n" .
+                "will re-throw \n" .
+                $exception
+            );
+            throw $exception;
+        }
+    }
+}

--- a/src/Application/Messenger/Handler/GiftAidResultHandler.php
+++ b/src/Application/Messenger/Handler/GiftAidResultHandler.php
@@ -8,7 +8,9 @@ use MatchBot\Domain\DonationRepository;
 use MatchBot\Domain\SalesforceWriteProxy;
 use Messages;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
+#[AsMessageHandler]
 class GiftAidResultHandler
 {
     public function __construct(

--- a/src/Application/Messenger/Handler/StripePayoutHandler.php
+++ b/src/Application/Messenger/Handler/StripePayoutHandler.php
@@ -3,7 +3,6 @@
 namespace MatchBot\Application\Messenger\Handler;
 
 use Doctrine\ORM\EntityManagerInterface;
-use MatchBot\Application\Assertion;
 use MatchBot\Application\Messenger\StripePayout;
 use MatchBot\Domain\Donation;
 use MatchBot\Domain\DonationRepository;
@@ -14,14 +13,15 @@ use Psr\Log\LogLevel;
 use Stripe\BalanceTransaction;
 use Stripe\Exception\ApiErrorException;
 use Stripe\StripeClient;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 /**
  * Takes `Payout` messages off the queue, calls back out to Stripe to find out which donations
  * to mark Paid, and marks updates for a *future* push to Salesforce. Large payouts are liable to run
  * over the time limit for SQS acks if we push to Salesforce immediately.
  */
-class StripePayoutHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+class StripePayoutHandler
 {
     /**
      * @var int How many levels of previous payout to check. We know that when a payout takes 3 or more tries, the

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -319,6 +319,9 @@ class Donation extends SalesforceWriteProxy
      */
     private function __construct(string $amount, string $currencyCode, PaymentMethodType $paymentMethodType)
     {
+        // We only fully support GBP, however we have test cases covering the following currencies:
+        Assertion::inArray($currencyCode, ['GBP', 'CAD', 'USD', 'SEK']);
+
         $this->setUuid(Uuid::uuid4());
         $this->fundingWithdrawals = new ArrayCollection();
         $this->currencyCode = $currencyCode;

--- a/src/Domain/DonationService.php
+++ b/src/Domain/DonationService.php
@@ -230,9 +230,6 @@ readonly class DonationService
             );
         }
 
-        // Attempt immediate sync. Buffered for a future batch sync if the SF call fails.
-        $this->donationRepository->push($donation, true);
-
         return $donation;
     }
 

--- a/src/Domain/SalesforceWriteProxy.php
+++ b/src/Domain/SalesforceWriteProxy.php
@@ -46,6 +46,17 @@ abstract class SalesforceWriteProxy extends SalesforceProxy
      */
     public const PUSH_STATUS_REMOVED = 'removed';
 
+    public const array POSSIBLE_PUSH_STATUSES = [
+        self::PUSH_STATUS_NOT_SENT,
+        self::PUSH_STATUS_PENDING_CREATE,
+        self::PUSH_STATUS_CREATING,
+        self::PUSH_STATUS_PENDING_UPDATE,
+        self::PUSH_STATUS_PENDING_ADDITIONAL_UPDATE,
+        self::PUSH_STATUS_UPDATING,
+        self::PUSH_STATUS_COMPLETE,
+        self::PUSH_STATUS_REMOVED,
+    ];
+
     /**
      * @return bool Whether the entity has been modified in MatchBot subsequently after its creation.
      */

--- a/tests/Application/Actions/Donations/ConfirmTest.php
+++ b/tests/Application/Actions/Donations/ConfirmTest.php
@@ -24,13 +24,41 @@ use Stripe\Exception\InvalidRequestException;
 use Stripe\Exception\UnknownApiErrorException;
 use Stripe\PaymentIntent;
 use Stripe\PaymentMethod;
+use Symfony\Component\Messenger\RoutableMessageBus;
 
 class ConfirmTest extends TestCase
 {
+    private Confirm $sut;
+
+    /** @var ObjectProphecy<Stripe>  */
+    private ObjectProphecy $stripeProphecy;
+    private bool $donationIsCancelled = false;
+
+    /** @var ObjectProphecy<EntityManagerInterface>  */
+    private ObjectProphecy $entityManagerProphecy;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->stripeProphecy = $this->prophesize(Stripe::class);
+        $messageBusStub = $this->createStub(RoutableMessageBus::class);
+        $messageBusStub->method('dispatch')->willReturnArgument(0);
+
+        $this->entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
+
+        $this->sut = new Confirm(
+            new NullLogger(),
+            $this->getDonationRepository(),
+            $this->stripeProphecy->reveal(),
+            $this->entityManagerProphecy->reveal(),
+            $messageBusStub,
+        );
+    }
+
     public function testItConfirmsACardDonation(): void
     {
         // arrange
-        $stripeClientProphecy = $this->fakeStripeClient(
+        $this->fakeStripeClient(
             cardDetails: ['brand' => 'discover', 'country' => 'some-country'],
             paymentMethodId: 'PAYMENT_METHOD_ID',
             updatedIntentData: [
@@ -52,20 +80,12 @@ class ConfirmTest extends TestCase
         );
 
         // Make sure the latest fees, based on card type, are saved to the database.
-        $em = $this->prophesize(EntityManagerInterface::class);
-        $em->beginTransaction()->shouldBeCalledOnce();
-        $em->flush()->shouldBeCalledOnce();
-        $em->commit()->shouldBeCalledOnce();
-
-        $sut = new Confirm(
-            new NullLogger(),
-            $this->getDonationRepository(),
-            $stripeClientProphecy->reveal(),
-            $em->reveal(),
-        );
+        $this->entityManagerProphecy->beginTransaction()->shouldBeCalledOnce();
+        $this->entityManagerProphecy->flush()->shouldBeCalledOnce();
+        $this->entityManagerProphecy->commit()->shouldBeCalledOnce();
 
         // act
-        $response = $this->callConfirm($sut);
+        $response = $this->callConfirm($this->sut);
 
         // assert
 
@@ -80,31 +100,25 @@ class ConfirmTest extends TestCase
     {
         // arrange
         $newCharityFee = '42.00';
-        $stripeClientProphecy = $this->successReadyFakeStripeClient(
+        $this->successReadyFakeStripeClient(
             amountInWholeUnits: $newCharityFee,
             confirmCallExpected: false,
         );
-
-        $sut = new Confirm(
-            new NullLogger(),
-            $this->getDonationRepository(donationIsCancelled: true),
-            $stripeClientProphecy->reveal(),
-            $this->prophesize(EntityManagerInterface::class)->reveal()
-        );
+        $this->donationIsCancelled = true;
 
         // assert
         $this->expectException(HttpBadRequestException::class);
         $this->expectExceptionMessage("Donation status is 'Cancelled', must be 'Pending' to confirm payment");
 
         // act
-        $this->callConfirm($sut);
+        $this->callConfirm($this->sut);
     }
 
     public function testItReturns402OnDecline(): void
     {
         // arrange
 
-        $stripeClientProphecy = $this->fakeStripeClient(
+        $this->fakeStripeClient(
             cardDetails: ['brand' => 'discover', 'country' => 'some-country'],
             paymentMethodId: 'PAYMENT_METHOD_ID',
             updatedIntentData: [
@@ -125,15 +139,9 @@ class ConfirmTest extends TestCase
             confirmFailsWithPaymentMethodUsedError: false,
         );
 
-        $sut = new Confirm(
-            new NullLogger(),
-            $this->getDonationRepository(),
-            $stripeClientProphecy->reveal(),
-            $this->prophesize(EntityManagerInterface::class)->reveal()
-        );
 
         // act
-        $response = $this->callConfirm($sut);
+        $response = $this->callConfirm($this->sut);
 
         // assert
 
@@ -159,7 +167,7 @@ class ConfirmTest extends TestCase
         // in reality the fee would be calculated according to details of the card etc. The Calculator class is
         //tested separately. This is just a dummy value.
 
-        $stripeClientProphecy = $this->fakeStripeClient(
+        $this->fakeStripeClient(
             cardDetails: ['brand' => 'discover', 'country' => 'some-country'],
             paymentMethodId: 'PAYMENT_METHOD_ID',
             updatedIntentData: [
@@ -180,15 +188,8 @@ class ConfirmTest extends TestCase
             confirmFailsWithPaymentMethodUsedError: true,
         );
 
-        $sut = new Confirm(
-            new NullLogger(),
-            $this->getDonationRepository(),
-            $stripeClientProphecy->reveal(),
-            $this->prophesize(EntityManagerInterface::class)->reveal()
-        );
-
         // act
-        $response = $this->callConfirm($sut);
+        $response = $this->callConfirm($this->sut);
 
         // assert
 
@@ -205,9 +206,7 @@ class ConfirmTest extends TestCase
     public function testItReturns500OnApiError(): void
     {
         // arrange
-
-
-        $stripeClientProphecy = $this->fakeStripeClient(
+        $this->fakeStripeClient(
             cardDetails: ['brand' => 'discover', 'country' => 'some-country'],
             paymentMethodId: 'PAYMENT_METHOD_ID',
             updatedIntentData: [
@@ -228,15 +227,8 @@ class ConfirmTest extends TestCase
             confirmFailsWithPaymentMethodUsedError: false,
         );
 
-        $sut = new Confirm(
-            new NullLogger(),
-            $this->getDonationRepository(),
-            $stripeClientProphecy->reveal(),
-            $this->prophesize(EntityManagerInterface::class)->reveal()
-        );
-
         // act
-        $response = $this->callConfirm($sut);
+        $response = $this->callConfirm($this->sut);
 
         // assert
 
@@ -250,14 +242,11 @@ class ConfirmTest extends TestCase
         );
     }
 
-    /**
-     * @return ObjectProphecy<Stripe>
-     */
     private function successReadyFakeStripeClient(
         string $amountInWholeUnits,
         bool $confirmCallExpected
-    ): ObjectProphecy {
-        return $this->fakeStripeClient(
+    ): void {
+        $this->fakeStripeClient(
             cardDetails: ['brand' => 'discover', 'country' => 'some-country'],
             paymentMethodId: 'PAYMENT_METHOD_ID',
             updatedIntentData: [
@@ -280,9 +269,6 @@ class ConfirmTest extends TestCase
         );
     }
 
-    /**
-     * @return ObjectProphecy<Stripe>
-     */
     private function fakeStripeClient(
         array $cardDetails,
         string $paymentMethodId,
@@ -293,34 +279,35 @@ class ConfirmTest extends TestCase
         bool $confirmFailsWithApiError,
         bool $confirmFailsWithPaymentMethodUsedError,
         bool $updatePaymentIntentAndConfirmExpected = true,
-    ): ObjectProphecy {
+    ): void {
         $paymentMethod = new PaymentMethod(['id' => 'id-doesnt-matter-for-test']);
         $paymentMethod->type = 'card';
 
         /** @psalm-suppress InvalidPropertyAssignmentValue */
         $paymentMethod->card = $cardDetails;
-        $stripeProphecy = $this->prophesize(Stripe::class);
-        $stripeProphecy->updatePaymentMethodBillingDetail($paymentMethodId, Argument::type(Donation::class))
+        $this->stripeProphecy->updatePaymentMethodBillingDetail($paymentMethodId, Argument::type(Donation::class))
             ->willReturn($paymentMethod);
 
         $updatedPaymentIntent = new PaymentIntent(['id' => 'id-doesnt-matter-for-test', ...$updatedIntentData]);
         $updatedPaymentIntent->status = $updatedIntentData['status'];
         $updatedPaymentIntent->client_secret = $updatedIntentData['client_secret']; // here
 
-        $stripeProphecy->retrievePaymentIntent($paymentIntentId)
+        $this->stripeProphecy->retrievePaymentIntent($paymentIntentId)
             ->willReturn($updatedPaymentIntent);
 
         if (!$updatePaymentIntentAndConfirmExpected) {
-            return $stripeProphecy;
+            return; // $this->stripeProphecy;
         }
 
-        $stripeProphecy->updatePaymentIntent(
+        $this->stripeProphecy->updatePaymentIntent(
             $paymentIntentId,
             $expectedMetadataUpdate
         )->shouldBeCalled();
 
-        $confirmation = $stripeProphecy->confirmPaymentIntent($paymentIntentId, ["payment_method" => $paymentMethodId])
-            ->willReturn($updatedPaymentIntent);
+        $confirmation = $this->stripeProphecy->confirmPaymentIntent(
+            $paymentIntentId,
+            ["payment_method" => $paymentMethodId]
+        )->willReturn($updatedPaymentIntent);
 
         if ($confirmFailsWithCardError) {
             $exception = CardException::factory(
@@ -351,48 +338,43 @@ class ConfirmTest extends TestCase
         }
 
         $confirmation->shouldBeCalled();
-
-        return $stripeProphecy;
     }
 
     /**
      * @return DonationRepository Really an ObjectProphecy<DonationRepository>, but psalm
      *                            complains about that.
      */
-    private function getDonationRepository(bool $donationIsCancelled = false): DonationRepository
+    private function getDonationRepository(): DonationRepository
     {
         $donationRepositoryProphecy = $this->prophesize(DonationRepository::class);
 
-        $donation = Donation::fromApiModel(
-            new DonationCreate(
-                currencyCode: 'GBP',
-                donationAmount: '63.0',
-                projectId: 'doesnt0matter12345',
-                psp: 'stripe',
-                countryCode: 'GB',
-            ),
-            $this->getMinimalCampaign(),
-        );
+        $testCase = $this;
+        $donationRepositoryProphecy->findAndLockOneBy(['uuid' => 'DONATION_ID'])->will(function () use ($testCase) {
+            $donation = Donation::fromApiModel(
+                new DonationCreate(
+                    currencyCode: 'GBP',
+                    donationAmount: '63.0',
+                    projectId: 'doesnt0matter12345',
+                    psp: 'stripe',
+                    countryCode: 'GB',
+                ),
+                $testCase->getMinimalCampaign(),
+            );
 
-        $donation->update(
-            giftAid: false,
-            donorBillingPostcode: 'SW1 1AA',
-            donorName: DonorName::of('Charlie', 'The Charitable'),
-            donorEmailAddress: EmailAddress::of('user@example.com'),
-        );
+            $donation->update(
+                giftAid: false,
+                donorBillingPostcode: 'SW1 1AA',
+                donorName: DonorName::of('Charlie', 'The Charitable'),
+                donorEmailAddress: EmailAddress::of('user@example.com'),
+            );
 
-        $donation->setTransactionId('PAYMENT_INTENT_ID');
-        if ($donationIsCancelled) {
-            $donation->cancel();
-        }
+            $donation->setTransactionId('PAYMENT_INTENT_ID');
+            if ($testCase->donationIsCancelled) {
+                $donation->cancel();
+            }
 
-
-
-        $donationRepositoryProphecy->findAndLockOneBy(['uuid' => 'DONATION_ID'])->willReturn(
-            $donation
-        );
-
-        $donationRepositoryProphecy->push($donation, false)->willReturn(true);
+            return $donation;
+        });
 
         return $donationRepositoryProphecy->reveal();
     }

--- a/tests/Application/Actions/Hooks/StripePaymentsUpdateTest.php
+++ b/tests/Application/Actions/Hooks/StripePaymentsUpdateTest.php
@@ -15,6 +15,8 @@ use MatchBot\Domain\DonorAccountRepository;
 use Prophecy\Argument;
 use Stripe\Service\BalanceTransactionService;
 use Stripe\StripeClient;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\RoutableMessageBus;
 use Symfony\Component\Notifier\Bridge\Slack\Block\SlackHeaderBlock;
 use Symfony\Component\Notifier\Bridge\Slack\Block\SlackSectionBlock;
 use Symfony\Component\Notifier\Bridge\Slack\SlackOptions;
@@ -22,6 +24,18 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 
 class StripePaymentsUpdateTest extends StripeTest
 {
+    public function setUp(): void
+    {
+        $container = $this->getAppInstance()->getContainer();
+        \assert($container instanceof Container);
+
+        $routableMessageBusProphecy = $this->prophesize(RoutableMessageBus::class);
+        $routableMessageBusProphecy->dispatch(Argument::type(Envelope::class), Argument::cetera())
+            ->willReturnArgument();
+
+        $container->set(RoutableMessageBus::class, $routableMessageBusProphecy->reveal());
+    }
+
     public function testUnsupportedAction(): void
     {
         $app = $this->getAppInstance();
@@ -120,10 +134,6 @@ class StripePaymentsUpdateTest extends StripeTest
             ->willReturn($donation)
             ->shouldBeCalledOnce();
 
-        $donationRepoProphecy
-            ->push(Argument::type(Donation::class), false)
-            ->willReturn(true)
-            ->shouldBeCalledOnce();
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
 
@@ -171,10 +181,6 @@ class StripePaymentsUpdateTest extends StripeTest
             ->willReturn($donation)
             ->shouldBeCalledOnce();
 
-        $donationRepoProphecy
-            ->push(Argument::type(Donation::class), false)
-            ->willReturn(true)
-            ->shouldBeCalledOnce();
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
 
@@ -223,10 +229,6 @@ class StripePaymentsUpdateTest extends StripeTest
             ->releaseMatchFunds($donation)
             ->shouldBeCalledOnce();
 
-        $donationRepoProphecy
-            ->push(Argument::type(Donation::class), false)
-            ->willReturn(true)
-            ->shouldBeCalledOnce();
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
 
@@ -353,10 +355,6 @@ class StripePaymentsUpdateTest extends StripeTest
         $donationRepoProphecy
             ->releaseMatchFunds($donation)
             ->shouldBeCalledOnce();
-        $donationRepoProphecy
-            ->push(Argument::type(Donation::class), false)
-            ->willReturn(true)
-            ->shouldBeCalledOnce();
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
 
@@ -449,10 +447,6 @@ class StripePaymentsUpdateTest extends StripeTest
             ->releaseMatchFunds($donation)
             ->shouldBeCalledOnce();
 
-        $donationRepoProphecy
-            ->push(Argument::type(Donation::class), false)
-            ->willReturn(true)
-            ->shouldBeCalledOnce();
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
 
@@ -513,10 +507,6 @@ class StripePaymentsUpdateTest extends StripeTest
             ->releaseMatchFunds($donation)
             ->shouldBeCalledOnce();
 
-        $donationRepoProphecy
-            ->push(Argument::type(Donation::class), false)
-            ->willReturn(true)
-            ->shouldBeCalledOnce();
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
 
@@ -562,16 +552,12 @@ class StripePaymentsUpdateTest extends StripeTest
             ->releaseMatchFunds($donation)
             ->shouldNotBeCalled();
 
-        $donationRepoProphecy
-            ->push(Argument::type(Donation::class), false)
-            ->willReturn(true)
-            ->shouldBeCalledOnce();
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
         $entityManagerProphecy->beginTransaction()->shouldBeCalledOnce();
         $entityManagerProphecy->persist(Argument::type(Donation::class))->shouldBeCalledOnce();
-        $entityManagerProphecy->flush()->shouldBeCalledOnce();
-        $entityManagerProphecy->commit()->shouldBeCalledOnce();
+        $entityManagerProphecy->flush()->shouldBeCalled();
+        $entityManagerProphecy->commit()->shouldBeCalled();
 
         $container->set(EntityManagerInterface::class, $entityManagerProphecy->reveal());
         $container->set(DonationRepository::class, $donationRepoProphecy->reveal());

--- a/tests/Application/Commands/RedistributeMatchFundsTest.php
+++ b/tests/Application/Commands/RedistributeMatchFundsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MatchBot\Tests\Application\Commands;
 
+use Doctrine\ORM\EntityManagerInterface;
 use MatchBot\Application\Commands\RedistributeMatchFunds;
 use MatchBot\Application\HttpModels\DonationCreate;
 use MatchBot\Domain\Campaign;
@@ -21,17 +22,25 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\RoutableMessageBus;
 
-class RedistibuteMatchFundsTest extends TestCase
+class RedistributeMatchFundsTest extends TestCase
 {
     private \DateTimeImmutable $newYearsEveNoon;
     private \DateTimeImmutable $earlyNovemberNoon;
+
+    /** @var ObjectProphecy<RoutableMessageBus> */
+    private ObjectProphecy $messageBusProphecy;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->newYearsEveNoon = new \DateTimeImmutable('2023-12-31T12:00:00');
         $this->earlyNovemberNoon = new \DateTimeImmutable('2023-11-05T12:00:00');
+
+        $this->messageBusProphecy = $this->prophesize(RoutableMessageBus::class);
+        $this->messageBusProphecy->dispatch(Argument::type(Envelope::class), Argument::cetera())->willReturnArgument();
     }
 
     public function testNoEligibleDonations(): void
@@ -77,8 +86,6 @@ class RedistibuteMatchFundsTest extends TestCase
         $donationRepoProphecy->allocateMatchFunds($donation)
             ->shouldBeCalledOnce()
             ->willReturn('10.00');
-        $donationRepoProphecy->push($donation, false)
-            ->shouldBeCalledOnce();
 
         $loggerProphecy = $this->prophesize(LoggerInterface::class);
         $loggerProphecy->error(Argument::type('string'))->shouldNotBeCalled();
@@ -133,8 +140,6 @@ class RedistibuteMatchFundsTest extends TestCase
         $donationRepoProphecy->allocateMatchFunds($donation)
             ->shouldBeCalledOnce()
             ->willReturn('5.00'); // Half the donation matched after redistribution.
-        $donationRepoProphecy->push($donation, false)
-            ->shouldBeCalledOnce();
 
         $uuid = $donation->getUuid();
         $loggerProphecy = $this->prophesize(LoggerInterface::class);
@@ -214,9 +219,11 @@ class RedistibuteMatchFundsTest extends TestCase
     ): RedistributeMatchFunds {
         $command = new RedistributeMatchFunds(
             $campaignFundingRepository->reveal(),
+            $this->createStub(EntityManagerInterface::class),
             $now,
             $donationRepoProphecy->reveal(),
             $loggerProphecy->reveal(),
+            $this->messageBusProphecy->reveal(),
         );
         $command->setLockFactory(new LockFactory(new AlwaysAvailableLockStore()));
         $command->setLogger(new NullLogger());

--- a/tests/Application/Commands/RetrospectivelyMatchTest.php
+++ b/tests/Application/Commands/RetrospectivelyMatchTest.php
@@ -5,15 +5,19 @@ declare(strict_types=1);
 namespace MatchBot\Tests\Application\Commands;
 
 use DateTime;
+use Doctrine\ORM\EntityManagerInterface;
 use MatchBot\Application\Commands\RetrospectivelyMatch;
 use MatchBot\Domain\Donation;
 use MatchBot\Domain\DonationRepository;
 use MatchBot\Tests\Application\DonationTestDataTrait;
 use MatchBot\Tests\TestCase;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Log\NullLogger;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\RoutableMessageBus;
 use Symfony\Component\Notifier\ChatterInterface;
 
 class RetrospectivelyMatchTest extends TestCase
@@ -22,10 +26,16 @@ class RetrospectivelyMatchTest extends TestCase
 
     private ChatterInterface $chatter;
 
+    /** @var ObjectProphecy<RoutableMessageBus> */
+    private ObjectProphecy $messageBusProphecy;
+
     public function setUp(): void
     {
         $chatterProphecy = $this->prophesize(ChatterInterface::class);
         $this->chatter = $chatterProphecy->reveal();
+
+        $this->messageBusProphecy = $this->prophesize(RoutableMessageBus::class);
+        $this->messageBusProphecy->dispatch(Argument::type(Envelope::class), Argument::cetera())->willReturnArgument();
     }
 
     /**
@@ -33,11 +43,7 @@ class RetrospectivelyMatchTest extends TestCase
      */
     public function testMissingDaysBackRunsInDefaultMode(): void
     {
-        $command = new RetrospectivelyMatch($this->getDonationRepo(true), $this->chatter);
-        $command->setLockFactory(new LockFactory(new AlwaysAvailableLockStore()));
-        $command->setLogger(new NullLogger());
-
-        $commandTester = new CommandTester($command);
+        $commandTester = $this->getCommandTester(matchingIsAllocated: true);
         $commandTester->execute([]);
 
         $expectedOutputLines = [
@@ -52,11 +58,7 @@ class RetrospectivelyMatchTest extends TestCase
 
     public function testNonWholeDaysBackIsRounded(): void
     {
-        $command = new RetrospectivelyMatch($this->getDonationRepo(false), $this->chatter);
-        $command->setLockFactory(new LockFactory(new AlwaysAvailableLockStore()));
-        $command->setLogger(new NullLogger());
-
-        $commandTester = new CommandTester($command);
+        $commandTester = $this->getCommandTester(matchingIsAllocated: false);
         $commandTester->execute(['days-back' => '7.5']);
 
         $expectedOutputLines = [
@@ -71,11 +73,7 @@ class RetrospectivelyMatchTest extends TestCase
 
     public function testWholeDaysBackProceeds(): void
     {
-        $command = new RetrospectivelyMatch($this->getDonationRepo(false), $this->chatter);
-        $command->setLockFactory(new LockFactory(new AlwaysAvailableLockStore()));
-        $command->setLogger(new NullLogger());
-
-        $commandTester = new CommandTester($command);
+        $commandTester = $this->getCommandTester(matchingIsAllocated: false);
         $commandTester->execute(['days-back' => '8']);
 
         $expectedOutputLines = [
@@ -102,16 +100,25 @@ class RetrospectivelyMatchTest extends TestCase
             $donationRepo->allocateMatchFunds(Argument::type(Donation::class))
                 ->shouldBeCalledOnce()
                 ->willReturn('123.45');
-            $donationRepo->push(Argument::type(Donation::class), false)
-                ->shouldBeCalledOnce()
-                ->willReturn(true);
         } else {
             $donationRepo->allocateMatchFunds(Argument::type(Donation::class))
-                ->shouldNotBeCalled();
-            $donationRepo->push(Argument::type(Donation::class), false)
                 ->shouldNotBeCalled();
         }
 
         return $donationRepo->reveal();
+    }
+
+    public function getCommandTester(bool $matchingIsAllocated): CommandTester
+    {
+        $command = new RetrospectivelyMatch(
+            $this->getDonationRepo($matchingIsAllocated),
+            $this->chatter,
+            $this->messageBusProphecy->reveal(),
+            $this->createStub(EntityManagerInterface::class),
+        );
+        $command->setLockFactory(new LockFactory(new AlwaysAvailableLockStore()));
+        $command->setLogger(new NullLogger());
+
+        return new CommandTester($command);
     }
 }

--- a/tests/Application/Messenger/Handler/DonationStateUpdatedHandlerTest.php
+++ b/tests/Application/Messenger/Handler/DonationStateUpdatedHandlerTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace MatchBot\Tests\Application\Messenger\Handler;
+
+use MatchBot\Application\Messenger\DonationStateUpdated;
+use MatchBot\Application\Messenger\Handler\DonationStateUpdatedHandler;
+use MatchBot\Application\Persistence\RetrySafeEntityManager;
+use MatchBot\Domain\DonationRepository;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Log\NullLogger;
+
+class DonationStateUpdatedHandlerTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /** @var ObjectProphecy<DonationRepository>  */
+    private ObjectProphecy $donationRepositoryProphecy;
+
+    public function setUp(): void
+    {
+        $this->donationRepositoryProphecy = $this->prophesize(DonationRepository::class);
+    }
+
+    public function testItPushesOneDonationToSf(): void
+    {
+        $donation = \MatchBot\Tests\TestCase::someDonation();
+        $this->donationRepositoryProphecy->findOneBy(['uuid' => $donation->getUuid()])->willReturn($donation);
+        $this->donationRepositoryProphecy->push($donation, false)->shouldBeCalledOnce();
+
+        $sut = new DonationStateUpdatedHandler(
+            $this->donationRepositoryProphecy->reveal(),
+            $this->createStub(RetrySafeEntityManager::class),
+            new NullLogger(),
+        );
+
+        $message = DonationStateUpdated::fromDonation($donation);
+
+        $sut->__invoke($message);
+    }
+
+    public function testItPushesDonationTwiceToSfWhenCreatedAndUpdated(): void
+    {
+        $donation = \MatchBot\Tests\TestCase::someDonation();
+        $this->donationRepositoryProphecy->findOneBy(['uuid' => $donation->getUuid()])->willReturn($donation);
+        $this->donationRepositoryProphecy->push($donation, true)->shouldBeCalledOnce();
+        $this->donationRepositoryProphecy->push($donation, false)->shouldBeCalledOnce();
+
+        $sut = new DonationStateUpdatedHandler(
+            $this->donationRepositoryProphecy->reveal(),
+            $this->createStub(RetrySafeEntityManager::class),
+            new NullLogger(),
+        );
+
+        $sut->__invoke(DonationStateUpdated::fromDonation($donation, isNew: true));
+        $sut->__invoke(DonationStateUpdated::fromDonation($donation));
+    }
+
+    /**
+     * Messenger should automatically `nack()` the message as appropriate
+     */
+    public function testItThrowsIfDonationCannotBeFound(): void
+    {
+        $donation = \MatchBot\Tests\TestCase::someDonation();
+        $this->donationRepositoryProphecy->findOneBy(['uuid' => $donation->getUuid()])->willReturn(null);
+        $sut = new DonationStateUpdatedHandler(
+            $this->donationRepositoryProphecy->reveal(),
+            $this->createStub(RetrySafeEntityManager::class),
+            new NullLogger(),
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Donation not found');
+
+        $sut->__invoke(DonationStateUpdated::fromDonation($donation));
+    }
+
+    /**
+     * Messenger should automatically `nack()` the message as appropriate
+     */
+    public function testItThrowsIfDonationCannotBePushed(): void
+    {
+        $donation = \MatchBot\Tests\TestCase::someDonation();
+        $this->donationRepositoryProphecy->findOneBy(['uuid' => $donation->getUuid()])->willReturn($donation);
+        $this->donationRepositoryProphecy->push($donation, false)->willThrow(new \Exception('Failed to push to SF'));
+
+        $sut = new DonationStateUpdatedHandler(
+            $this->donationRepositoryProphecy->reveal(),
+            $this->createStub(RetrySafeEntityManager::class),
+            new NullLogger(),
+        );
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Failed to push to SF');
+
+        $sut->__invoke(DonationStateUpdated::fromDonation($donation));
+    }
+}

--- a/tests/Domain/DonationTest.php
+++ b/tests/Domain/DonationTest.php
@@ -429,7 +429,7 @@ class DonationTest extends TestCase
     public function testIsReadyToConfirmWithRequiredFieldsSet(): void
     {
         $donation = Donation::fromApiModel(new DonationCreate(
-            currencyCode: 'GBB',
+            currencyCode: 'GBP',
             donationAmount: '1',
             projectId: '123456789012345678',
             psp: 'stripe',
@@ -453,7 +453,7 @@ class DonationTest extends TestCase
     public function testIsNotReadyToConfirmWithoutBillingPostcode(): void
     {
         $donation = Donation::fromApiModel(new DonationCreate(
-            currencyCode: 'GBB',
+            currencyCode: 'GBP',
             donationAmount: '1',
             projectId: '123456789012345678',
             psp: 'stripe',
@@ -479,7 +479,7 @@ class DonationTest extends TestCase
     public function testIsNotReadyToConfirmWithoutTBGComsPreference(): void
     {
         $donation = Donation::fromApiModel(new DonationCreate(
-            currencyCode: 'GBB',
+            currencyCode: 'GBP',
             donationAmount: '1',
             projectId: '123456789012345678',
             psp: 'stripe',
@@ -506,7 +506,7 @@ class DonationTest extends TestCase
     public function testIsNotReadyToConfirmWithoutCharityComsPreference(): void
     {
         $donation = Donation::fromApiModel(new DonationCreate(
-            currencyCode: 'GBB',
+            currencyCode: 'GBP',
             donationAmount: '1',
             projectId: '123456789012345678',
             psp: 'stripe',
@@ -534,7 +534,7 @@ class DonationTest extends TestCase
     public function testIsNotReadyToConfirmWithoutBillingCountry(): void
     {
         $donation = Donation::fromApiModel(new DonationCreate(
-            currencyCode: 'GBB',
+            currencyCode: 'GBP',
             donationAmount: '1',
             projectId: '123456789012345678',
             psp: 'stripe',
@@ -552,7 +552,7 @@ class DonationTest extends TestCase
     public function testIsNotReadyToConfirmWithoutDonorName(): void
     {
         $donation = Donation::fromApiModel(new DonationCreate(
-            currencyCode: 'GBB',
+            currencyCode: 'GBP',
             donationAmount: '1',
             projectId: '123456789012345678',
             psp: 'stripe',
@@ -570,7 +570,7 @@ class DonationTest extends TestCase
     public function testIsNotReadyToConfirmWithoutDonorEmail(): void
     {
         $donation = Donation::fromApiModel(new DonationCreate(
-            currencyCode: 'GBB',
+            currencyCode: 'GBP',
             donationAmount: '1',
             projectId: '123456789012345678',
             psp: 'stripe',
@@ -587,7 +587,7 @@ class DonationTest extends TestCase
     public function testIsNotReadyToConfirmWhenCancelled(): void
     {
         $donation = Donation::fromApiModel(new DonationCreate(
-            currencyCode: 'GBB',
+            currencyCode: 'GBP',
             donationAmount: '1',
             projectId: '123456789012345678',
             psp: 'stripe',

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,8 +6,10 @@ namespace MatchBot\Tests;
 
 use DI\ContainerBuilder;
 use Exception;
+use MatchBot\Application\HttpModels\DonationCreate;
 use MatchBot\Domain\Campaign;
 use MatchBot\Domain\Charity;
+use MatchBot\Domain\Donation;
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -187,6 +189,20 @@ class TestCase extends PHPUnitTestCase
         $campaign->setEndDate(new \DateTimeImmutable('3000-01-01'));
 
         return $campaign;
+    }
+
+    public static function someDonation(): Donation
+    {
+        return Donation::fromApiModel(new DonationCreate(
+            currencyCode: 'GBP',
+            donationAmount: '1',
+            projectId: '123456789012345678',
+            psp: 'stripe',
+            firstName: null,
+            lastName: null,
+            emailAddress: 'user@example.com',
+            countryCode: 'GB',
+        ), TestCase::someCampaign());
     }
 
     /**


### PR DESCRIPTION
* Revert https://github.com/thebiggive/matchbot/pull/912
* Simplify to a single message handler without batching
* Increase delay stamps' time to 3 seconds
* Minor tidying to make Messenger config more similar across the app