### PR TITLE
BG2-2722 – Cache bust as needed for SF change messages

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -54,7 +54,7 @@ a donation funds user transfers cash into their account.
 To start the app and its dependencies (`db` and `redis`) locally:
 
 ```shell
-    docker-compose up -d app
+    docker compose up -d app
 ```
 
 
@@ -63,8 +63,8 @@ To start the app and its dependencies (`db` and `redis`) locally:
 To get PHP dependencies and an initial data in structure in place, you'll need to run these once:
 
 ```shell
-    docker-compose exec app composer install
-    docker-compose exec app composer doctrine:delete-and-recreate
+    docker compose exec app composer install
+    docker compose exec app composer doctrine:delete-and-recreate
 ```
 
 If dependencies change you may occasionally need to re-run the `composer install`.
@@ -76,7 +76,7 @@ you will need to flush Redis data to start afresh. You can remove and re-create 
 Docker container, or just flush the data store:
 
 ```shell
-    docker-compose exec redis redis-cli FLUSHALL
+    docker compose exec redis redis-cli FLUSHALL
 ```
 
 ## Run unit tests
@@ -84,8 +84,8 @@ Docker container, or just flush the data store:
 Once you have the app running, you can test with: 
 
 ```shell
-    docker-compose exec app composer run test
-    docker-compose exec app composer run integration-test
+    docker compose exec app composer run test
+    docker compose exec app composer run integration-test
 ```
 
 When run with a coverage driver (e.g. Xdebug enabled by using `thebiggive/php:dev-8.1`),
@@ -94,7 +94,7 @@ this will save coverage data to `./coverage.xml` and `./coverage-integration.xml
 Linting is run with
 
 ```shell
-    docker-compose exec app composer run lint:check
+    docker compose exec app composer run lint:check
 ```
 
 To understand how these commands are run in CI, see [the CircleCI config file](./.circleci/config.yml).
@@ -149,7 +149,7 @@ The headline for each script's purpose is defined in its description in the PHP 
 run
 
 ```shell
-    docker-compose exec app composer matchbot:list-commands
+    docker compose exec app composer matchbot:list-commands
 ```
 
 for an overview of how all [`Commands`](./src/Application/Commands) in the app describe themselves.
@@ -159,7 +159,7 @@ for an overview of how all [`Commands`](./src/Application/Commands) in the app d
 To run a script in an already-running Docker `app` container, use:
 
 ```shell
