### PR TITLE
DON-1025: Avoid TZ discrepancies on mandate expectedNextPaymentDate

### DIFF
--- a/integrationTests/ListRegularGivingMandatesTest.php
+++ b/integrationTests/ListRegularGivingMandatesTest.php
@@ -75,7 +75,7 @@ class ListRegularGivingMandatesTest extends IntegrationTest
                     'type' => 'monthly',
                     'dayOfMonth' => 28,
                     'activeFrom' => '2024-08-06T00:00:00+00:00',
-                    'expectedNextPaymentDate' => '2024-08-28T00:00:00+01:00',
+                    'expectedNextPaymentDate' => '2024-08-28T06:00:00+01:00',
                 ],
                 'charityName' => $charityName,
                 'giftAid' => true,

--- a/src/Domain/RegularGivingMandate.php
+++ b/src/Domain/RegularGivingMandate.php
@@ -123,15 +123,15 @@ class RegularGivingMandate extends SalesforceWriteProxy
         // We only operate in UK market so all timestamps should be for this TZ:
         Assertion::same($currentDateTime->getTimezone()->getName(), 'Europe/London');
 
-        $today = $currentDateTime->setTime(0, 0);
+        $nextPaymentDayIsNextMonth = $currentDateTime->format('d') >= $this->dayOfMonth->value;
 
-        $nextPaymentDayIsNextMonth = $today->format('d') >= $this->dayOfMonth->value;
-
-        $todayOrNextMonth = $nextPaymentDayIsNextMonth ? $today->add(new \DateInterval("P1M")) : $today;
+        $todayOrNextMonth = $nextPaymentDayIsNextMonth ?
+            $currentDateTime->add(new \DateInterval("P1M")) :
+            $currentDateTime;
 
         return new \DateTimeImmutable(
-            $todayOrNextMonth->format('Y-m-' . $this->dayOfMonth->value),
-            $today->getTimezone()
+            $todayOrNextMonth->format('Y-m-' . $this->dayOfMonth->value . 'T06:00:00'),
+            $currentDateTime->getTimezone()
         );
     }
 }

--- a/tests/Domain/RegularGivingMandateTest.php
+++ b/tests/Domain/RegularGivingMandateTest.php
@@ -75,7 +75,7 @@ class RegularGivingMandateTest extends TestCase
                     "type": "monthly",
                     "dayOfMonth": 12,
                     "activeFrom": null,
-                    "expectedNextPaymentDate": "2024-09-12T00:00:00+01:00"
+                    "expectedNextPaymentDate": "2024-09-12T06:00:00+01:00"
                   },
                   "charityName": "Charity Name",
                   "giftAid": true,
@@ -126,9 +126,9 @@ class RegularGivingMandateTest extends TestCase
 
         return [
             // current date, configured payment day, expected next payment day
-            ['2024-08-23T17:30:00Z', 23, '2024-09-23T00:00:00+0100'],
-            ['2024-12-23T17:30:00Z', 23, '2025-01-23T00:00:00+0000'], // TZ is +0 because its winter
-            ['2024-08-22T17:30:00Z', 23, '2024-08-23T00:00:00+0100'],
+            ['2024-08-23T17:30:00Z', 23, '2024-09-23T06:00:00+0100'],
+            ['2024-12-23T17:30:00Z', 23, '2025-01-23T06:00:00+0000'], // TZ is +0 because its winter
+            ['2024-08-22T17:30:00Z', 23, '2024-08-23T06:00:00+0100'],
         ];
     }
 }


### PR DESCRIPTION
Saying that we expect to take payment at 6am rather than midnight. Not expecting to display the time, only the date, but using 6am makes sure the date will be the same in at least the UTC and London timezones.