### PR TITLE
MAT-376: WIP (but mergable) create new pending donations based on regular giving man…

### DIFF
--- a/integrationTests/DonationPersistenceTest.php
+++ b/integrationTests/DonationPersistenceTest.php
@@ -87,7 +87,6 @@ class DonationPersistenceTest extends IntegrationTest
             'charityFeeVat' => '0.00',
             'originalPspFee' => '0.00',
             'currencyCode' => 'GBP',
-            'feeCoverAmount' => '0.00',
             'collectedAt' => null,
             'refundedAt' => '2023-06-22 10:00:00',
             'tbgShouldProcessGiftAid' => null,
@@ -101,6 +100,8 @@ class DonationPersistenceTest extends IntegrationTest
             'paymentMethodType' => 'card',
             'totalPaidByDonor' => null,
             'preAuthorizationDate' => null,
+            'mandate_id' => null,
+            'mandateSequenceNumber' => null,
 
             'updatedAt' => '1970-01-01',
             'createdAt' => '1970-01-01'

--- a/src/Application/Commands/TakeRegularGivingDonations.php
+++ b/src/Application/Commands/TakeRegularGivingDonations.php
@@ -12,6 +12,9 @@ use MatchBot\Domain\CampaignFundingRepository;
 use MatchBot\Domain\DonationRepository;
 use MatchBot\Domain\DonationService;
 use MatchBot\Domain\FundingWithdrawalRepository;
+use MatchBot\Domain\MandateService;
+use MatchBot\Domain\RegularGivingMandate;
+use MatchBot\Domain\RegularGivingMandateRepository;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -26,8 +29,10 @@ class TakeRegularGivingDonations extends LockingCommand
     /** @psalm-suppress PossiblyUnusedMethod - called by PHP-DI */
     public function __construct(
         private \DateTimeImmutable $now,
+        private RegularGivingMandateRepository $mandateRepository,
         private DonationRepository $donationRepository,
         private DonationService $donationService,
+        private MandateService $mandateService,
         private EntityManager $em,
     ) {
         parent::__construct();
@@ -42,8 +47,16 @@ class TakeRegularGivingDonations extends LockingCommand
 
     private function createNewDonationsAccordingToRegularGivingMandates(): void
     {
-        // todo - implement.
-        // Some details of how to actually create these donations are still to be worked out.
+        /* we want any mandates that are:
+            - Currently active
+            - have "donations created up to" null or in the past.
+        */
+        $mandates = $this->mandateRepository->findMandatesWithDonationsToCreateOn($this->now, limit: 20);
+
+        foreach ($mandates as [$mandate]) {
+            $this->makeDonationForMandate($mandate);
+            $this->em->flush();
+        }
     }
 
     private function confirmPreCreatedDonationsThatHaveReachedPaymentDate(OutputInterface $output): void
@@ -57,6 +70,7 @@ class TakeRegularGivingDonations extends LockingCommand
             - Send metadata to stripe so to identify the payment as regular giving when we view it there.
             - Handle exceptions and continue to next donation, e.g. if donation does not have customer ID, or there
               is no donor account in our db for that ID, or they do not have a payment method on file for this purpose.
+            - Ensure we don't send emails that are meant for confirmation of on-session donations
             - Probably other things.
         */
         $donations = $this->donationRepository->findPreAuthorizedDonationsReadyToConfirm($this->now, limit:20);
@@ -72,5 +86,22 @@ class TakeRegularGivingDonations extends LockingCommand
         }
 
         $this->em->flush();
+    }
+
+    private function makeDonationForMandate(RegularGivingMandate $mandate): void
+    {
+        $this->mandateService->makeNextDonationForMandate($mandate);
+        // todo - create donation and persist.
+        // Requires adding a couple of new properties to the donation class & schema
+        // - mandate ID & mandate sequence number. DB should ensure the combination is unique.
+        // May need to adjust the DQL used to fetch the mandates so we also fetch the maximum existing sequence number,
+        // or the last donation of each mandate so we know which one we're creating.
+
+        // Also have to think about what to do if we need to create more than one. Shouldn't ever happen in prod as
+        // will run this script daily and only need to create donations monthly, but probably worth dealing with in case
+        // and for dev environments.
+
+        // may want to write this in a service class instead of directly here so that it's more testable and
+        // can potentially be invoked via HTTP for testing.
     }
 }

