### PR TITLE
BG2-2620: Allow salesforce to mark a charity as needing update

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,8 @@ SALESFORCE_DONATION_API=https://sf-api-staging.thebiggivetest.org.uk/donations/s
 SALESFORCE_FUND_API=https://sf-api-staging.thebiggivetest.org.uk/funds/services/apexrest/v1.0/funds
 SALESFORCE_WEBHOOK_RECEIVER=https://sf-api-staging.thebiggivetest.org.uk/webhooks/services/apexrest/v2.0
 
+SALESFORCE_SECRET_KEY=topsecret
+
 # Mailer vars
 MAILER_BASE_URI=https://mailer-staging.thebiggivetest.org.uk
 MAILER_SEND_SECRET=

--- a/app/dependencies.php
+++ b/app/dependencies.php
@@ -445,6 +445,18 @@ return function (ContainerBuilder $containerBuilder) {
 
         ClockInterfaceAlias::class => fn() => new NativeClock(),
 
+        Auth\SalesforceAuthMiddleware::class =>
+            function (ContainerInterface $c) {
+               /**
+                * @psalm-suppress MixedArrayAccess
+                * @psalm-suppress MixedArgument
+                */
+                return new Auth\SalesforceAuthMiddleware(
+                    sfApiKey: $c->get('settings')['salesforce']['apiKey'],
+                    logger: $c->get(LoggerInterface::class)
+                );
+            },
+
         DonationService::class =>
             static function (ContainerInterface $c): DonationService {
             /**

--- a/app/routes.php
+++ b/app/routes.php
@@ -67,7 +67,7 @@ return function (App $app) {
     // Requests from Salesforce
 
     $app->post(
-        '/charities/{salesforceId:[a-zA-Z0-9]{18}}/update-required',
+        '/hooks/charities/{salesforceId:[a-zA-Z0-9]{18}}/update-required',
         MarkUpdateRequiredFromSF::class
     )
         ->add(SalesforceAuthMiddleware::class);

--- a/app/routes.php
+++ b/app/routes.php
@@ -68,8 +68,8 @@ return function (App $app) {
 
     $app->post(
         '/charities/{salesforceId:[a-zA-Z0-9]{18}}/update-required',
-        MarkUpdateRequiredFromSF::class
-    )->add(SalesforceAuthMiddleware::class);
+        MarkUpdateRequiredFromSF::class)
+        ->add(SalesforceAuthMiddleware::class);
 
     $app->options('/{routes:.+}', function ($request, $response, $args) {
         return $response;

--- a/app/routes.php
+++ b/app/routes.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Los\RateLimit\RateLimitMiddleware;
+use MatchBot\Application\Actions\Charities\MarkUpdateRequiredFromSF;
 use MatchBot\Application\Actions\DeletePaymentMethod;
 use MatchBot\Application\Actions\UpdatePaymentMethod;
 use MatchBot\Application\Actions\Donations;
@@ -13,6 +14,7 @@ use MatchBot\Application\Actions\Status;
 use MatchBot\Application\Auth\DonationPublicAuthMiddleware;
 use MatchBot\Application\Auth\PersonManagementAuthMiddleware;
 use MatchBot\Application\Auth\PersonWithPasswordAuthMiddleware;
+use MatchBot\Application\Auth\SalesforceAuthMiddleware;
 use Middlewares\ClientIp;
 use Slim\App;
 use Slim\Exception\HttpNotFoundException;
@@ -61,6 +63,13 @@ return function (App $app) {
     // Authenticated through Stripe's SDK signature verification
     $app->post('/hooks/stripe', Hooks\StripePaymentsUpdate::class);
     $app->post('/hooks/stripe-connect', Hooks\StripePayoutUpdate::class);
+
+    // Requests from Salesforce
+
+    $app->post(
+        '/charities/{salesforceId:[a-zA-Z0-9]{18}}/update-required',
+        MarkUpdateRequiredFromSF::class
+    )->add(SalesforceAuthMiddleware::class);
 
     $app->options('/{routes:.+}', function ($request, $response, $args) {
         return $response;

--- a/app/routes.php
+++ b/app/routes.php
@@ -68,7 +68,8 @@ return function (App $app) {
 
     $app->post(
         '/charities/{salesforceId:[a-zA-Z0-9]{18}}/update-required',
-        MarkUpdateRequiredFromSF::class)
+        MarkUpdateRequiredFromSF::class
+    )
         ->add(SalesforceAuthMiddleware::class);
 
     $app->options('/{routes:.+}', function ($request, $response, $args) {

--- a/app/settings.php
+++ b/app/settings.php
@@ -106,6 +106,11 @@ return function (ContainerBuilder $containerBuilder) {
                 'accountWebhookSecret' => getenv('STRIPE_WEBHOOK_SIGNING_SECRET'),
                 'connectAppWebhookSecret' => getenv('STRIPE_CONNECT_WEBHOOK_SIGNING_SECRET'),
             ],
+
+            'salesforce' => [
+                // authenticates requests originating from salesforce to matchbot:
+                'apiKey' => getenv('SALESFORCE_SECRET_KEY'),
+            ]
         ],
     ]);
 };

--- a/src/Application/Actions/Charities/MarkUpdateRequiredFromSF.php
+++ b/src/Application/Actions/Charities/MarkUpdateRequiredFromSF.php
@@ -16,9 +16,6 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Log\LoggerInterface;
 use Slim\Exception\HttpNotFoundException;
 
-/**
- * @psalm-suppress UnusedClass - to be added to routes.php, need to think about authorization requirements.
- */
 class MarkUpdateRequiredFromSF extends Action
 {
     public function __construct(

--- a/src/Application/Actions/Charities/MarkUpdateRequiredFromSF.php
+++ b/src/Application/Actions/Charities/MarkUpdateRequiredFromSF.php
@@ -49,6 +49,6 @@ class MarkUpdateRequiredFromSF extends Action
 
         $data = [];
 
-        return $this->respondWithData($response, $data, 201);
+        return $this->respondWithData($response, $data);
     }
 }

--- a/src/Application/Actions/Charities/MarkUpdateRequiredFromSF.php
+++ b/src/Application/Actions/Charities/MarkUpdateRequiredFromSF.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Application\Actions\Charities;
+
+use Doctrine\ORM\EntityManagerInterface;
+use MatchBot\Application\Actions\Action;
+use MatchBot\Application\Assertion;
+use MatchBot\Domain\CharityRepository;
+use MatchBot\Domain\DomainException\DomainRecordNotFoundException;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @psalm-suppress UnusedClass - to be added to routes.php, need to think about authorization requirements.
+ */
+class MarkUpdateRequiredFromSF extends Action
+{
+    public function __construct(
+        private CharityRepository $charityRepository,
+        LoggerInterface $logger,
+        private \DateTimeImmutable $now,
+        private EntityManagerInterface $em,
+    ) {
+        parent::__construct($logger);
+    }
+
+    protected function action(Request $request, Response $response, array $args): Response
+    {
+        /** @var ?string $salesforceId */
+        $salesforceId = $args['salesforceId'] ?? null;
+        Assertion::nullOrString($salesforceId);
+
+        if ($salesforceId === null) {
+            throw new DomainRecordNotFoundException('Missing donation ID');
+        }
+
+        $charity = $this->charityRepository->findOneBy(['salesforceId' => $salesforceId]);
+
+        if ($charity === null) {
+            throw new DomainRecordNotFoundException('Charity not found');
+        }
+
+        $charity->setUpdateRequiredFromSFSince($this->now);
+
+        $this->em->flush();
+
+        $data = [];
+
+        return $this->respondWithData($response, $data, 201);
+    }
+}

--- a/src/Application/Auth/SalesforceAuthMiddleware.php
+++ b/src/Application/Auth/SalesforceAuthMiddleware.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Application\Auth;
+
+use Fig\Http\Message\StatusCodeInterface;
+use JetBrains\PhpStorm\Pure;
+use MatchBot\Application\Assertion;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Log\LoggerInterface;
+use Slim\Psr7\Response;
+
+/**
+ * This middleware requires that a request is from our own Salesforce instance, based on a shared secret. Salesforce
+ * is a source of truth for much of our data so requests from it may be trusted with wide powers to modify matchbot state.
+ *
+ * Based on \BigGive\Identity\Client\Mailer
+ */
+readonly class SalesforceAuthMiddleware implements MiddlewareInterface
+{
+    #[Pure]
+    public function __construct(
+        /** @var non-empty-string $sfApiKey */
+        #[\SensitiveParameter]
+        private string $sfApiKey,
+
+        private LoggerInterface $logger,
+    )
+    {
+        Assertion::notEmpty($this->sfApiKey);
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        if (!$this->verify($request)) {
+            return $this->unauthorised($this->logger);
+        }
+
+        return $handler->handle($request);
+    }
+
+    protected function unauthorised(LoggerInterface $logger): ResponseInterface
+    {
+        $logger->warning('Unauthorised');
+
+        /** @var ResponseInterface $response */
+        $response = new Response(StatusCodeInterface::STATUS_UNAUTHORIZED);
+        $response->getBody()->write(json_encode(['error' => 'Unauthorized'], JSON_PRETTY_PRINT));
+
+        return $response->withHeader('Content-Type', 'application/json');
+    }
+
+    private function verify(ServerRequestInterface $request): bool
+    {
+        $givenHash = $request->getHeaderLine('x-send-verify-hash');
+
+        $expectedHash = hash_hmac(
+            'sha256',
+            trim((string) $request->getBody()),
+            $this->sfApiKey
+        );
+
+        return ($givenHash === $expectedHash);
+    }
+}

--- a/src/Application/Auth/SalesforceAuthMiddleware.php
+++ b/src/Application/Auth/SalesforceAuthMiddleware.php
@@ -16,7 +16,8 @@ use Slim\Psr7\Response;
 
 /**
  * This middleware requires that a request is from our own Salesforce instance, based on a shared secret. Salesforce
- * is a source of truth for much of our data so requests from it may be trusted with wide powers to modify matchbot state.
+ * is a source of truth for much of our data so requests from it may be trusted with wide powers to modify matchbot
+ * state.
  *
  * Based on \BigGive\Identity\Client\Mailer
  */
@@ -27,10 +28,8 @@ readonly class SalesforceAuthMiddleware implements MiddlewareInterface
         /** @var non-empty-string $sfApiKey */
         #[\SensitiveParameter]
         private string $sfApiKey,
-
         private LoggerInterface $logger,
-    )
-    {
+    ) {
         Assertion::notEmpty($this->sfApiKey);
     }
 

--- a/src/Domain/Charity.php
+++ b/src/Domain/Charity.php
@@ -248,4 +248,10 @@ class Charity extends SalesforceReadProxy
 
         $this->updateFromSFRequiredSince = null;
     }
