### PR TITLE
Try upgrading all orbs to latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,12 @@
 version: 2.1
 
 orbs:
-  aws-ecr: circleci/aws-ecr@9.0.2
-  aws-ecs: circleci/aws-ecs@4.0.0
-  aws-cli: circleci/aws-cli@4.1.3
-  codecov: codecov/codecov@3.2.4
+  aws-ecr: circleci/aws-ecr@9.3.1
+  aws-ecs: circleci/aws-ecs@4.1.0
+  aws-cli: circleci/aws-cli@5.0.0
+  codecov: codecov/codecov@4.1.0
   jira: circleci/jira@2.1.0
-  slack: circleci/slack@4.12.1
+  slack: circleci/slack@4.13.3
 
 jobs:
   test: # Also lints first


### PR DESCRIPTION
Seems we already set `CODECOV_TOKEN` at project level (c.f. [v4 upgrade notes](https://github.com/codecov/codecov-circleci-orb/releases/tag/v4.0.0)), so hopefully no documented BC breaks.