### PR TITLE
MAT-363 – consider lost connections alarm-worthy, while keeping retry support for now

### DIFF
--- a/src/Domain/DonationRepository.php
+++ b/src/Domain/DonationRepository.php
@@ -708,10 +708,10 @@ class DonationRepository extends SalesforceWriteProxyRepository
                     $tries,
                 ));
             } catch (DBALException\ConnectionLost $exception) {
-                // Seen at fairly quiet times before we increased DB wait_timeout from 8 hours,
-                // as workers live up to 24 hours. Should happen rarely or never with new DB config.
+                // Seen only at fairly quiet times *and* before we increased DB wait_timeout from 8 hours
+                // to just over workers' max lifetime of 24 hours. Should happen rarely or never with new DB config.
                 $tries++;
-                $this->logInfo(sprintf(
+                $this->logError(sprintf(
                     '%s: Connection lost while setting Salesforce fields on donation %s, try #%d',
                     get_class($exception),
                     $uuid,


### PR DESCRIPTION
Per https://github.com/thebiggive/matchbot/pull/964#discussion_r1717119580

We have no info logs since this went live earlier this week, so the hypothesis about why it failed is probably right but we don't have much data yet. Will be good to have a prompt to investigate again if we get any occurrences with the new config.