### PR TITLE
MAT-376: Create command to generate a regular giving mandate for testing

### DIFF
--- a/matchbot-cli.php
+++ b/matchbot-cli.php
@@ -17,6 +17,7 @@ use MatchBot\Application\Commands\RedistributeMatchFunds;
 use MatchBot\Application\Commands\ResetMatching;
 use MatchBot\Application\Commands\RetrospectivelyMatch;
 use MatchBot\Application\Commands\ScheduledOutOfSyncFundsCheck;
+use MatchBot\Application\Commands\SetupTestMandate;
 use MatchBot\Application\Commands\TakeRegularGivingDonations;
 use MatchBot\Application\Commands\UpdateCampaigns;
 use MatchBot\Application\Matching;
@@ -106,6 +107,7 @@ $commands = [
         $psr11App->get(LoggerInterface::class),
     ),
     $psr11App->get(TakeRegularGivingDonations::class),
+    $psr11App->get(SetupTestMandate::class),
 ];
 
 foreach ($commands as $command) {

--- a/src/Application/Commands/SetupTestMandate.php
+++ b/src/Application/Commands/SetupTestMandate.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace MatchBot\Application\Commands;
+
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\ORM\EntityManagerInterface;
+use Infection\Console\IO;
+use MatchBot\Application\Environment;
+use MatchBot\Application\HttpModels\DonationCreate;
+use MatchBot\Domain\Campaign;
+use MatchBot\Domain\CampaignRepository;
+use MatchBot\Domain\Charity;
+use MatchBot\Domain\DayOfMonth;
+use MatchBot\Domain\Donation;
+use MatchBot\Domain\DonorAccount;
+use MatchBot\Domain\DonorAccountRepository;
+use MatchBot\Domain\DonorName;
+use MatchBot\Domain\EmailAddress;
+use MatchBot\Domain\Money;
+use MatchBot\Domain\PaymentMethodType;
+use MatchBot\Domain\PersonId;
+use MatchBot\Domain\RegularGivingMandate;
+use MatchBot\Domain\Salesforce18Id;
+use MatchBot\Domain\StripeCustomerId;
+use MatchBot\Domain\StripePaymentMethodId;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Use to create a regular giving agreement for test purposes. Usage example:
+ *
+ * To create a regular giving mandate for the emergency campaign, with gift aid enabled, for
+ * a donor with the given identity server UUID, stripe customer ID and payment method ID, to donate £500 each month
+ * on the 20th day of the month, starting this month if today is <19th otherwise starting next month run:
+ *
+ * ./matchbot matchbot:setup-test-mandate --campaign Emergency --gift-aid
+ *      --donor-uuid 72f1e368-65f3-11ef-878f-fb0a039f0650 --donor-stripeid cus_xyxzaxasfdef
+*       --donor-pmid pm_1xyzxzyxzyxzyxzyxzyxzyxz 500 20
+ *
+ * This doesn't create the intitial donation, but it does pre-authorise the 2nd and 3rd donations.
+ */
+#[AsCommand(
+    name: 'matchbot:setup-test-mandate',
+    description: "For use in non-prod only. Sets up a new regular giving mandate in the DB so we can test processing",
+)]
+class SetupTestMandate extends LockingCommand
+{
+    private \DateTimeImmutable $now;
+
+    /** @psalm-suppress PossiblyUnusedMethod */
+    public function __construct(
+        private Environment $environment,
+        private EntityManagerInterface $em,
+        private CampaignRepository $campaignRepository,
+        private DonorAccountRepository $donorAccountRepository,
+        \DateTimeImmutable $now,
+    ) {
+        parent::__construct();
+        $this->now = $now->setTimezone(new \DateTimeZone('Europe/London'));
+    }
+
+    public function configure(): void
+    {
+        $this->addOption('donor-uuid', 'du', InputOption::VALUE_REQUIRED, 'UUID of the donor in identity service');
+        $this->addOption('donor-stripeid', 'ds', InputOption::VALUE_REQUIRED, 'id of the donor in stripe');
+        $this->addOption(
+            'donor-pmid',
+            'dp',
+            InputOption::VALUE_REQUIRED,
+            'id of payment method in stripe'
+        );
+
+        $this->addOption('campaign', 'c', InputOption::VALUE_REQUIRED);
+        $this->addOption('gift-aid', 'g', InputOption::VALUE_NONE);
+        $this->addArgument('amount', InputArgument::OPTIONAL, 'Amount in pounds');
+        $this->addArgument('day-of-month', InputArgument::OPTIONAL, 'Amount in pounds');
+    }
+
+    protected function doExecute(InputInterface $input, OutputInterface $output): int
+    {
+        if ($this->environment == Environment::Production) {
+            throw new \Exception("Not for use in production");
+        }
+
+        $io = new SymfonyStyle($input, $output);
+
+        $donorId = PersonId::of((string) $input->getOption('donor-uuid'));
+        $amount = (int)($input->getArgument('amount') ?? '1');
+        $campaignName = (string) $input->getOption('campaign');
+
+        (new Criteria())->where(Criteria::expr()->contains('name', $campaignName));
+
+        $campaign = $this->campaignRepository->matching(new Criteria())->first();
+
+        if (!$campaign) {
+            $io->error("No campaign found for {$campaignName}");
+            return Command::FAILURE;
+        }
+
+        $charity = $campaign->getCharity();
+
+        $dayOfMonth = DayOfMonth::of((int)($input->getArgument('day-of-month') ?? '1'));
+
+        $mandate = new RegularGivingMandate(
+            $donorId,
+            Money::fromPoundsGBP($amount),
+            Salesforce18Id::ofCampaign(
+                $campaign->getSalesforceId() ?? throw new \Exception('Missing campaign sf ID')
+            ),
+            Salesforce18Id::ofCharity(
+                $charity->getSalesforceId() ?? throw new \Exception('Missing charity sf ID')
+            ),
+            (bool)$input->getOption('gift-aid'),
+            $dayOfMonth
+        );
+        $mandate->activate($this->now);
+
+        $donorStripeId = (string)$input->getOption('donor-stripeid');
+
+        $donor = $this->donorAccountRepository->findByStripeIdOrNull(StripeCustomerId::of($donorStripeId));
+        if ($donor === null) {
+            $donor = new DonorAccount(
+                EmailAddress::of('test@biggive.org'),
+                DonorName::of('First Name', 'Last Name'),
+                StripeCustomerId::of($donorStripeId)
+            );
+            $this->em->persist($donor);
+        }
+        $donor->setRegularGivingPaymentMethod(StripePaymentMethodId::of((string) $input->getOption('donor-pmid')));
+
+
+        $this->makePreAuthedDonations($mandate, $campaign, $donor);
+
+        $this->em->persist($mandate);
+        $this->em->flush();
+
+        $io->writeln("Created new regular giving mandate:");
+        $io->writeln(json_encode($mandate->toFrontEndApiModel($charity, $this->now), JSON_PRETTY_PRINT));
+
+        return 0;
+    }
+
+    private function makePreAuthedDonations(
+        RegularGivingMandate $mandate,
+        Campaign $campaign,
+        DonorAccount $donor,
+    ): void {
+        $paymentDay2ndDonation = $mandate->firstPaymentDayAfter($this->now);
+        $paymentDay3rdDonation = $mandate->firstPaymentDayAfter($paymentDay2ndDonation);
+
+        $this->preAuthorizeNewDonation($mandate, $campaign, $donor, $paymentDay2ndDonation);
+        $this->preAuthorizeNewDonation($mandate, $campaign, $donor, $paymentDay3rdDonation);
+    }
+
+
+    public function preAuthorizeNewDonation(
+        RegularGivingMandate $mandate,
+        Campaign $campaign,
+        DonorAccount $donor,
+        \DateTimeImmutable $paymentDay,
+    ): void {
+        $donation = Donation::fromApiModel(
+            new DonationCreate(
+                'GBP',
+                (string)($mandate->amount->amountInPence / 100),
+                $campaign->getSalesforceId() ?? throw new \Exception('missing campaign sf ID'),
+                'stripe',
+                PaymentMethodType::Card,
+                'GB',
+                false,
+                false,
+                false,
+                $donor->stripeCustomerId->stripeCustomerId,
+                '0',
+                $donor->donorName->first,
+                $donor->donorName->last,
+                $donor->emailAddress->email
+            ),
+            $campaign
+        );
+        $donation->update(
+            giftAid: $mandate->hasGiftAid(),
+            donorHomeAddressLine1: 'donor home address',
+            donorEmailAddress: $donor->emailAddress,
+            donorBillingPostcode: 'SW1 1AA'
+        );
+
+        $donation->preAuthorize($paymentDay);
+        $this->em->persist($donation);
+    }
+}

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -1450,6 +1450,16 @@ class Donation extends SalesforceWriteProxy
     }
 
     /**
+     * Authorises BG to collect this donation at the given date in the future.
+     */
+    public function preAuthorize(DateTimeImmutable $paymentDate): void
+    {
+        $this->assertIsReadyToConfirm();
+        $this->preAuthorizationDate = $paymentDate;
+        $this->donationStatus = DonationStatus::PreAuthorized;
+    }
+
+    /**
      * @return numeric-string|null The total the donor paid, either as recorded at the time or as we can calculate from
      * other info, in major currency units.
      *

--- a/src/Domain/DonorAccount.php
+++ b/src/Domain/DonorAccount.php
@@ -60,4 +60,9 @@ class DonorAccount extends Model
 
         return StripePaymentMethodId::of($this->regularGivingPaymentMethod);
     }
+
+    public function setRegularGivingPaymentMethod(StripePaymentMethodId $methodId): void
+    {
+        $this->regularGivingPaymentMethod = $methodId->stripePaymentMethodId;
+    }
 }

--- a/src/Domain/Money.php
+++ b/src/Domain/Money.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\Mapping as ORM;
  * @psalm-immutable
  */
 #[Embeddable]