--- a/src/Application/Commands/TakeRegularGivingDonations.php
+++ b/src/Application/Commands/TakeRegularGivingDonations.php
@@ -47,10 +47,6 @@ class TakeRegularGivingDonations extends LockingCommand
 
     private function createNewDonationsAccordingToRegularGivingMandates(): void
     {
-        /* we want any mandates that are:
-            - Currently active
-            - have "donations created up to" null or in the past.
-        */
         $mandates = $this->mandateRepository->findMandatesWithDonationsToCreateOn($this->now, limit: 20);
 
         foreach ($mandates as [$mandate]) {
@@ -91,17 +87,8 @@ class TakeRegularGivingDonations extends LockingCommand
     private function makeDonationForMandate(RegularGivingMandate $mandate): void
     {
         $this->mandateService->makeNextDonationForMandate($mandate);
-        // todo - create donation and persist.
-        // Requires adding a couple of new properties to the donation class & schema
-        // - mandate ID & mandate sequence number. DB should ensure the combination is unique.
-        // May need to adjust the DQL used to fetch the mandates so we also fetch the maximum existing sequence number,
-        // or the last donation of each mandate so we know which one we're creating.
-
         // Also have to think about what to do if we need to create more than one. Shouldn't ever happen in prod as
         // will run this script daily and only need to create donations monthly, but probably worth dealing with in case
         // and for dev environments.
-
-        // may want to write this in a service class instead of directly here so that it's more testable and
-        // can potentially be invoked via HTTP for testing.
     }
 }

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -27,6 +27,7 @@ use function bccomp;
 use function sprintf;
 
 #[ORM\Table]
+#[ORM\UniqueConstraint(fields: ['mandateSequenceNumber', 'mandate'])]
 #[ORM\Index(name: 'campaign_and_status', columns: ['campaign_id', 'donationStatus'])]
 #[ORM\Index(name: 'date_and_status', columns: ['createdAt', 'donationStatus'])]
 #[ORM\Index(name: 'updated_date_and_status', columns: ['updatedAt', 'donationStatus'])]
@@ -204,6 +205,23 @@ class Donation extends SalesforceWriteProxy
 
     #[ORM\Column(type: 'string', nullable: true)]
     protected ?string $donorLastName = null;
+
+    /**
+     * Position in sequence of donations taken in relation to a regular giving mandate, e.g. 1st
+     * (taken at mandate creation time), 2nd, 3rd etc.
+     *
+     * Null only iff this is an ad-hoc, non regular-giving donation.
+     *
+     * @psalm-suppress PossiblyUnusedProperty - used in DQL
+     */
+    #[ORM\Column(type: 'integer', nullable: true)]
+    protected ?int $mandateSequenceNumber = null;
+
+    /**
+     * @psalm-suppress PossiblyUnusedProperty - used in DQL
+     */
+    #[ORM\ManyToOne(targetEntity: RegularGivingMandate::class)]
+    protected ?RegularGivingMandate $mandate = null;
 
     /**
      * Previously known as donor postal address,

--- a/src/Domain/DonationRepository.php
+++ b/src/Domain/DonationRepository.php
@@ -11,6 +11,7 @@ use DateTime;
 use Doctrine\Common\Cache\CacheProvider;
 use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\LockMode;
+use Doctrine\ORM\Query;
 use GuzzleHttp\Exception\ClientException;
 use MatchBot\Application\Assertion;
 use MatchBot\Application\HttpModels\DonationCreate;
@@ -825,5 +826,25 @@ class DonationRepository extends SalesforceWriteProxyRepository
         /** @var list<Donation> $result */
         $result = $query->getResult();
         return $result;
+    }
+
+    public function maxSequenceNumberForMandate(int $mandateId): ?DonationSequenceNumber
+    {
+        $query = $this->getEntityManager()->createQuery(<<<DQL
+            SELECT MAX(d.mandateSequenceNumber) from MatchBot\Domain\Donation d join d.mandate m
+            WHERE m.id = :mandate_id 
+        DQL
+        );
+
+        $query->setParameter('mandate_id', $mandateId);
+
+        $number = $query->getOneOrNullResult(Query::HYDRATE_SINGLE_SCALAR);
+        \assert(is_int($number) || is_null($number));
+
+        if ($number === null) {
+            return null;
+        }
+
+        return DonationSequenceNumber::of($number);
     }
 }

