### PR TITLE
MAT-376: Take pre-authorized donation using payment method saved on donor account

### DIFF
--- a/app/dependencies.php
+++ b/app/dependencies.php
@@ -31,6 +31,7 @@ use MatchBot\Domain\CampaignRepository;
 use MatchBot\Domain\DonationFundsNotifier;
 use MatchBot\Domain\DonationRepository;
 use MatchBot\Domain\DonationService;
+use MatchBot\Domain\DonorAccountRepository;
 use MatchBot\Monolog\Handler\SlackHandler;
 use MatchBot\Monolog\Processor\AwsTraceIdProcessor;
 use Mezzio\ProblemDetails\ProblemDetailsResponseFactory;
@@ -507,6 +508,7 @@ return function (ContainerBuilder $containerBuilder) {
                     chatter: $chatter,
                     clock: $c->get(ClockInterfaceAlias::class),
                     rateLimiterFactory: $rateLimiterFactory,
+                    donorAccountRepository: $c->get(DonorAccountRepository::class),
                 );
             }
     ]);

--- a/src/Application/Actions/Donations/Confirm.php
+++ b/src/Application/Actions/Donations/Confirm.php
@@ -13,6 +13,7 @@ use MatchBot\Client\Stripe;
 use MatchBot\Domain\Donation;
 use MatchBot\Domain\DonationRepository;
 use MatchBot\Domain\DonationService;
+use MatchBot\Domain\StripePaymentMethodId;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Log\LoggerInterface;
@@ -154,7 +155,7 @@ EOF
 
 
         try {
-            $updatedIntent = $this->donationService->confirm($donation, $paymentMethodId);
+            $updatedIntent = $this->donationService->confirm($donation, StripePaymentMethodId::of($paymentMethodId));
         } catch (CardException $exception) {
             $this->entityManager->rollback();
 

--- a/src/Client/LiveStripeClient.php
+++ b/src/Client/LiveStripeClient.php
@@ -3,6 +3,7 @@
 namespace MatchBot\Client;
 
 use MatchBot\Domain\Donation;
+use MatchBot\Domain\StripePaymentMethodId;
 use Stripe\Exception\InvalidArgumentException;
 use Stripe\PaymentIntent;
 use Stripe\PaymentMethod;
@@ -62,8 +63,8 @@ class LiveStripeClient implements Stripe
         );
     }
 
-    public function retrievePaymentMethod(string $paymentMethodId): PaymentMethod
+    public function retrievePaymentMethod(StripePaymentMethodId $pmId): PaymentMethod
     {
-        return $this->stripeClient->paymentMethods->retrieve($paymentMethodId);
+        return $this->stripeClient->paymentMethods->retrieve($pmId->stripePaymentMethodId);
     }
 }

--- a/src/Client/Stripe.php
+++ b/src/Client/Stripe.php
@@ -3,6 +3,7 @@
 namespace MatchBot\Client;
 
 use MatchBot\Domain\Donation;
+use MatchBot\Domain\StripePaymentMethodId;
 use Stripe\Exception\ApiErrorException;
 use Stripe\Exception\InvalidRequestException;
 use Stripe\PaymentIntent;
@@ -50,5 +51,5 @@ interface Stripe
      */
     public function updatePaymentMethodBillingDetail(string $paymentMethodId, Donation $donation): void;
 
-    public function retrievePaymentMethod(string $paymentMethodId): PaymentMethod;
+    public function retrievePaymentMethod(StripePaymentMethodId $pmId): PaymentMethod;
 }

--- a/src/Client/StubStripeClient.php
+++ b/src/Client/StubStripeClient.php
@@ -3,6 +3,7 @@
 namespace MatchBot\Client;
 
 use MatchBot\Domain\Donation;
+use MatchBot\Domain\StripePaymentMethodId;
 use Ramsey\Uuid\Uuid;
 use Stripe\PaymentIntent;
 use Stripe\PaymentMethod;
@@ -66,7 +67,7 @@ class StubStripeClient implements Stripe
         $this->pause();
     }
 
-    public function retrievePaymentMethod(string $paymentMethodId): PaymentMethod
+    public function retrievePaymentMethod(StripePaymentMethodId $pmId): PaymentMethod
     {
         $this->pause();
 

--- a/src/Domain/DomainException/NoDonorAccountException.php
+++ b/src/Domain/DomainException/NoDonorAccountException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Domain\DomainException;
+
+class NoDonorAccountException extends DomainException
+{
+}

--- a/src/Domain/DonationRepository.php
+++ b/src/Domain/DonationRepository.php
@@ -815,7 +815,7 @@ class DonationRepository extends SalesforceWriteProxyRepository
         $query = $this->getEntityManager()->createQuery(<<<DQL
             SELECT donation from Matchbot\Domain\Donation donation
             WHERE donation.donationStatus = '$preAuthorized'
-            AND donation.preAuthorizationDate >= :now
+            AND donation.preAuthorizationDate <= :now
         DQL
         );
 

--- a/src/Domain/DonorAccount.php
+++ b/src/Domain/DonorAccount.php
@@ -31,11 +31,33 @@ class DonorAccount extends Model
     #[ORM\Embedded(class: 'StripeCustomerId', columnPrefix: false)]
     public readonly StripeCustomerId $stripeCustomerId;
 
+    /**
+     * The payment method selected for use in off session, regular giving payments, when the donor isn't around to
+     * make an individual choice for each donation. Must be a payment card, and have
+     * ['setup_future_usage' => 'on_session'] selected.
+     *
+     * String not embeddable because ORM does not support nullable embeddables.
+     */
+    #[ORM\Column(type: 'string', nullable: true, length: 255)]
+    private ?string $regularGivingPaymentMethod = null;
+
     public function __construct(EmailAddress $emailAddress, DonorName $donorName, StripeCustomerId $stripeCustomerId)
     {
         $this->createdNow();
         $this->emailAddress = $emailAddress;
         $this->stripeCustomerId = $stripeCustomerId;
         $this->donorName = $donorName;
+    }
+
+    /**
+     * @psalm-suppress PossiblyUnusedMethod - to be used soon.
+     */
+    public function getRegularGivingPaymentMethod(): ?StripePaymentMethodId
+    {
+        if ($this->regularGivingPaymentMethod === null) {
+            return null;
+        }
+
+        return StripePaymentMethodId::of($this->regularGivingPaymentMethod);
     }
 }