+
+
+    public function setUpdateRequiredFromSFSince(\DateTimeImmutable $since): void
+    {
+        $this->updateFromSFRequiredSince = $since;
+    }
 }

--- a/src/Domain/Charity.php
+++ b/src/Domain/Charity.php
@@ -10,6 +10,8 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Table]
 #[ORM\Entity(repositoryClass: CharityRepository::class)]
 #[ORM\HasLifecycleCallbacks]
+#[ORM\Index(columns: ["salesforceId"])]
+#[ORM\Index(columns: ["updateFromSFRequiredSince"])]
 class Charity extends SalesforceReadProxy
 {
     use TimestampsTrait;
@@ -80,6 +82,12 @@ class Charity extends SalesforceReadProxy
      */
     #[ORM\Column(type: 'boolean')]
     private bool $tbgApprovedToClaimGiftAid = false;
+
+    /**
+     * @psalm-suppress UnusedProperty - will be used soon.
+     */
+    #[ORM\Column(nullable: true)]
+    private ?\DateTimeImmutable $updateFromSFRequiredSince = null;
 
     public function __construct(
         string $salesforceId,
@@ -237,5 +245,7 @@ class Charity extends SalesforceReadProxy
         $this->setRegulatorNumber($regulatorNumber);
 
         $this->setSalesforceLastPull($time);
+
+        $this->updateFromSFRequiredSince = null;
     }
 }