--- a/src/Domain/DonationSequenceNumber.php
+++ b/src/Domain/DonationSequenceNumber.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace MatchBot\Domain;
+
+use MatchBot\Application\Assertion;
+
+/**
+ * Used for a donation given as part of a regular giving mandate. May not be duplicated within one mandate, and
+ * indicates the date the donation should be taken, e.g. #1 indicates the donation taken at time of mandate creation,
+ * #2, will be taken one month (or possibly other regular period) later, #3 will be taken two months later etc.
+ *
+ * @psalm-suppress PossiblyUnusedProperty - to be used soon.
+ */
+readonly class DonationSequenceNumber
+{
+    private function __construct(
+        public int $number
+    ) {
+        // having a mandate last for 100 years is ambitious, putting some upper limit in mostly to because its better
+        // than no limit, and it could catch a bug.
+        Assertion::between($number, 1, 12 * 100);
+    }
+
+    public static function of(int $number): DonationSequenceNumber
+    {
+        return new self($number);
+    }
+}

--- a/src/Domain/DonationSequenceNumber.php
+++ b/src/Domain/DonationSequenceNumber.php
@@ -16,7 +16,7 @@ readonly class DonationSequenceNumber
     private function __construct(
         public int $number
     ) {
-        // having a mandate last for 100 years is ambitious, putting some upper limit in mostly to because its better
+        // having a mandate last for 100 years is ambitious, putting some upper limit in mostly because its better
         // than no limit, and it could catch a bug.
         Assertion::between($number, 1, 12 * 100);
     }

--- a/src/Domain/DonationService.php
+++ b/src/Domain/DonationService.php
@@ -25,6 +25,7 @@ use Random\Randomizer;
 use Slim\Exception\HttpBadRequestException;
 use Stripe\Card;
 use Stripe\Exception\ApiErrorException;
+use Stripe\Mandate;
 use Symfony\Component\Clock\ClockInterface;
 use Symfony\Component\Notifier\ChatterInterface;
 use Symfony\Component\Notifier\Exception\TransportExceptionInterface;

--- a/src/Domain/DonationService.php
+++ b/src/Domain/DonationService.php
@@ -25,7 +25,6 @@ use Random\Randomizer;
 use Slim\Exception\HttpBadRequestException;
 use Stripe\Card;
 use Stripe\Exception\ApiErrorException;
-use Stripe\Mandate;
 use Symfony\Component\Clock\ClockInterface;
 use Symfony\Component\Notifier\ChatterInterface;
 use Symfony\Component\Notifier\Exception\TransportExceptionInterface;

--- a/src/Domain/MandateService.php
+++ b/src/Domain/MandateService.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace MatchBot\Domain;
+
+use MatchBot\Application\Assertion;
+use Stripe\Mandate;
+
+readonly class MandateService
+{
+    /** @psalm-suppress PossiblyUnusedMethod - will be used by DI */
+    public function __construct(
+        private DonationRepository $donationRepository,
+    ) {
+    }
+    public function makeNextDonationForMandate(RegularGivingMandate $mandate): void
+    {
+        $mandateId = $mandate->getId();
+        Assertion::notNull($mandateId);
+
+        $lastSequenceNumber = $this->donationRepository->maxSequenceNumberForMandate($mandateId);
+
+        throw new \Exception(
+            "Implementation incomplete, found max sequence number is {$lastSequenceNumber?->number}"
+        );
+
+        // ask the mandate to calculate the approprate payment day for the next donation...
+    }
+}

--- a/src/Domain/RegularGivingMandate.php
+++ b/src/Domain/RegularGivingMandate.php
@@ -15,6 +15,7 @@ use UnexpectedValueException;
  */
 #[ORM\Table]
 #[ORM\Index(name: 'uuid', columns: ['uuid'])]
+#[ORM\Index(name: 'donationsCreatedUpTo', columns: ['donationsCreatedUpTo'])]
 #[ORM\Entity(
     repositoryClass: null // we construct our own repository
 )]
@@ -48,6 +49,9 @@ class RegularGivingMandate extends SalesforceWriteProxy
 
     #[ORM\Column(type: 'datetime_immutable', nullable: true)]
     private ?\DateTimeImmutable $activeFrom = null;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    private ?\DateTimeImmutable $donationsCreatedUpTo = null;
 
     #[ORM\Column(type: 'string', enumType: MandateStatus::class)]
     private MandateStatus $status = MandateStatus::Pending;
@@ -140,5 +144,18 @@ class RegularGivingMandate extends SalesforceWriteProxy
     public function hasGiftAid(): bool
     {
         return $this->giftAid;
+    }
+
+    /**
+     * Records that all donations we plan to take for this donation before the given time have been created
+     * and saved as pre-authorized donations. This means that no more donations need to be created based on this
+     * mandate before that date.
+     *
+     * @psalm-suppress PossiblyUnusedMethod - to be used soon.
+     */
+    public function setDonationsCreatedUpTo(?\DateTimeImmutable $donationsCreatedUpTo): void
+    {
+        Assertion::same($this->status, MandateStatus::Active);
+        $this->donationsCreatedUpTo = $donationsCreatedUpTo;
     }
 }

