### PR TITLE
Clear wrong HMRC ref no for one charity

### DIFF
--- a/src/Migrations/Version20240807113023.php
+++ b/src/Migrations/Version20240807113023.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240807113023 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Clear wrong HMRC ref number that was already removed from SF';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(sql: <<<SQL
+            UPDATE Charity set hmrcReferenceNumber = null where salesforceId = '0016900002tly4dAAA' LIMIT 1;
+            SQL
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        throw new \Exception("no going back");
+    }
+}


### PR DESCRIPTION
Another charity should have this ref, but we have a duplicate constraint so that update from SF is getting blocked