### PR TITLE
Don-993: Record total paid by donor on donation record

### DIFF
--- a/integrationTests/DonationPersistenceTest.php
+++ b/integrationTests/DonationPersistenceTest.php
@@ -99,6 +99,7 @@ class DonationPersistenceTest extends IntegrationTest
             'tbgGiftAidResponseDetail' => null,
             'pspCustomerId' => null,
             'paymentMethodType' => 'card',
+            'totalPaidByDonor' => null,
 
             'updatedAt' => '1970-01-01',
             'createdAt' => '1970-01-01'

--- a/integrationTests/DonationRepositoryTest.php
+++ b/integrationTests/DonationRepositoryTest.php
@@ -97,6 +97,7 @@ class DonationRepositoryTest extends IntegrationTest
 
         $donation->collectFromStripeCharge(
             chargeId: 'charge_id',
+            totalPaidFractional: 300,
             transferId: 'transfer_id',
             cardBrand: null,
             cardCountry: null,

--- a/integrationTests/RedistributeMatchingCommandTest.php
+++ b/integrationTests/RedistributeMatchingCommandTest.php
@@ -176,12 +176,13 @@ class RedistributeMatchingCommandTest extends IntegrationTest
         $donation->setTransactionId('pi_' . $this->randomString());
         $donation->setSalesforceId(substr('006' . $this->randomString(), 0, 18));
         $donation->collectFromStripeCharge(
-            'chg' . (string)$randomizer->getBytesFromString('0123456789abcdef', 10),
-            'tsf' . (string)$randomizer->getBytesFromString('0123456789abcdef', 10),
-            null,
-            null,
-            '0',
-            time(),
+            chargeId: 'chg' . (string)$randomizer->getBytesFromString('0123456789abcdef', 10),
+            totalPaidFractional: (int)((float)$amount * 100),
+            transferId: 'tsf' . (string)$randomizer->getBytesFromString('0123456789abcdef', 10),
+            cardBrand: null,
+            cardCountry: null,
+            originalFeeFractional: '0',
+            chargeCreationTimestamp: time(),
         );
 
         $championFundWithdrawal = new FundingWithdrawal($championFundCampaignFunding);

--- a/src/Application/Actions/Hooks/StripePaymentsUpdate.php
+++ b/src/Application/Actions/Hooks/StripePaymentsUpdate.php
@@ -158,6 +158,7 @@ class StripePaymentsUpdate extends Stripe
 
             $donation->collectFromStripeCharge(
                 chargeId: $charge->id,
+                totalPaidFractional: $charge->amount,
                 transferId: (string)$charge->transfer,
                 cardBrand: $cardBrand,
                 cardCountry: $cardCountry,

--- a/src/Application/Actions/Hooks/StripePaymentsUpdate.php
+++ b/src/Application/Actions/Hooks/StripePaymentsUpdate.php
@@ -317,7 +317,7 @@ class StripePaymentsUpdate extends Stripe
             ));
             $refundDate = DateTimeImmutable::createFromFormat('U', (string)$event->created);
             assert($refundDate instanceof DateTimeImmutable);
