### PR TITLE
MAT-363 – DB persist stability improvements; review fixes; test improvements

### DIFF
--- a/integrationTests/DonationRepositoryTest.php
+++ b/integrationTests/DonationRepositoryTest.php
@@ -217,7 +217,6 @@ class DonationRepositoryTest extends IntegrationTest
         $donationClientProphecy = $this->prophesize(\MatchBot\Client\Donation::class);
 
         $busProphecy = $this->prophesize(RoutableMessageBus::class);
-        $dummyEnvelope = new Envelope(new \stdClass()); // Final so can't prophesise.
 
         $pendingCreate = \MatchBot\Domain\SalesforceWriteProxy::PUSH_STATUS_PENDING_CREATE;
         $connection->executeStatement(<<<SQL
@@ -234,7 +233,7 @@ class DonationRepositoryTest extends IntegrationTest
 
         // assert
         $busDispatchMethod = $busProphecy->dispatch(Argument::type(Envelope::class))
-            ->willReturn($dummyEnvelope);
+            ->willReturn(new Envelope(new \stdClass()));
         if ($shouldPush) {
             $busDispatchMethod->shouldBeCalledOnce();
         } else {

--- a/integrationTests/DonationRepositoryTest.php
+++ b/integrationTests/DonationRepositoryTest.php
@@ -234,15 +234,18 @@ class DonationRepositoryTest extends IntegrationTest
 
         // assert
         $busDispatchMethod = $busProphecy->dispatch(Argument::type(Envelope::class))
-            ->will(/**
-             * @param array{0: Envelope} $args
-             */ function (array $args) use ($donationUUID) {
-                $envelope = $args[0];
-                $message = $envelope->getMessage();
-                TestCase::assertInstanceOf(DonationUpserted::class, $message);
-                TestCase::assertSame($donationUUID, $message->uuid);
-                return $envelope;
-            });
+            ->will(
+                /**
+                 * @param array{0: Envelope} $args
+                 */
+                function (array $args) use ($donationUUID) {
+                    $envelope = $args[0];
+                    $message = $envelope->getMessage();
+                    TestCase::assertInstanceOf(DonationUpserted::class, $message);
+                    TestCase::assertSame($donationUUID, $message->uuid);
+                    return $envelope;
+                }
+            );
 
         if ($shouldPush) {
             $busDispatchMethod->shouldBeCalledOnce();

--- a/integrationTests/DonationRepositoryTest.php
+++ b/integrationTests/DonationRepositoryTest.php
@@ -234,12 +234,13 @@ class DonationRepositoryTest extends IntegrationTest
 
         // assert
         $busDispatchMethod = $busProphecy->dispatch(Argument::type(Envelope::class))
-            ->will(function (array $args) use ($donationUUID) {
-                /** @var Envelope $envelope */
+            ->will(/**
+             * @param array{0: Envelope} $args
+             */ function (array $args) use ($donationUUID) {
                 $envelope = $args[0];
                 $message = $envelope->getMessage();
-                \assert($message instanceof DonationUpserted);
-                \assert($message->uuid === $donationUUID);
+                TestCase::assertInstanceOf(DonationUpserted::class, $message);
+                TestCase::assertSame($donationUUID, $message->uuid);
                 return $envelope;
             });
 

--- a/src/Application/Actions/Donations/Confirm.php
+++ b/src/Application/Actions/Donations/Confirm.php
@@ -22,7 +22,7 @@ use Stripe\Exception\ApiErrorException;
 use Stripe\Exception\CardException;
 use Stripe\Exception\InvalidRequestException;
 use Symfony\Component\Messenger\Envelope;
-use Symfony\Component\Messenger\RoutableMessageBus;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 class Confirm extends Action
 {
@@ -45,7 +45,7 @@ class Confirm extends Action
         private DonationRepository $donationRepository,
         private Stripe $stripe,
         private EntityManagerInterface $entityManager,
-        private RoutableMessageBus $bus,
+        private MessageBusInterface $bus,
     ) {
         parent::__construct($logger);
     }

--- a/src/Application/Messenger/AbstractStateChanged.php
+++ b/src/Application/Messenger/AbstractStateChanged.php
@@ -11,13 +11,13 @@ use MatchBot\Application\Assertion;
 abstract class AbstractStateChanged
 {
     /**
-     * @psalm-suppress PossiblyUnusedProperty Plan is to use `$json` with mandates
+     * @psalm-suppress PossiblyUnusedProperty Plan is to use `$jsonSnapshot` with mandates
      */
-    public array $json;
+    public array $jsonSnapshot;
 
     protected function __construct(public string $uuid, array $json)
     {
         Assertion::uuid($this->uuid);
-        $this->json = $json;
+        $this->jsonSnapshot = $json;
     }
 }

--- a/src/Application/Messenger/DonationUpserted.php
+++ b/src/Application/Messenger/DonationUpserted.php
@@ -6,16 +6,16 @@ use MatchBot\Domain\Donation;
 
 class DonationUpserted extends AbstractStateChanged
 {
-    private function __construct(public string $uuid, public array $json)
+    private function __construct(public string $uuid, public array $jsonSnapshot)
     {
-        parent::__construct($uuid, $json);
+        parent::__construct($uuid, $jsonSnapshot);
     }
 
     public static function fromDonation(Donation $donation): self
     {
         return new self(
             uuid: $donation->getUuid(),
-            json: $donation->toSFApiModel(),
+            jsonSnapshot: $donation->toSFApiModel(),
         );
     }
 }

--- a/src/Client/Donation.php
+++ b/src/Client/Donation.php
@@ -26,9 +26,9 @@ class Donation extends Common
             $response = $this->getHttpClient()->post(
                 $this->getSetting('donation', 'baseUri') . '/' . $message->uuid,
                 [
-                    'json' => $message->json,
+                    'json' => $message->jsonSnapshot,
                     'headers' => [
-                        'X-Webhook-Verify-Hash' => $this->hash(json_encode($message->json)),
+                        'X-Webhook-Verify-Hash' => $this->hash(json_encode($message->jsonSnapshot)),
                     ],
                 ]
             );

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -1415,7 +1415,9 @@ class Donation extends SalesforceWriteProxy
         $this->setTipGiftAid($tipGiftAid);
         $this->setTbgShouldProcessGiftAid($this->getCampaign()->getCharity()->isTbgClaimingGiftAid());
         $this->setDonorHomePostcode($donorHomePostcode);
-        $this->setDonorName($donorName);
+        if ($donorName) {
+            $this->setDonorName($donorName);
+        }
         $this->setDonorEmailAddress($donorEmailAddress);
         $this->setTbgComms($tbgComms);
         $this->setCharityComms($charityComms);

--- a/src/Domain/DonationRepository.php
+++ b/src/Domain/DonationRepository.php
@@ -19,7 +19,7 @@ use MatchBot\Client\NotFoundException;
 use Symfony\Component\Lock\Exception\LockAcquiringException;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Messenger\Envelope;
-use Symfony\Component\Messenger\RoutableMessageBus;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
  * @template-extends SalesforceWriteProxyRepository<Donation, \MatchBot\Client\Donation>
@@ -655,10 +655,9 @@ class DonationRepository extends SalesforceWriteProxyRepository
      * By using FIFO queues and deduplicating on UUID if there are multiple consumers, we should make it unlikely
      * that Salesforce hits Donation record lock contention issues.
      *
-     * @param RoutableMessageBus $bus   We had to not DI this to avoid a circular dependency.
      * @return int  Number of objects pushed
      */
-    public function pushSalesforcePending(\DateTimeImmutable $now, RoutableMessageBus $bus): int
+    public function pushSalesforcePending(\DateTimeImmutable $now, MessageBusInterface $bus): int
     {
         // We don't want to push donations that were created or modified in the last 5 minutes,
         // to avoid collisions with other pushes.

--- a/src/Domain/DonationRepository.php
+++ b/src/Domain/DonationRepository.php
@@ -30,6 +30,8 @@ class DonationRepository extends SalesforceWriteProxyRepository
     /** Maximum of each type of pending object to process */
     private const MAX_PER_BULK_PUSH = 5_000;
 
+    private const int MAX_SALEFORCE_FIELD_UPDATE_TRIES = 3;
+
     private CampaignRepository $campaignRepository;
     private FundRepository $fundRepository;
     private LockFactory $lockFactory;
@@ -51,46 +53,14 @@ class DonationRepository extends SalesforceWriteProxyRepository
         $this->matchingAdapter = $adapter;
     }
 
-    public function doCreate(AbstractStateChanged $changeMessage): bool
+    public function doCreate(AbstractStateChanged $changeMessage): void
     {
-        Assertion::isInstanceOf($changeMessage, DonationUpserted::class);
-
-        try {
-            $salesforceDonationId = $this->getClient()->createOrUpdate($changeMessage);
-            $this->setSalesforceIdIfNeeded($changeMessage, $salesforceDonationId);
-        } catch (NotFoundException $ex) {
-            // Thrown only for *sandbox* 404s -> quietly stop trying to push donation to a removed campaign.
-            $this->logInfo(
-                "Marking Salesforce donation {$changeMessage->uuid} as campaign removed; will not try to push again."
-            );
-
-            return false;
-        } catch (BadRequestException $exception) {
-            return false;
-        }
-
-        return true;
+        $this->upsert($changeMessage);
     }
 
-    public function doUpdate(AbstractStateChanged $changeMessage): bool
+    public function doUpdate(AbstractStateChanged $changeMessage): void
     {
-        Assertion::isInstanceOf($changeMessage, DonationUpserted::class);
-
-        try {
-            $salesforceDonationId = $this->getClient()->createOrUpdate($changeMessage);
-        } catch (NotFoundException $ex) {
-            // Thrown only for *sandbox* 404s -> quietly stop trying to push the removed donation.
-            $this->logInfo(
-                "Marking 404 campaign Salesforce donation {$changeMessage->uuid} as complete; " .
-                'will not try to push again.'
-            );
-
-            return false;
-        }
-
-        $this->setSalesforceIdIfNeeded($changeMessage, $salesforceDonationId);
-
-        return true;
+        $this->upsert($changeMessage);
     }
 
     /**
@@ -705,52 +675,85 @@ class DonationRepository extends SalesforceWriteProxyRepository
         return count($proxiesToCreate) + count($proxiesToUpdate);
     }
 
-    private function setSalesforceIdIfNeeded(AbstractStateChanged $changeMessage, Salesforce18Id $salesforceId): void
-    {
-        // If Salesforce ID wasn't set yet, try to safely set it. If it
-        // fails, this should be safe to leave for a later update. Salesforce has UUIDs so
-        // we won't lose the ability to reconcile the records.
+    private function setSalesforceFieldsWithRetry(
+        AbstractStateChanged $changeMessage,
+        ?Salesforce18Id $salesforceId
+    ): void {
+        $tries = 0;
+
+        // Try to safely set Salesforce ID, and other push tracking fields. If it
+        // fails repeatedly, this should be safe to leave for a later update.
+        // Salesforce has UUIDs so we won't lose the ability to reconcile the records.
         $uuid = $changeMessage->uuid;
-        try {
-            $this->safelySetSalesforceId($uuid, $salesforceId);
-        } catch (DBALException\LockWaitTimeoutException $exception) {
-            // Initial checks on Regression suggest that this happens semi-regularly and that recovery
-            // from later calls is very possibly good enough without retrying here. So for now the level
-            // is `.INFO` only, and we also need to avoid logging the 'An exception occurred...' bit of
-            // the message to stop a sensitive log metric pattern from interpreting the event as an error.
-            $messageWithoutPrefix = str_replace(
-                'An exception occurred while executing a query: ',
-                '',
-                $exception->getMessage(),
-            );
-            $this->logInfo(sprintf(
-                'Lock unavailable to give donation %s Salesforce ID %s, will leave for later: %s',
-                $uuid,
-                $salesforceId,
-                $messageWithoutPrefix,
-            ));
-        }
+
+        do {
+            try {
+                $this->setSalesforceFields($uuid, $salesforceId);
+                return;
+            } catch (DBALException\RetryableException $exception) {
+                $tries++;
+                $this->logInfo(sprintf(
+                    '%s: Lock unavailable to set Salesforce fields on donation %s with Salesforce ID %s on try #%d',
+                    get_class($exception),
+                    $uuid,
+                    $salesforceId?->value ?? 'null',
+                    $tries,
+                ));
+            }
+        } while ($tries < self::MAX_SALEFORCE_FIELD_UPDATE_TRIES);
+
+        $this->logWarning(
+            "Failed to set Salesforce fields for donation $uuid after $tries tries"
+        );
     }
 
     /**
-     * Sets a Salesforce ID without its own lock and importantly without the ORM, using
-     * a raw DQL `UPDATE` that should make it safe irrespective of ORM work that could
-     * also be happening on the record.
+     * Sets a Salesforce ID (and general status things)without its own lock and importantly without the ORM, using
+     * a raw DQL `UPDATE` that should make it safe irrespective of ORM work that could also be happening on the record.
      *
      * @throws DBALException\LockWaitTimeoutException if some other transaction is holding a lock
      */
-    private function safelySetSalesforceId(string $uuid, Salesforce18Id $salesforceId): void
+    private function setSalesforceFields(string $uuid, ?Salesforce18Id $salesforceId): void
     {
         $query = $this->getEntityManager()->createQuery(
             <<<'DQL'
             UPDATE Matchbot\Domain\Donation donation
-            SET donation.salesforceId = :salesforceId
+            SET
+                donation.salesforceId = :salesforceId,
+                donation.salesforcePushStatus = 'complete',
+                donation.salesforceLastPush = NOW()
             WHERE donation.uuid = :uuid
             DQL
         );
-        $query->setParameter('salesforceId', $salesforceId->value);
+        $query->setParameter('salesforceId', $salesforceId?->value);
         $query->setParameter('uuid', $uuid);
         $query->execute();
+    }
+
+    private function upsert(AbstractStateChanged $changeMessage): void
+    {
+        Assertion::isInstanceOf($changeMessage, DonationUpserted::class);
+
+        try {
+            $salesforceDonationId = $this->getClient()->createOrUpdate($changeMessage);
+        } catch (NotFoundException $ex) {
+            // Thrown only for *sandbox* 404s -> quietly stop trying to push donation to a removed campaign.
+            $this->logInfo(
+                "Marking 404 campaign Salesforce donation {$changeMessage->uuid} as complete; " .
+                'will not try to push again.'
+            );
+            $this->setSalesforceFieldsWithRetry($changeMessage, null);
+
+            return;
+        } catch (BadRequestException $exception) {
+            $this->logError(
+                "Pushing Salesforce donation {$changeMessage->uuid} got 400: {$exception->getMessage()}"
+            );
+
+            return;
+        }
+
+        $this->setSalesforceFieldsWithRetry($changeMessage, $salesforceDonationId);
     }
 
     /**

--- a/tests/Application/Actions/Donations/UpdateHandlesLockExceptionTest.php
+++ b/tests/Application/Actions/Donations/UpdateHandlesLockExceptionTest.php
@@ -9,7 +9,6 @@ use Doctrine\DBAL\Exception\LockWaitTimeoutException;
 use Doctrine\ORM\EntityManagerInterface;
 use GuzzleHttp\Psr7\ServerRequest;
 use MatchBot\Application\Actions\Donations\Update;
-use MatchBot\Application\Messenger\DonationUpserted;
 use MatchBot\Client\Stripe;
 use MatchBot\Domain\Campaign;
 use MatchBot\Domain\Donation;

--- a/tests/Application/Actions/Donations/UpdateHandlesLockExceptionTest.php
+++ b/tests/Application/Actions/Donations/UpdateHandlesLockExceptionTest.php
@@ -41,10 +41,14 @@ class UpdateHandlesLockExceptionTest extends TestCase
     /** @var ObjectProphecy<EntityManagerInterface>  */
     private ObjectProphecy $entityManagerProphecy;
 
+    /** @var ObjectProphecy<RoutableMessageBus> */
+    private ObjectProphecy $messageBusProphecy;
+
     public function setUp(): void
     {
         $this->donationRepositoryProphecy = $this->prophesize(DonationRepository::class);
         $this->entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
+        $this->messageBusProphecy = $this->prophesize(RoutableMessageBus::class);
     }
 
     public function testRetriesOnUpdateStillPendingLockException(): void
@@ -76,8 +80,6 @@ class UpdateHandlesLockExceptionTest extends TestCase
 
         $this->setExpectationsForPersistAfterRetry($donationId, $donation, DonationStatus::Cancelled);
 
-        // TODO expect something on bus instead
-//        $this->donationRepositoryProphecy->push($upsertMessage, false)->shouldBeCalled();
         $this->donationRepositoryProphecy->releaseMatchFunds($donation)->shouldBeCalled();
 
         $updateAction = $this->makeUpdateAction();
@@ -170,13 +172,19 @@ class UpdateHandlesLockExceptionTest extends TestCase
         $this->entityManagerProphecy->persist(Argument::type(Donation::class))
             ->shouldBeCalledTimes(2); // One failure, one success
         $this->entityManagerProphecy->commit()->shouldBeCalledOnce();
+
+        /**
+         * @see \MatchBot\IntegrationTests\DonationRepositoryTest for more granular checks of what's
+         * in the envelope. There isn't much variation in what we dispatch so it's not critical to
+         * repeat these checks in every test, but we do want to check we are dispatching the
+         * expected number of times.
+         */
+        $this->messageBusProphecy->dispatch(Argument::type(Envelope::class))->shouldBeCalledOnce()
+            ->willReturnArgument();
     }
 
     private function makeUpdateAction(): Update
     {
-        $routableMessageBusProphecy = $this->prophesize(RoutableMessageBus::class);
-        $routableMessageBusProphecy->dispatch(Argument::type(Envelope::class))->willReturnArgument();
-
         return new Update(
             $this->donationRepositoryProphecy->reveal(),
             $this->entityManagerProphecy->reveal(),
@@ -184,7 +192,7 @@ class UpdateHandlesLockExceptionTest extends TestCase
             $this->createStub(Stripe::class),
             new NullLogger(),
             new MockClock(),
-            $routableMessageBusProphecy->reveal(),
+            $this->messageBusProphecy->reveal(),
         );
     }
 }

--- a/tests/Application/Messenger/Handler/DonationUpsertedHandlerTest.php
+++ b/tests/Application/Messenger/Handler/DonationUpsertedHandlerTest.php
@@ -26,14 +26,16 @@ class DonationUpsertedHandlerTest extends TestCase
 
     public function testItPushesOneDonationToSf(): void
     {
-        $this->donationRepositoryProphecy->push(Argument::type(DonationUpserted::class), false)->shouldBeCalledOnce();
+        $message = self::someUpsertedMessage();
+
+        $this->donationRepositoryProphecy->push($message, false)->shouldBeCalledOnce();
 
         $sut = new DonationUpsertedHandler(
             $this->donationRepositoryProphecy->reveal(),
             new NullLogger(),
         );
 
-        $sut->__invoke(self::someUpsertedMessage());
+        $sut->__invoke($message);
     }
 
     /**
@@ -41,7 +43,9 @@ class DonationUpsertedHandlerTest extends TestCase
      */
     public function testItLogsErrorIfDonationCannotBePushed(): void
     {
-        $this->donationRepositoryProphecy->push(Argument::type(DonationUpserted::class), false)
+        $message = self::someUpsertedMessage();
+
+        $this->donationRepositoryProphecy->push($message, false)
             ->willThrow(new \Exception('Failed to push to SF'));
 
         $loggerWithOneError = $this->prophesize(LoggerInterface::class);
@@ -53,6 +57,6 @@ class DonationUpsertedHandlerTest extends TestCase
             $loggerWithOneError->reveal(),
         );
 
-        $sut->__invoke(self::someUpsertedMessage());
+        $sut->__invoke($message);
     }
 }

--- a/tests/Domain/DonationRepositoryTest.php
+++ b/tests/Domain/DonationRepositoryTest.php
@@ -170,10 +170,12 @@ class DonationRepositoryTest extends TestCase
             ->buildFromApiRequest($createPayload);
     }
 
-    public function testPushResponseError(): void
+    /**
+     * Logs an error too – but for the purposes of this test just verify it doesn't crash unhandled
+     * for now.
+     */
+    public function testPushResponseBadRequestErrorIsHandled(): void
     {
-        $this->expectException(Client\BadRequestException::class); // This kind's left unhandled
-
         $donationClientProphecy = $this->prophesize(Client\Donation::class);
         $donationClientProphecy
             ->createOrUpdate(Argument::type(DonationUpserted::class))


### PR DESCRIPTION
* Addressed what I could from https://github.com/thebiggive/matchbot/pull/922 review
* Combined needlessly two step Salesforce field updates and simplified surrounding logic further
* Introduced a retry for saving the Salesforce fields and increased log severity level if it fails
* Moved some tests that asserted things about `push()` calls to the equivalent bus dispatches