### PR TITLE
DON-1025: Expose mandate next payment date to frontend

### DIFF
--- a/app/dependencies.php
+++ b/app/dependencies.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use Brick\DateTime\Instant;
 use DI\Container;
 use DI\ContainerBuilder;
 use Doctrine\DBAL\Connection;

--- a/integrationTests/ListRegularGivingMandatesTest.php
+++ b/integrationTests/ListRegularGivingMandatesTest.php
@@ -36,6 +36,11 @@ class ListRegularGivingMandatesTest extends IntegrationTest
         $campaignSfId = $this->randomString();
         $charitySfId = $this->randomString();
 
+        $container = $this->getContainer();
+
+        // Assume current date is 27th July in UTC, and 28th July in UK:
+        $container->set(\DateTimeImmutable::class, new \DateTimeImmutable('2024-07-27T23:00:00+00:00'));
+
         $charityName = "Charity Name " . $this->randomString();
 
         $this->addCampaignAndCharityToDB(
@@ -70,6 +75,7 @@ class ListRegularGivingMandatesTest extends IntegrationTest
                     'type' => 'monthly',
                     'dayOfMonth' => 28,
                     'activeFrom' => '2024-08-06T00:00:00+00:00',
+                    'expectedNextPaymentDate' => '2024-08-28',
                 ],
                 'charityName' => $charityName,
                 'giftAid' => true,

--- a/src/Domain/RegularGivingMandate.php
+++ b/src/Domain/RegularGivingMandate.php
@@ -96,7 +96,7 @@ class RegularGivingMandate extends SalesforceWriteProxy
         $this->activeFrom = $activationDate;
     }
 
-    public function toFrontEndApiModel(Charity $charity): array
+    public function toFrontEndApiModel(Charity $charity, \DateTimeImmutable $now): array
     {
         Assertion::same($charity->salesforceId, $this->charityId);
 
@@ -110,6 +110,7 @@ class RegularGivingMandate extends SalesforceWriteProxy
                 'type' => 'monthly',
                 'dayOfMonth' => $this->dayOfMonth->value,
                 'activeFrom' => $this->activeFrom?->format(\DateTimeInterface::ATOM),
+                'expectedNextPaymentDate' => $this->firstPaymentDayAfter($now)->format('Y-m-d'),
             ],
             'charityName' => $charity->getName(),
             'giftAid' => $this->giftAid,

--- a/src/Domain/RegularGivingService.php
+++ b/src/Domain/RegularGivingService.php
@@ -2,21 +2,25 @@
 
 namespace MatchBot\Domain;
 
-class RegularGivingService
+readonly class RegularGivingService
 {
     /** @psalm-suppress PossiblyUnusedMethod - used by DI container  */
-    public function __construct(private RegularGivingMandateRepository $regularGivingMandateRepository)
-    {
+    public function __construct(
+        private RegularGivingMandateRepository $regularGivingMandateRepository,
+        private \DateTimeImmutable $now
+    ) {
     }
 
     public function allActiveForDonorAsApiModel(PersonId $donor): array
     {
         $mandatesWithCharities = $this->regularGivingMandateRepository->allActiveForDonorWithCharities($donor);
 
+        $currentUKTime = $this->now->setTimezone(new \DateTimeZone("Europe/London"));
+
         return array_map(/**
          * @param array{0: RegularGivingMandate, 1: Charity} $tuple
          * @return array
-         */            static fn(array $tuple) => $tuple[0]->toFrontendApiModel($tuple[1]),
+         */            static fn(array $tuple) => $tuple[0]->toFrontendApiModel($tuple[1], $currentUKTime),
             $mandatesWithCharities
         );
     }

--- a/tests/Domain/RegularGivingMandateTest.php
+++ b/tests/Domain/RegularGivingMandateTest.php
@@ -68,14 +68,15 @@ class RegularGivingMandateTest extends TestCase
                   "schedule": {
                     "type": "monthly",
                     "dayOfMonth": 12,
-                    "activeFrom": null
+                    "activeFrom": null,
+                    "expectedNextPaymentDate": "2024-09-12"
                   },
                   "charityName": "Charity Name",
                   "giftAid": true,
                   "status": "pending"
                 }
             JSON,
-            \json_encode($mandate->toFrontEndApiModel($charity))
+            \json_encode($mandate->toFrontEndApiModel($charity, new \DateTimeImmutable('2024-08-12')))
         );
     }
     /** @dataProvider invalidRegularGivingAmounts */


### PR DESCRIPTION
Diff in test shows the change in output here:

```diff
              "schedule": {
                    "type": "monthly",
                    "dayOfMonth": 12,
                    "activeFrom": null
+                   "expectedNextPaymentDate": "2024-09-12"
              },
```