-    docker-compose exec app composer {name:of:script:from:composer.json}
+    docker compose exec app composer {name:of:script:from:composer.json}
 ```
 
 ### How tasks run on staging & production

--- a/integrationTests/PullCharityUpdatedBasedOnSfHookTest.php
+++ b/integrationTests/PullCharityUpdatedBasedOnSfHookTest.php
@@ -37,7 +37,7 @@ class PullCharityUpdatedBasedOnSfHookTest extends IntegrationTest
 
         $campaignClientProphecy = $this->prophesize(Client\Campaign::class);
 
-        $campaignClientProphecy->getById($campaign->getSalesforceId())->willReturn(
+        $campaignClientProphecy->getById($campaign->getSalesforceId(), withCache: false)->willReturn(
             $this->simulatedCampaignFromSFAPI(
                 $sfId,
                 'New Charity Name',

--- a/src/Application/Messenger/Handler/CharityUpdatedHandler.php
+++ b/src/Application/Messenger/Handler/CharityUpdatedHandler.php
@@ -42,7 +42,9 @@ class CharityUpdatedHandler
         foreach ($campaignsToUpdate as $campaign) {
             // also implicitly updates the charity every time.
             try {
-                $campaignRepository->updateFromSf($campaign);
+                // We need to ensure SF tells CloudFront not to cache this particular response, or to bundle
+                // it with public API calls for the same endpoint that may have been recently cached.
+                $campaignRepository->updateFromSf($campaign, withCache: false);
                 $atLeastOneCampaignUpdated = true;
             } catch (NotFoundException $e) {
                 if ($this->environment === Environment::Production) {

--- a/src/Client/Campaign.php
+++ b/src/Client/Campaign.php
@@ -14,10 +14,11 @@ class Campaign extends Common
      * @throws NotFoundException if Campaign with given ID not found
      * @throws CampaignNotReady if campaign found in SF but not ready for use in matchbot.
      */
-    public function getById(string $id): array
+    public function getById(string $id, bool $withCache): array
     {
+        $uri = $this->getUri("{$this->getSetting('campaign', 'baseUri')}/$id", $withCache);
         try {
-            $response = $this->getHttpClient()->get("{$this->getSetting('campaign', 'baseUri')}/$id");
+            $response = $this->getHttpClient()->get($uri);
         } catch (RequestException $exception) {
             if ($exception->getResponse() && $exception->getResponse()->getStatusCode() === 404) {
                 // may be safely caught in sandboxes

--- a/src/Client/Common.php
+++ b/src/Client/Common.php
@@ -34,4 +34,13 @@ abstract class Common
 
         return $this->httpClient;
     }
+
+    protected function getUri(string $uri, bool $withCache): string
+    {
+        if (!$withCache) {
+            $uri .= '?nocache=1';
+        }
+
+        return $uri;
+    }
 }

--- a/src/Client/Fund.php
+++ b/src/Client/Fund.php
@@ -11,9 +11,10 @@ class Fund extends Common
      * @return array Single Fund, as associative array
      * @throws NotFoundException if Fund with given ID not found
      */
-    public function getById(string $fundId): array
+    public function getById(string $fundId, bool $withCache = true): array
     {
-        $response = $this->getHttpClient()->get("{$this->getSetting('fund', 'baseUri')}/$fundId");
+        $uri = $this->getUri("{$this->getSetting('fund', 'baseUri')}/$fundId", $withCache);
+        $response = $this->getHttpClient()->get($uri);
 
         if ($response->getStatusCode() !== 200) {
             throw new NotFoundException('Fund not found');

--- a/src/Domain/CampaignRepository.php
+++ b/src/Domain/CampaignRepository.php
@@ -95,7 +95,7 @@ class CampaignRepository extends SalesforceReadProxyRepository
      * @throws \Exception if start or end dates' formats are invalid
      * @throws Client\CampaignNotReady
      */
-    protected function doUpdateFromSf(SalesforceReadProxy $proxy): void
+    protected function doUpdateFromSf(SalesforceReadProxy $proxy, bool $withCache): void
     {
         $campaign = $proxy;
 
@@ -105,7 +105,7 @@ class CampaignRepository extends SalesforceReadProxyRepository
             throw new \Exception("Cannot update campaign with missing salesforce ID");
         }
 
-        $campaignData = $client->getById($salesforceId);
+        $campaignData = $client->getById($salesforceId, $withCache);
 
         if ($campaign->hasBeenPersisted() && $campaign->getCurrencyCode() !== $campaignData['currencyCode']) {
             $this->logWarning(sprintf(

--- a/src/Domain/FundRepository.php
+++ b/src/Domain/FundRepository.php
@@ -180,14 +180,14 @@ class FundRepository extends SalesforceReadProxyRepository
      *
      * @param Fund $proxy
      */
-    protected function doUpdateFromSf(SalesforceReadProxy $proxy): void
+    protected function doUpdateFromSf(SalesforceReadProxy $proxy, bool $withCache): void
     {
         $fundId = $proxy->getSalesforceId();
         if ($fundId == null) {
             throw new \Exception("Missing ID on fund, cannot update from SF");
         }
 
-        $fundData = $this->getClient()->getById($fundId);
+        $fundData = $this->getClient()->getById($fundId, $withCache);
         $proxy->setName($fundData['name'] ?? '');
     }
 }

--- a/src/Domain/RegularGivingMandate.php
+++ b/src/Domain/RegularGivingMandate.php
@@ -2,8 +2,6 @@
 
 namespace MatchBot\Domain;
 
-use Brick\DateTime\LocalDate;
-use Brick\DateTime\LocalDateTime;
 use Doctrine\ORM\Mapping as ORM;
 use MatchBot\Application\Assertion;
 use Ramsey\Uuid\Uuid;

--- a/tests/Application/Messenger/Handler/CharityUpdatedHandlerTest.php
+++ b/tests/Application/Messenger/Handler/CharityUpdatedHandlerTest.php
@@ -37,7 +37,7 @@ class CharityUpdatedHandlerTest extends TestCase
         // Besides confirming the handler doesn't crash, this is the point of the test as it stands.
         // Given that the above repo helper had a campaign, we expect `updateFromSf()` which calls
         // out to the API to also be called.
-        $campaignRepositoryProphecy->updateFromSf($onlyRelevantCampaign)->shouldBeCalledOnce();
+        $campaignRepositoryProphecy->updateFromSf($onlyRelevantCampaign, withCache: false)->shouldBeCalledOnce();
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
         $entityManagerProphecy->flush()->shouldBeCalledOnce();

--- a/tests/Domain/FundRepositoryTest.php
+++ b/tests/Domain/FundRepositoryTest.php
@@ -15,9 +15,7 @@ use MatchBot\Domain\ChampionFund;
 use MatchBot\Domain\Fund;
 use MatchBot\Domain\FundRepository;
 use MatchBot\Tests\TestCase;
-use PHPUnit\Framework\MockObject\MockObject;
 use Prophecy\Argument;
-use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
@@ -28,7 +26,7 @@ class FundRepositoryTest extends TestCase
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
         $fundClientProphecy = $this->prophesize(Client\Fund::class);
         $fundClientProphecy
-            ->getById('sfFakeId987')
+            ->getById('sfFakeId987', withCache: true)
             ->shouldBeCalledOnce()
             ->willReturn([
                 'name' => 'API Fund Name',
@@ -46,7 +44,7 @@ class FundRepositoryTest extends TestCase
         // `FundRepository` such that `doPull()` is a real call but `pull()` doesn't try a real DB engine lookup.
         $fund->setSalesforceId('sfFakeId987');
 
-        $repo->updateFromSf($fund, false); // Don't auto-save as non-DB-backed tests can't persist
+        $repo->updateFromSf($fund, autoSave: false); // Don't auto-save as non-DB-backed tests can't persist
 
         $this->assertEquals('API Fund Name', $fund->getName());
     }


### PR DESCRIPTION
Ask single Campaign & Fund Salesforce API endpoints not to cache when we were just specifically told there is an update.