--- a/src/Domain/NoRegularGivingPaymentMethod.php
+++ b/src/Domain/NoRegularGivingPaymentMethod.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace MatchBot\Domain;
+
+use MatchBot\Domain\DomainException\DomainException;
+
+class NoRegularGivingPaymentMethod extends DomainException
+{
+}

--- a/src/Domain/StripePaymentMethodId.php
+++ b/src/Domain/StripePaymentMethodId.php
@@ -7,18 +7,18 @@ use Doctrine\ORM\Mapping\Embeddable;
 use MatchBot\Application\Assertion;
 
 #[Embeddable]
-readonly class StripeCustomerId
+readonly class StripePaymentMethodId
 {
     #[Column(type: 'string')]
-    public string $stripeCustomerId;
+    public readonly string $stripePaymentMethodId;
 
     private function __construct(
         string $stripeCustomerId
     ) {
-        $this->stripeCustomerId = $stripeCustomerId;
-        Assertion::notEmpty($this->stripeCustomerId);
-        Assertion::maxLength($this->stripeCustomerId, 255);
-        Assertion::regex($this->stripeCustomerId, '/^cus_[a-zA-Z0-9]+$/'); // e.g. cus_df64s36cf
+        $this->stripePaymentMethodId = $stripeCustomerId;
+        Assertion::notEmpty($this->stripePaymentMethodId);
+        Assertion::maxLength($this->stripePaymentMethodId, 255);
+        Assertion::regex($this->stripePaymentMethodId, '/^pm_[a-zA-Z0-9]+$/'); // e.g. pm_df64s36cf
     }
 
     /**

--- a/src/Migrations/Version20240828120951.php
+++ b/src/Migrations/Version20240828120951.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240828120951 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add payment method ID for use in regular giving to DB';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE DonorAccount ADD regularGivingPaymentMethod VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE DonorAccount DROP regularGivingPaymentMethod');
+    }
+}

--- a/tests/Application/Actions/Donations/CreateTest.php
+++ b/tests/Application/Actions/Donations/CreateTest.php
@@ -18,6 +18,7 @@ use MatchBot\Domain\CampaignRepository;
 use MatchBot\Domain\Donation;
 use MatchBot\Domain\DonationRepository;
 use MatchBot\Domain\DonationStatus;
+use MatchBot\Domain\DonorAccountRepository;
 use MatchBot\Domain\FundingWithdrawal;
 use MatchBot\Tests\TestCase;
 use MatchBot\Tests\TestData;
@@ -98,6 +99,7 @@ class CreateTest extends TestCase
 
         $campaignRepositoryProphecy = $this->prophesize(CampaignRepository::class);
         $container->set(CampaignRepository::class, $campaignRepositoryProphecy->reveal());
+        $container->set(DonorAccountRepository::class, $this->createStub(DonorAccountRepository::class));
 
         $this->messageBusProphecy = $this->prophesize(RoutableMessageBus::class);
     }

--- a/tests/Domain/DonationServiceTest.php
+++ b/tests/Domain/DonationServiceTest.php
@@ -14,6 +14,7 @@ use MatchBot\Domain\DomainException\CharityAccountLacksNeededCapaiblities;
 use MatchBot\Domain\Donation;
 use MatchBot\Domain\DonationRepository;
 use MatchBot\Domain\DonationService;
+use MatchBot\Domain\DonorAccountRepository;
 use MatchBot\Tests\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -131,7 +132,8 @@ class DonationServiceTest extends TestCase
             matchingAdapter: $this->prophesize(Adapter::class)->reveal(),
             chatter: $this->chatterProphecy->reveal(),
             clock: $this->prophesize(ClockInterface::class)->reveal(),
-            rateLimiterFactory: new RateLimiterFactory(['id' => 'stub', 'policy' => 'no_limit'], new InMemoryStorage())
+            rateLimiterFactory: new RateLimiterFactory(['id' => 'stub', 'policy' => 'no_limit'], new InMemoryStorage()),
+            donorAccountRepository: $this->createStub(DonorAccountRepository::class),
         );
     }
 


### PR DESCRIPTION
…unt table

I have tested this manually by editing data in my local database to have a donation in 'PreAuthorized' status with a `preAuthorizationDate` of yesterday, and making sure I have an entry for myself in the DonorAccount table with a working card's ID from stripe as my `regularGivingPaymentMethod`. Given that I can run in the docker container

```
./matchbot matchbot:take-regular-giving-donations
```

and my donation gets collected.