--- a/src/Domain/RegularGivingMandateRepository.php
+++ b/src/Domain/RegularGivingMandateRepository.php
@@ -50,6 +50,35 @@ class RegularGivingMandateRepository
 
         $query->setParameter('donorId', $donor->id);
 
+        return $this->getMandatesWithCharities($query);
+    }
+
+    /**
+     * @return list<array{0: RegularGivingMandate, 1: Charity}>
+     */
+    public function findMandatesWithDonationsToCreateOn(\DateTimeImmutable $now, int $limit): array
+    {
+        $active = MandateStatus::Active->value;
+        $query = $this->em->createQuery(<<<"DQL"
+            SELECT r, c FROM MatchBot\Domain\RegularGivingMandate r 
+            LEFT JOIN MatchBot\Domain\Charity c WITH r.charityId = c.salesforceId
+            WHERE r.status = '{$active}'
+            AND (r.donationsCreatedUpTo IS NULL OR r.donationsCreatedUpTo <= :now)
+        DQL
+        );
+
+        $query->setParameter('now', $now);
+        $query->setMaxResults($limit);
+
+        return $this->getMandatesWithCharities($query);
+    }
+
+    /**
+     * @param \Doctrine\ORM\Query $query . Query must be for mandates and charities jonied together.
+     * @return list<array{0: RegularGivingMandate, 1: Charity}>
+     */
+    private function getMandatesWithCharities(\Doctrine\ORM\Query $query)
+    {
         /** @var list<RegularGivingMandate|Charity> $x */
         $x = $query->getResult();
 

--- a/src/Migrations/Version20240830164310.php
+++ b/src/Migrations/Version20240830164310.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240830164310 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add columns and indexes for regular giving, delete unused columns';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE Donation ADD mandate_id INT UNSIGNED DEFAULT NULL, ADD mandateSequenceNumber INT DEFAULT NULL, DROP feeCoverAmount');
+        $this->addSql('ALTER TABLE Donation ADD CONSTRAINT FK_C893E3F66C1129CD FOREIGN KEY (mandate_id) REFERENCES RegularGivingMandate (id)');
+        $this->addSql('CREATE INDEX IDX_C893E3F66C1129CD ON Donation (mandate_id)');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_C893E3F621F7BD156C1129CD ON Donation (mandateSequenceNumber, mandate_id)');
+        $this->addSql('ALTER TABLE RegularGivingMandate ADD donationsCreatedUpTo DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\'');
+        $this->addSql('CREATE INDEX donationsCreatedUpTo ON RegularGivingMandate (donationsCreatedUpTo)');
+
+        $this->addSql('ALTER TABLE Campaign DROP feePercentage');
+        $this->addSql('ALTER TABLE Charity DROP updateFromSFRequiredSince');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE Campaign ADD feePercentage NUMERIC(3, 1) DEFAULT NULL');
+        $this->addSql('ALTER TABLE Charity ADD updateFromSFRequiredSince DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\'');
+        $this->addSql('ALTER TABLE Donation DROP FOREIGN KEY FK_C893E3F66C1129CD');
+        $this->addSql('DROP INDEX IDX_C893E3F66C1129CD ON Donation');
+        $this->addSql('DROP INDEX UNIQ_C893E3F621F7BD156C1129CD ON Donation');
+        $this->addSql('ALTER TABLE Donation ADD feeCoverAmount NUMERIC(18, 2) DEFAULT \'0.00\' NOT NULL, DROP mandate_id, DROP mandateSequenceNumber');
+        $this->addSql('DROP INDEX donationsCreatedUpTo ON RegularGivingMandate');
+        $this->addSql('ALTER TABLE RegularGivingMandate DROP donationsCreatedUpTo');
+    }
+}


### PR DESCRIPTION
Sets up various prerequisites for creating new donations based on regular giving mandates. Adds some new incomplete functions for creating those donations to be continued in a later PR.

Would have been neater to either know the prerequisites in advance and do just them, or do the overall functions first with the prerequisite stuff stubbed out, this is a slightly awkward mix of outside-in and inside-out working, but should be OK.

Would also be nice to have more tests but the work so far was so CRUD-based it's hard to see where to put tests. Next thing may be the logic for converting a sequence number to a date, which will definitely be unit tested, and for creating a donation object with that will will also be unit tested.
