### PR TITLE
Restore DB columns that have been dropped from staging but not yet dr…

### DIFF
--- a/integrationTests/DonationPersistenceTest.php
+++ b/integrationTests/DonationPersistenceTest.php
@@ -87,6 +87,7 @@ class DonationPersistenceTest extends IntegrationTest
             'charityFeeVat' => '0.00',
             'originalPspFee' => '0.00',
             'currencyCode' => 'GBP',
+            'feeCoverAmount' => '0.00',
             'collectedAt' => null,
             'refundedAt' => '2023-06-22 10:00:00',
             'tbgShouldProcessGiftAid' => null,

--- a/src/Migrations/Version20240821103038.php
+++ b/src/Migrations/Version20240821103038.php
@@ -16,8 +16,12 @@ final class Version20240821103038 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE Campaign DROP feePercentage');
-        $this->addSql('ALTER TABLE Donation DROP feeCoverAmount');
+        // Commenting out DROP statements below that have run in staging, before they run in prod.
+    //    $this->addSql('ALTER TABLE Campaign DROP feePercentage');
+    //    $this->addSql('ALTER TABLE Donation DROP feeCoverAmount');
+
+        // and added ALTER below, will not run in staging but will run in circleCI and prod
+            $this->addSql('ALTER TABLE Donation ALTER COLUMN feeCoverAmount SET DEFAULT 0');
     }
 
     public function down(Schema $schema): void

--- a/src/Migrations/Version20240823121343.php
+++ b/src/Migrations/Version20240823121343.php
@@ -20,7 +20,8 @@ final class Version20240823121343 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $this->addSql('DROP INDEX IDX_4CC08E823A4E7063 ON Charity');
-        $this->addSql('ALTER TABLE Charity DROP updateFromSFRequiredSince');
+        // Commenting out DROP statements below that have run in staging, before they run in prod.
+      //  $this->addSql('ALTER TABLE Charity DROP updateFromSFRequiredSince');
     }
 
     public function down(Schema $schema): void


### PR DESCRIPTION
…opped from prod

Starting to regret dropping these in advance of deploying the code that doens't need them to prod. Wanting to follow the more conservative path of first deploying the code that doesn't require these columns and only after that dropping the columns.

When we're ready to drop the columns we can do another migration a try-catch to drop them just in environments where they're not dropped yet.

Editing old migrations before they hit prod rather than just adding a new one to run after them because I want to avoid dropping the columns in prod for now, not drop them and then restore them.