-class Money implements \JsonSerializable, \Stringable
+readonly class Money implements \JsonSerializable, \Stringable
 {
     /**
      * @param int $amountInPence - Amount of money in minor units, i.e. pence, assumed to be worth 1/100 of the major
@@ -20,9 +20,9 @@ class Money implements \JsonSerializable, \Stringable
      */
     private function __construct(
         #[Column(type: 'integer')]
-        private readonly int $amountInPence,
+        public int $amountInPence,
         #[Column(type: 'string', enumType: Currency::class)]
-        private readonly Currency $currency
+        public Currency $currency
     ) {
         Assertion::between(
             $this->amountInPence,

--- a/src/Domain/RegularGivingMandate.php
+++ b/src/Domain/RegularGivingMandate.php
@@ -121,7 +121,9 @@ class RegularGivingMandate extends SalesforceWriteProxy
     public function firstPaymentDayAfter(\DateTimeImmutable $currentDateTime): \DateTimeImmutable
     {
         // We only operate in UK market so all timestamps should be for this TZ:
-        Assertion::same($currentDateTime->getTimezone()->getName(), 'Europe/London');
+        // Not sure why some timestamps generated in tests are having TZ names BST or GMT rather than London,
+        // but that's also OK.
+        Assertion::inArray($currentDateTime->getTimezone()->getName(), ['Europe/London', 'BST', 'GMT']);
 
         $nextPaymentDayIsNextMonth = $currentDateTime->format('d') >= $this->dayOfMonth->value;
 
@@ -133,5 +135,10 @@ class RegularGivingMandate extends SalesforceWriteProxy
             $todayOrNextMonth->format('Y-m-' . $this->dayOfMonth->value . 'T06:00:00'),
             $currentDateTime->getTimezone()
         );
+    }
+
+    public function hasGiftAid(): bool
+    {
+        return $this->giftAid;
     }
 }


### PR DESCRIPTION
Docblock from new command:

```php
/**
 * Use to create a regular giving agreement for test purposes. Usage example:
 *
 * To create a regular giving mandate for the emergency campaign, with gift aid enabled, for
 * a donor with the given identity server UUID, stripe customer ID and payment method ID, to donate £500 each month
 * on the 20th day of the month, starting this month if today is <19th otherwise starting next month run:
 *
 * ./matchbot matchbot:setup-test-mandate --campaign Emergency --gift-aid
 *      --donor-uuid 72f1e368-65f3-11ef-878f-fb0a039f0650 --donor-stripeid cus_xyxzaxasfdef
*       --donor-pmid pm_1xyzxzyxzyxzyxzyxzyxzyxz 500 20
 *
 * This doesn't create the intitial donation, but it does pre-authorise the 2nd and 3rd donations.
 */
 ```