--- a/src/Domain/CharityRepository.php
+++ b/src/Domain/CharityRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MatchBot\Domain;
 
 use Doctrine\ORM\EntityRepository;
+use MatchBot\Domain\DomainException\DomainRecordNotFoundException;
 
 /**
  * Not a SalesforceReadyProxyRepository for now, because we only need to pull charity data
@@ -15,4 +16,12 @@ use Doctrine\ORM\EntityRepository;
  */
 class CharityRepository extends EntityRepository
 {
+    /**
+     * @throws DomainRecordNotFoundException
+     */
+    public function findOneBySfIDOrThrow(Salesforce18Id $sfId): Charity
+    {
+        return $this->findOneBy(['salesforceId' => $sfId->value]) ??
+            throw new DomainRecordNotFoundException('Charity not found');
+    }
 }

--- a/src/Migrations/Version20240709162518.php
+++ b/src/Migrations/Version20240709162518.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240709162518 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'ADD Charity.updateFromSFRequiredSince column';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE Charity ADD updateFromSFRequiredSince DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\'');
+        $this->addSql('CREATE INDEX IDX_4CC08E82D8961D21 ON Charity (salesforceId)');
+        $this->addSql('CREATE INDEX IDX_4CC08E823A4E7063 ON Charity (updateFromSFRequiredSince)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IDX_4CC08E82D8961D21 ON Charity');
+        $this->addSql('DROP INDEX IDX_4CC08E823A4E7063 ON Charity');
+        $this->addSql('ALTER TABLE Charity DROP updateFromSFRequiredSince');
+    }
+}