-            $donation->setPartialRefundDate($refundDate);
+            $donation->setTipRefunded($refundDate);
         } elseif ($isFullRefund) {
             $this->logger->info(sprintf(
                 'Marking donation %s refunded based on charge ID %s',

--- a/src/Application/Actions/Hooks/StripePaymentsUpdate.php
+++ b/src/Application/Actions/Hooks/StripePaymentsUpdate.php
@@ -318,7 +318,6 @@ class StripePaymentsUpdate extends Stripe
             $refundDate = DateTimeImmutable::createFromFormat('U', (string)$event->created);
             assert($refundDate instanceof DateTimeImmutable);
             $donation->setPartialRefundDate($refundDate);
-            $donation->setTipAmount('0.00');
         } elseif ($isFullRefund) {
             $this->logger->info(sprintf(
                 'Marking donation %s refunded based on charge ID %s',

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -1280,10 +1280,9 @@ class Donation extends SalesforceWriteProxy
     }
 
     /**
-     * When a donation has been partially refunded (e.g. a tip-only refund) we record the refund date but we
-     * don't change the status.
+     * Sets tip amount to zero and records the refund date.
      */
-    public function setPartialRefundDate(\DateTimeImmutable $datetime): void
+    public function setTipRefunded(\DateTimeImmutable $datetime): void
     {
         $this->refundedAt = $datetime;
         $this->setTipAmount('0.00');

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -1286,6 +1286,7 @@ class Donation extends SalesforceWriteProxy
     public function setPartialRefundDate(\DateTimeImmutable $datetime): void
     {
         $this->refundedAt = $datetime;
+        $this->setTipAmount('0.00');
     }
 
     public function cancel(): void

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -1486,7 +1486,10 @@ class Donation extends SalesforceWriteProxy
 
     /**
      * @return numeric-string|null The total the donor paid, either as recorded at the time or as we can calculate from
-     * other info, in major currency units
+     * other info, in major currency units.
+     *
+     * Returns *original* charge amount even if now fully reversed, but only the net balance paid if there
+     * was a tip-only refund.
      */
     public function getTotalPaidByDonor(): ?string
     {

--- a/src/Migrations/Version20240819164301.php
+++ b/src/Migrations/Version20240819164301.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240819164301 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add column matchbot.Donation.totalPaidByDonor';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE Donation ADD totalPaidByDonor NUMERIC(18, 2) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE Donation DROP totalPaidByDonor');
+    }
+}

--- a/tests/Application/Actions/Donations/UpdateTest.php
+++ b/tests/Application/Actions/Donations/UpdateTest.php
@@ -275,6 +275,7 @@ class UpdateTest extends TestCase
 
         $donationResponse->collectFromStripeCharge(
             chargeId: 'testchargeid',
+            totalPaidFractional: 100, // irrelevant
             transferId: 'test_transfer_id',
             cardBrand: null,
             cardCountry: null,

--- a/tests/Application/Actions/Hooks/StripePaymentsUpdateTest.php
+++ b/tests/Application/Actions/Hooks/StripePaymentsUpdateTest.php
@@ -111,8 +111,21 @@ class StripePaymentsUpdateTest extends StripeTest
         /** @var Container $container */
         $container = $this->getContainer();
 
-        $body = $this->getStripeHookMock('ch_succeeded');
         $donation = $this->getTestDonation();
+
+        /** @var array $webhookContent */
+        $webhookContent = json_decode(
+            $this->getStripeHookMock('ch_succeeded'),
+            associative: true,
+            flags: JSON_THROW_ON_ERROR
+        );
+
+        /**
+         * @psalm-suppress MixedArrayAssignment
+         * @psalm-suppress MixedArrayAccess
+         */
+        $webhookContent['data']['object']['amount'] = $donation->getAmountFractionalIncTip();
+        $body = json_encode($webhookContent);
         $webhookSecret = $this->getValidWebhookSecret($container);
         $time = (string) time();
 
@@ -156,8 +169,21 @@ class StripePaymentsUpdateTest extends StripeTest
         /** @var Container $container */
         $container = $this->getContainer();
 
-        $body = $this->getStripeHookMock('ch_succeeded_sek');
         $donation = $this->getTestDonation('6000.00', currencyCode: 'SEK');
+
+        /** @var array $webhookContent */
+        $webhookContent = json_decode(
+            $this->getStripeHookMock('ch_succeeded_sek'),
+            associative: true,
+            flags: JSON_THROW_ON_ERROR
+        );
+
+        /**
+         * @psalm-suppress MixedArrayAssignment
+         * @psalm-suppress MixedArrayAccess
+         */
+        $webhookContent['data']['object']['amount'] = $donation->getAmountFractionalIncTip();
+        $body = json_encode($webhookContent);
 
         $webhookSecret = $this->getValidWebhookSecret($container);
         $time = (string) time();

--- a/tests/Application/DonationTestDataTrait.php
+++ b/tests/Application/DonationTestDataTrait.php
@@ -102,6 +102,7 @@ trait DonationTestDataTrait
         if ($collected) {
             $donation->collectFromStripeCharge(
                 chargeId: 'ch_externalId_123',
+                totalPaidFractional: (int)(((float)$amount + (float)$tipAmount) * 100),
                 transferId: 'tr_externalId_123',
                 cardBrand: null,
                 cardCountry: null,


### PR DESCRIPTION
At present the calculation of the total paid by donor (core amount + any tip + any fee cover) is done several times and is expressed in four separate lines of code - one here and three in frontend. This PR makes matchbot record the result as it comes back from Stripe so that it can replace two of the lines in frontend. We may or may not also want to replace the final one, which is for displaying the expected amount *before* the payment is taken.

See https://github.com/thebiggive/donate-frontend/pull/1617#discussion_r1720106522