### PR TITLE
BG2-2620: Don't generate alarm on attempt to update charity with expi…

### DIFF
--- a/src/Application/Actions/Charities/UpdateCharityFromSalesforce.php
+++ b/src/Application/Actions/Charities/UpdateCharityFromSalesforce.php
@@ -44,16 +44,28 @@ class UpdateCharityFromSalesforce extends Action
         }
 
         $campaignsToUpdate = $this->campaignRepository->findUpdatableForCharity($sfId);
+        $atLeastOneCampaignUpdated = false;
         foreach ($campaignsToUpdate as $campaign) {
             // also implicitly updates the charity every time.
             try {
                 $this->campaignRepository->updateFromSf($campaign);
+                $atLeastOneCampaignUpdated = true;
             } catch (NotFoundException $e) {
                 if ($this->environment === Environment::Production) {
                     // we don't expect to delete campaigns in prod
                     throw $e;
                 }
+            } catch (CampaignNotReady $e) {
+                // but it is normal for campaigns in prod to go from ready to not ready, e.g. when the campaign period
+                // ends.
+                $this->logger->warning($e->getMessage() . "while updating charity " . $sfId->value);
             }
+        }
+
+        if (! $atLeastOneCampaignUpdated) {
+            $this->logger->warning(
+                "Could not update charity " . $sfId->value . "from salesforce as no-known updateable campaigns"
+            );
         }
 
         $this->em->flush();

--- a/src/Application/Commands/UpdateCampaigns.php
+++ b/src/Application/Commands/UpdateCampaigns.php
@@ -61,7 +61,7 @@ EOT
 
             try {
                 $this->pull($campaign, $output);
-            } catch (NotFoundException $exception) {
+            } catch (NotFoundException | CampaignNotReady $exception) {
                 if (getenv('APP_ENV') === 'production') {
                     // This is currently possible if a charity had a campaign already launchable
                     // before, but no longer meets the requirements to run it. Our Saleforce APIs


### PR DESCRIPTION
…red campaigns

It's probably better to allow the campaigns to be updated to reflect the expired status, but we don't have to do that today.