--- a/src/Migrations/Version20240709162926.php
+++ b/src/Migrations/Version20240709162926.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240709162926 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE Charity CHANGE updateFromSFRequiredSince updateFromSFRequiredSince DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE Charity CHANGE updateFromSFRequiredSince updateFromSFRequiredSince DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\'');
+    }
+}

--- a/tests/Application/Auth/SalesforceAuthMiddlewareTest.php
+++ b/tests/Application/Auth/SalesforceAuthMiddlewareTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mailer\Tests\Application\Auth;
 
-
 use Laminas\Diactoros\Request;
 use MatchBot\Application\Auth\SalesforceAuthMiddleware;
 use MatchBot\Tests\TestCase;

--- a/tests/Application/Auth/SalesforceAuthMiddlewareTest.php
+++ b/tests/Application/Auth/SalesforceAuthMiddlewareTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mailer\Tests\Application\Auth;
+
+
+use Laminas\Diactoros\Request;
+use MatchBot\Application\Auth\SalesforceAuthMiddleware;
+use MatchBot\Tests\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\NullLogger;
+use Slim\CallableResolver;
+use Slim\Psr7\Factory\ResponseFactory;
+use Slim\Psr7\Response;
+use Slim\Routing\Route;
+
+/**
+ * Based on \Mailer\Tests\Application\Auth\SendAuthMiddlewareTest
+ */
+class SalesforceAuthMiddlewareTest extends TestCase
+{
+    private const string API_KEY = 'TEST-API-KEY';
+
+    public function testMissingAuthRejected(): void
+    {
+        $body = bin2hex(random_bytes(100));
+        $request = $this->buildRequest($body, null);
+
+        $response = $this->getInstance()->process($request, $this->getSuccessHandler());
+
+        $this->assertEquals(401, $response->getStatusCode());
+    }
+
+    public function testWrongAuthRejected(): void
+    {
+        $body = bin2hex(random_bytes(100));
+        $hash = hash_hmac('sha256', $body, 'the-wrong-secret');
+        $request = $this->buildRequest($body, $hash);
+
+        $response = $this->getInstance()->process($request, $this->getSuccessHandler());
+
+        $this->assertEquals(401, $response->getStatusCode());
+    }
+
+    public function testCorrectAuthAccepted(): void
+    {
+        $body = bin2hex(random_bytes(100));
+        $hash = hash_hmac('sha256', $body, self::API_KEY);
+
+        $request = $this->buildRequest($body, $hash);
+        $response = $this->getInstance()->process($request, $this->getSuccessHandler());
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    private function buildRequest(string $body, ?string $hash = null): ServerRequestInterface
+    {
+        $headers = $hash !== null ? ['x-send-verify-hash' => $hash] : [];
+
+
+        return $this->createRequest('GET', 'any-path', $body, $headers);
+    }
+
+    /**
+     * Simulate a route returning a 200 OK. Test methods should get here only when they expect auth
+     * success from the middleware.
+     */
+    private function getSuccessHandler(): Route
+    {
+        return new Route(
+            ['get'],
+            '',
+            static function () {
+                return new Response(200);
+            },
+            new ResponseFactory(),
+            new CallableResolver()
+        );
+    }
+
+    private function getInstance(): SalesforceAuthMiddleware
+    {
+        return new SalesforceAuthMiddleware(self::API_KEY, new NullLogger());
+    }
+}


### PR DESCRIPTION
For now matchbot will just record this mark in the db, and not do anything about it. Next step is doing something about it. Possibly I should have implemented them in the opposite order for more effective CI.