### PR TITLE
Mat 376 cont iii

### DIFF
--- a/integrationTests/ListRegularGivingMandatesTest.php
+++ b/integrationTests/ListRegularGivingMandatesTest.php
@@ -124,6 +124,6 @@ class ListRegularGivingMandatesTest extends IntegrationTest
         $em->persist($mandate);
         $em->flush();
 
-        return $mandate->uuid;
+        return $mandate->getUuid();
     }
 }

--- a/src/Application/Actions/Donations/Confirm.php
+++ b/src/Application/Actions/Donations/Confirm.php
@@ -155,7 +155,7 @@ EOF
 
 
         try {
-            $updatedIntent = $this->donationService->confirm($donation, StripePaymentMethodId::of($paymentMethodId));
+            $updatedIntent = $this->donationService->confirmOnSessionDonation($donation, StripePaymentMethodId::of($paymentMethodId));
         } catch (CardException $exception) {
             $this->entityManager->rollback();
 

--- a/src/Application/Actions/Donations/Confirm.php
+++ b/src/Application/Actions/Donations/Confirm.php
@@ -155,7 +155,10 @@ EOF
 
 
         try {
-            $updatedIntent = $this->donationService->confirmOnSessionDonation($donation, StripePaymentMethodId::of($paymentMethodId));
+            $updatedIntent = $this->donationService->confirmOnSessionDonation(
+                $donation,
+                StripePaymentMethodId::of($paymentMethodId)
+            );
         } catch (CardException $exception) {
             $this->entityManager->rollback();
 

--- a/src/Application/Commands/SetupTestMandate.php
+++ b/src/Application/Commands/SetupTestMandate.php
@@ -12,6 +12,7 @@ use MatchBot\Domain\CampaignRepository;
 use MatchBot\Domain\Charity;
 use MatchBot\Domain\DayOfMonth;
 use MatchBot\Domain\Donation;
+use MatchBot\Domain\DonationService;
 use MatchBot\Domain\DonorAccount;
 use MatchBot\Domain\DonorAccountRepository;
 use MatchBot\Domain\DonorName;
@@ -143,8 +144,11 @@ class SetupTestMandate extends LockingCommand
         $this->em->persist($mandate);
         $this->em->flush();
 
-        $io->writeln("Created new regular giving mandate:");
-        $io->writeln(json_encode($mandate->toFrontEndApiModel($charity, $this->now), JSON_PRETTY_PRINT));
+        $io->writeln(
+            "<fg=black;bg=green>" .
+            "Created new regular giving mandate: #{$mandate->getId()} for {$campaignName} by {$charity->getName()}" .
+            "</>"
+        );
 
         return 0;
     }

--- a/src/Application/Commands/SetupTestMandate.php
+++ b/src/Application/Commands/SetupTestMandate.php
@@ -93,9 +93,8 @@ class SetupTestMandate extends LockingCommand
         $amount = (int)($input->getArgument('amount') ?? '1');
         $campaignName = (string) $input->getOption('campaign');
 
-        (new Criteria())->where(Criteria::expr()->contains('name', $campaignName));
-
-        $campaign = $this->campaignRepository->matching(new Criteria())->first();
+        $criteria = (new Criteria())->where(Criteria::expr()->contains('name', $campaignName));
+        $campaign = $this->campaignRepository->matching($criteria)->first();
 
         if (!$campaign) {
             $io->error("No campaign found for {$campaignName}");

--- a/src/Application/Commands/SetupTestMandate.php
+++ b/src/Application/Commands/SetupTestMandate.php
@@ -175,7 +175,7 @@ class SetupTestMandate extends LockingCommand
         $donation = Donation::fromApiModel(
             new DonationCreate(
                 'GBP',
-                (string)($mandate->amount->amountInPence / 100),
+                (string)($mandate->getAmount()->amountInPence / 100),
                 $campaign->getSalesforceId() ?? throw new \Exception('missing campaign sf ID'),
                 'stripe',
                 PaymentMethodType::Card,

--- a/src/Application/Commands/TakeRegularGivingDonations.php
+++ b/src/Application/Commands/TakeRegularGivingDonations.php
@@ -101,7 +101,11 @@ class TakeRegularGivingDonations extends LockingCommand
         foreach ($donations as $donation) {
             $oldStatus = $donation->getDonationStatus();
             $output->writeln("processing donation $donation");
-            $this->donationService->confirmPreAuthorized($donation);
+            try {
+                $this->donationService->confirmPreAuthorized($donation);
+            } catch (\Exception $exception) {
+                $output->writeln('Exception, skipping donation: ' . $exception->getMessage());
+            }
             $output->writeln(
                 "Donation {$donation->getUuid()} went from " .
                 "{$oldStatus->name} to {$donation->getDonationStatus()->name}"

--- a/src/Application/Commands/TakeRegularGivingDonations.php
+++ b/src/Application/Commands/TakeRegularGivingDonations.php
@@ -69,7 +69,7 @@ class TakeRegularGivingDonations extends LockingCommand
         $this->applySimulatedDate($input->getOption('simulated-date'), $output);
 
         $this->createNewDonationsAccordingToRegularGivingMandates($io);
-        $this->confirmPreCreatedDonationsThatHaveReachedPaymentDate($output, $io);
+        $this->confirmPreCreatedDonationsThatHaveReachedPaymentDate($io);
 
         return 0;
     }
@@ -86,7 +86,7 @@ class TakeRegularGivingDonations extends LockingCommand
         }
     }
 
-    private function confirmPreCreatedDonationsThatHaveReachedPaymentDate(OutputInterface $output, SymfonyStyle $io): void
+    private function confirmPreCreatedDonationsThatHaveReachedPaymentDate(SymfonyStyle $io): void
     {
         /* Still to do to improve this before launch:
             - deal with possible "The parameter application_fee_amount cannot be updated on a PaymentIntent after a
@@ -111,7 +111,8 @@ class TakeRegularGivingDonations extends LockingCommand
             $io->writeln(
                 "Donation #{$donation->getId()} is pre-authorized to pay on" .
                 " <options=bold>{$preAuthDate->format('Y-m-d H:i:s')}</>}
-                ");
+                "
+            );
             $oldStatus = $donation->getDonationStatus();
             try {
                 $this->donationService->confirmPreAuthorized($donation);

--- a/src/Application/Commands/TakeRegularGivingDonations.php
+++ b/src/Application/Commands/TakeRegularGivingDonations.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand(
     name: 'matchbot:take-regular-giving-donations',
@@ -63,11 +64,12 @@ class TakeRegularGivingDonations extends LockingCommand
 
     protected function doExecute(InputInterface $input, OutputInterface $output): int
     {
+        $io = new SymfonyStyle($input, $output);
         /** @psalm-suppress MixedArgument */
         $this->applySimulatedDate($input->getOption('simulated-date'), $output);
 
         $this->createNewDonationsAccordingToRegularGivingMandates();
-        $this->confirmPreCreatedDonationsThatHaveReachedPaymentDate($output);
+        $this->confirmPreCreatedDonationsThatHaveReachedPaymentDate($output, $io);
 
         return 0;
     }
@@ -82,7 +84,7 @@ class TakeRegularGivingDonations extends LockingCommand
         }
     }
 
-    private function confirmPreCreatedDonationsThatHaveReachedPaymentDate(OutputInterface $output): void
+    private function confirmPreCreatedDonationsThatHaveReachedPaymentDate(OutputInterface $output, SymfonyStyle $io): void
     {
         /* Still to do to improve this before launch:
             - deal with possible "The parameter application_fee_amount cannot be updated on a PaymentIntent after a
@@ -99,16 +101,25 @@ class TakeRegularGivingDonations extends LockingCommand
         $donations = $this->donationRepository->findPreAuthorizedDonationsReadyToConfirm($this->now, limit:20);
 
         foreach ($donations as $donation) {
+            $preAuthDate = $donation->getPreAuthorizationDate();
+            \assert($preAuthDate instanceof \DateTimeImmutable);
+            $io->writeln("processing donation #{$donation->getId()}");
+            $io->writeln(
+                "Donation #{$donation->getId()} is pre-authorized to pay on" .
+                " <options=bold>{$preAuthDate->format('Y-m-d H:i:s')}</>}
+                ");
             $oldStatus = $donation->getDonationStatus();
-            $output->writeln("processing donation $donation");
             try {
                 $this->donationService->confirmPreAuthorized($donation);
             } catch (\Exception $exception) {
-                $output->writeln('Exception, skipping donation: ' . $exception->getMessage());
+                throw $exception;
+                $io->error('Exception, skipping donation: ' . $exception->getMessage());
+                continue;
             }
-            $output->writeln(
+            // status change not expected here - status will be changed by stripe callback to tell us its paid.
+            $io->writeln(
                 "Donation {$donation->getUuid()} went from " .
-                "{$oldStatus->name} to {$donation->getDonationStatus()->name}"
+                "<options=bold>{$oldStatus->name}</> to <options=bold>{$donation->getDonationStatus()->name}</>"
             );
         }
 

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -820,7 +820,7 @@ class Donation extends SalesforceWriteProxy
     public function getTransactionId(): string
     {
         if (!$this->transactionId) {
-            throw new \LogicException('Transaction ID not set');
+            throw new \LogicException('Transaction ID not set for donation ' . ($this->id ?? 'null'));
         }
 
         return $this->transactionId;

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -488,7 +488,8 @@ class Donation extends SalesforceWriteProxy
             // have a TypeError trying to get a string name from it.
             $charityName = "[pending charity threw " . get_class($t) . "]";
         }
-        return "Donation {$this->getUuid()} to $charityName";
+        $id = is_null($this->id) ? 'non-persisted' : "#{$this->id}";
+        return "Donation $id {$this->getUuid()} to $charityName";
     }
 
     /*

--- a/src/Domain/DonationService.php
+++ b/src/Domain/DonationService.php
@@ -186,8 +186,7 @@ class DonationService
     public function confirmOnSessionDonation(
         Donation $donation,
         StripePaymentMethodId $paymentMethodId
-    ): \Stripe\PaymentIntent
-    {
+    ): \Stripe\PaymentIntent {
         $this->updateDonationFees($paymentMethodId, $donation); // move this out to caller for non auto donation
         return $this->confirm($donation, $paymentMethodId);
     }

--- a/src/Domain/DonationService.php
+++ b/src/Domain/DonationService.php
@@ -32,7 +32,7 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\RateLimiter\Exception\RateLimitExceededException;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
 
-readonly class DonationService
+class DonationService
 {
     private const MAX_RETRY_COUNT = 3;
 
@@ -102,158 +102,7 @@ readonly class DonationService
             ));
         }
 
-        if (!$donation->getCampaign()->isOpen()) {
-            throw new CampaignNotOpen("Campaign {$donation->getCampaign()->getSalesforceId()} is not open");
-        }
-
-        // A closed EM can happen if the above tried to insert a campaign or fund, hit a duplicate error because
-        // another thread did it already, then successfully got the new copy. There's been no subsequent
-        // database persistence that needed an open manager, so none replaced the broken one. In that
-        // edge case, we need to handle that before `persistWithoutRetries()` has a chance of working.
-        if (!$this->entityManager->isOpen()) {
-            $this->entityManager->resetManager();
-        }
-
-        // Must persist before Stripe work to have ID available. Outer fn throws if all attempts fail.
-        $this->runWithPossibleRetry(function () use ($donation) {
-            $this->entityManager->persistWithoutRetries($donation);
-            $this->entityManager->flush();
-        }, 'Donation Create persist before stripe work');
-
-        if ($donation->getCampaign()->isMatched()) {
-            $this->runWithPossibleRetry(
-                function () use ($donation) {
-                    try {
-                        $this->donationRepository->allocateMatchFunds($donation);
-                    } catch (\Throwable $t) {
-                        // warning indicates that we *may* retry, as it depends on whether this is in the last retry or
-                        // not.
-                        $this->logger->warning(sprintf('Allocation got error, may retry: %s', $t->getMessage()));
-
-                        $this->matchingAdapter->releaseNewlyAllocatedFunds();
-
-                        // we have to also remove the FundingWithdrawls from MySQL - otherwise the redis amount
-                        // would be reduced again when the donation expires.
-                        $this->donationRepository->removeAllFundingWithdrawalsForDonation($donation);
-
-                        throw $t;
-                    }
-                },
-                'allocate match funds'
-            );
-        }
-
-        if ($donation->getPsp() === 'stripe') {
-            if (empty($donation->getCampaign()->getCharity()->getStripeAccountId())) {
-                // Try re-pulling in case charity has very recently onboarded with for Stripe.
-                $campaign = $donation->getCampaign();
-                $this->campaignRepository->updateFromSf($campaign);
-
-                // If still empty, error out
-                if (empty($campaign->getCharity()->getStripeAccountId())) {
-                    $this->logger->error(sprintf(
-                        'Stripe Payment Intent create error: Stripe Account ID not set for Account %s',
-                        $donation->getCampaign()->getCharity()->getSalesforceId() ?? 'missing charity sf ID',
-                    ));
-                    throw new StripeAccountIdNotSetForAccount(
-                    );
-                }
-
-                // Else we found new Stripe info and can proceed
-                $donation->setCampaign($campaign);
-            }
-
-            $createPayload = [
-                ...$donation->getStripeMethodProperties(),
-                ...$donation->getStripeOnBehalfOfProperties(),
-                'customer' => $pspCustomerId,
-                // Stripe Payment Intent `amount` is in the smallest currency unit, e.g. pence.
-                // See https://stripe.com/docs/api/payment_intents/object
-                'amount' => $donation->getAmountFractionalIncTip(),
-                'currency' => strtolower($donation->getCurrencyCode()),
-                'description' => $donation->getDescription(),
-                'capture_method' => 'automatic', // 'automatic' was default in previous API versions,
-                                                // default is now 'automatic_async'
-                'metadata' => [
-                    /**
-                     * Keys like comms opt ins are set only later. See the counterpart
-                     * in {@see Update::addData()} too.
-                     */
-                    'campaignId' => $donation->getCampaign()->getSalesforceId(),
-                    'campaignName' => $donation->getCampaign()->getCampaignName(),
-                    'charityId' => $donation->getCampaign()->getCharity()->getSalesforceId(),
-                    'charityName' => $donation->getCampaign()->getCharity()->getName(),
-                    'donationId' => $donation->getUuid(),
-                    'environment' => getenv('APP_ENV'),
-                    'matchedAmount' => $donation->getFundingWithdrawalTotal(),
-                    'stripeFeeRechargeGross' => $donation->getCharityFeeGross(),
-                    'stripeFeeRechargeNet' => $donation->getCharityFee(),
-                    'stripeFeeRechargeVat' => $donation->getCharityFeeVat(),
-                    'tipAmount' => $donation->getTipAmount(),
-                ],
-                'statement_descriptor' => $this->getStatementDescriptor($donation->getCampaign()->getCharity()),
-                // See https://stripe.com/docs/connect/destination-charges#application-fee
-                'application_fee_amount' => $donation->getAmountToDeductFractional(),
-                'transfer_data' => [
-                    'destination' => $donation->getCampaign()->getCharity()->getStripeAccountId(),
-                ],
-            ];
-
-            if ($donation->supportsSavingPaymentMethod()) {
-                $createPayload['setup_future_usage'] = 'on_session';
-            }
-
-            try {
-                $intent = $this->stripe->createPaymentIntent($createPayload);
-            } catch (ApiErrorException $exception) {
-                $message = $exception->getMessage();
-
-                $accountLacksCapabilities = str_contains(
-                    $message,
-                    // this message is an issue the charity needs to fix, we can't fix it for them.
-                    // We likely want to let the team know to hide the campaign from prominents views though.
-                    'Your destination account needs to have at least one of the following capabilities enabled'
-                );
-
-                $failureMessage = sprintf(
-                    'Stripe Payment Intent create error on %s, %s [%s]: %s. Charity: %s [%s].',
-                    $donation->getUuid(),
-                    $exception->getStripeCode() ?? 'unknown',
-                    get_class($exception),
-                    $message,
-                    $donation->getCampaign()->getCharity()->getName(),
-                    $donation->getCampaign()->getCharity()->getStripeAccountId() ?? 'unknown',
-                );
-
-                $level = $accountLacksCapabilities ? LogLevel::WARNING : LogLevel::ERROR;
-                $this->logger->log($level, $failureMessage);
-
-                if ($accountLacksCapabilities) {
-                    $env = getenv('APP_ENV');
-                    \assert(is_string($env));
-                    $failureMessageWithContext = sprintf(
-                        '[%s] %s',
-                        $env,
-                        $failureMessage,
-                    );
-                    $this->chatter->send(new ChatMessage($failureMessageWithContext));
-
-                    throw new CharityAccountLacksNeededCapaiblities();
-                }
-
-                throw new CouldNotMakeStripePaymentIntent();
-            }
-
-            $donation->setTransactionId($intent->id);
-
-            $this->runWithPossibleRetry(
-                function () use ($donation) {
-                    $this->entityManager->persistWithoutRetries($donation);
-                    $this->entityManager->flush();
-                },
-                'Donation Create persist after stripe work'
-            );
-        }
+        $this->enrollNewDonation($donation);
 
         return $donation;
     }
@@ -411,5 +260,176 @@ readonly class DonationService
         }
 
         $this->confirm($donation, $paymentMethod);
+    }
+
+    /**
+     * Does multiple things required when a new donation is added to the system including:
+     * - Checking that the campaign is open
+     * - Allocating match funds to the donation
+     * - Creating Stripe Payment intent
+     *
+     * @throws CampaignNotOpen
+     * @throws CampaignNotReady
+     * @throws CharityAccountLacksNeededCapaiblities
+     * @throws CouldNotMakeStripePaymentIntent
+     * @throws DBALServerException
+     * @throws ORMException
+     * @throws StripeAccountIdNotSetForAccount
+     * @throws TransportExceptionInterface
+     * @throws \MatchBot\Client\NotFoundException
+     */
+    public function enrollNewDonation(Donation $donation): void
+    {
+        if (!$donation->getCampaign()->isOpen()) {
+            throw new CampaignNotOpen("Campaign {$donation->getCampaign()->getSalesforceId()} is not open");
+        }
+
+        // A closed EM can happen if the above tried to insert a campaign or fund, hit a duplicate error because
+        // another thread did it already, then successfully got the new copy. There's been no subsequent
+        // database persistence that needed an open manager, so none replaced the broken one. In that
+        // edge case, we need to handle that before `persistWithoutRetries()` has a chance of working.
+        if (!$this->entityManager->isOpen()) {
+            $this->entityManager->resetManager();
+        }
+
+        // Must persist before Stripe work to have ID available. Outer fn throws if all attempts fail.
+        $this->runWithPossibleRetry(function () use ($donation) {
+            $this->entityManager->persistWithoutRetries($donation);
+            $this->entityManager->flush();
+        }, 'Donation Create persist before stripe work');
+
+        if ($donation->getCampaign()->isMatched()) {
+            $this->runWithPossibleRetry(
+                function () use ($donation) {
+                    try {
+                        $this->donationRepository->allocateMatchFunds($donation);
+                    } catch (\Throwable $t) {
+                        // warning indicates that we *may* retry, as it depends on whether this is in the last retry or
+                        // not.
+                        $this->logger->warning(sprintf('Allocation got error, may retry: %s', $t->getMessage()));
+
+                        $this->matchingAdapter->releaseNewlyAllocatedFunds();
+
+                        // we have to also remove the FundingWithdrawls from MySQL - otherwise the redis amount
+                        // would be reduced again when the donation expires.
+                        $this->donationRepository->removeAllFundingWithdrawalsForDonation($donation);
+
+                        throw $t;
+                    }
+                },
+                'allocate match funds'
+            );
+        }
+
+        if ($donation->getPsp() === 'stripe') {
+            if (empty($donation->getCampaign()->getCharity()->getStripeAccountId())) {
+                // Try re-pulling in case charity has very recently onboarded with for Stripe.
+                $campaign = $donation->getCampaign();
+                $this->campaignRepository->updateFromSf($campaign);
+
+                // If still empty, error out
+                if (empty($campaign->getCharity()->getStripeAccountId())) {
+                    $this->logger->error(sprintf(
+                        'Stripe Payment Intent create error: Stripe Account ID not set for Account %s',
+                        $donation->getCampaign()->getCharity()->getSalesforceId() ?? 'missing charity sf ID',
+                    ));
+                    throw new StripeAccountIdNotSetForAccount();
+                }
+
+                // Else we found new Stripe info and can proceed
+                $donation->setCampaign($campaign);
+            }
+
+            $createPayload = [
+                ...$donation->getStripeMethodProperties(),
+                ...$donation->getStripeOnBehalfOfProperties(),
+                'customer' => $donation->getPspCustomerId(),
+                // Stripe Payment Intent `amount` is in the smallest currency unit, e.g. pence.
+                // See https://stripe.com/docs/api/payment_intents/object
+                'amount' => $donation->getAmountFractionalIncTip(),
+                'currency' => strtolower($donation->getCurrencyCode()),
+                'description' => $donation->getDescription(),
+                'capture_method' => 'automatic', // 'automatic' was default in previous API versions,
+                // default is now 'automatic_async'
+                'metadata' => [
+                    /**
+                     * Keys like comms opt ins are set only later. See the counterpart
+                     * in {@see Update::addData()} too.
+                     */
+                    'campaignId' => $donation->getCampaign()->getSalesforceId(),
+                    'campaignName' => $donation->getCampaign()->getCampaignName(),
+                    'charityId' => $donation->getCampaign()->getCharity()->getSalesforceId(),
+                    'charityName' => $donation->getCampaign()->getCharity()->getName(),
+                    'donationId' => $donation->getUuid(),
+                    'environment' => getenv('APP_ENV'),
+                    'matchedAmount' => $donation->getFundingWithdrawalTotal(),
+                    'stripeFeeRechargeGross' => $donation->getCharityFeeGross(),
+                    'stripeFeeRechargeNet' => $donation->getCharityFee(),
+                    'stripeFeeRechargeVat' => $donation->getCharityFeeVat(),
+                    'tipAmount' => $donation->getTipAmount(),
+                ],
+                'statement_descriptor' => $this->getStatementDescriptor($donation->getCampaign()->getCharity()),
+                // See https://stripe.com/docs/connect/destination-charges#application-fee
+                'application_fee_amount' => $donation->getAmountToDeductFractional(),
+                'transfer_data' => [
+                    'destination' => $donation->getCampaign()->getCharity()->getStripeAccountId(),
+                ],
+            ];
+
+            if ($donation->supportsSavingPaymentMethod()) {
+                $createPayload['setup_future_usage'] = 'on_session';
+            }
+
+            try {
+                $intent = $this->stripe->createPaymentIntent($createPayload);
+            } catch (ApiErrorException $exception) {
+                $message = $exception->getMessage();
+
+                $accountLacksCapabilities = str_contains(
+                    $message,
+                    // this message is an issue the charity needs to fix, we can't fix it for them.
+                    // We likely want to let the team know to hide the campaign from prominents views though.
+                    'Your destination account needs to have at least one of the following capabilities enabled'
+                );
+
+                $failureMessage = sprintf(
+                    'Stripe Payment Intent create error on %s, %s [%s]: %s. Charity: %s [%s].',
+                    $donation->getUuid(),
+                    $exception->getStripeCode() ?? 'unknown',
+                    get_class($exception),
+                    $message,
+                    $donation->getCampaign()->getCharity()->getName(),
+                    $donation->getCampaign()->getCharity()->getStripeAccountId() ?? 'unknown',
+                );
+
+                $level = $accountLacksCapabilities ? LogLevel::WARNING : LogLevel::ERROR;
+                $this->logger->log($level, $failureMessage);
+
+                if ($accountLacksCapabilities) {
+                    $env = getenv('APP_ENV');
+                    \assert(is_string($env));
+                    $failureMessageWithContext = sprintf(
+                        '[%s] %s',
+                        $env,
+                        $failureMessage,
+                    );
+                    $this->chatter->send(new ChatMessage($failureMessageWithContext));
+
+                    throw new CharityAccountLacksNeededCapaiblities();
+                }
+
+                throw new CouldNotMakeStripePaymentIntent();
+            }
+
+            $donation->setTransactionId($intent->id);
+
+            $this->runWithPossibleRetry(
+                function () use ($donation) {
+                    $this->entityManager->persistWithoutRetries($donation);
+                    $this->entityManager->flush();
+                },
+                'Donation Create persist after stripe work'
+            );
+        }
     }
 }

--- a/src/Domain/DonationService.php
+++ b/src/Domain/DonationService.php
@@ -189,13 +189,13 @@ class DonationService
     ): \Stripe\PaymentIntent
     {
         $this->updateDonationFees($paymentMethodId, $donation); // move this out to caller for non auto donation
-        $this->confirm($donation, $paymentMethodId);
+        return $this->confirm($donation, $paymentMethodId);
     }
 
     /**
      * Finalized a donation, instructing stripe to attempt to take payment.
      */
-    public function confirm(
+    private function confirm(
         Donation $donation,
         StripePaymentMethodId $paymentMethodId
     ): \Stripe\PaymentIntent {

--- a/src/Domain/DonorAccount.php
+++ b/src/Domain/DonorAccount.php
@@ -86,9 +86,6 @@ class DonorAccount extends Model
         $this->uuid = is_null($uuid) ? null : Uuid::fromString($uuid->id);
     }
 
-    /**
-     * @psalm-suppress PossiblyUnusedMethod - to be used soon.
-     */
     public function getRegularGivingPaymentMethod(): ?StripePaymentMethodId
     {
         if ($this->regularGivingPaymentMethod === null) {

--- a/src/Domain/MandateService.php
+++ b/src/Domain/MandateService.php
@@ -17,8 +17,15 @@ readonly class MandateService
         private DonationService $donationService,
     ) {
     }
+
     public function makeNextDonationForMandate(RegularGivingMandate $mandate): Donation
     {
+        /*
+         * @todo: Refuse to create donation with preauth date in future. Other than for the 2nd and 3rd donations in
+         *        the mandate its unnecessary. Better to create them only when the date has been reached, so that we'll
+         *        be able to confirm immediatly, and have up to date info from the start on the donor's details, whether
+         *        or not they cancelled this mandate etc etc.
+         */
         $mandateId = $mandate->getId();
         Assertion::notNull($mandateId);
 
@@ -45,6 +52,7 @@ readonly class MandateService
         );
 
         $this->donationService->enrollNewDonation($donation);
+        $mandate->setDonationsCreatedUpTo($donation->getPreAuthorizationDate());
 
         return $donation;
     }

--- a/src/Domain/MandateService.php
+++ b/src/Domain/MandateService.php
@@ -14,6 +14,7 @@ readonly class MandateService
         private DonorAccountRepository $donorAccountRepository,
         private CampaignRepository $campaignRepository,
         private EntityManagerInterface $entityManager,
+        private DonationService $donationService,
     ) {
     }
     public function makeNextDonationForMandate(RegularGivingMandate $mandate): Donation
@@ -42,6 +43,8 @@ readonly class MandateService
             $donor,
             $campaign,
         );
+
+        $this->donationService->enrollNewDonation($donation);
 
         return $donation;
     }

--- a/src/Domain/RegularGivingMandate.php
+++ b/src/Domain/RegularGivingMandate.php
@@ -27,13 +27,13 @@ class RegularGivingMandate extends SalesforceWriteProxy
     private const int MAX_AMOUNT_PENCE = 500_00;
 
     #[ORM\Column(unique: true, type: 'uuid')]
-    public readonly UuidInterface $uuid;
+    private readonly UuidInterface $uuid;
 
     #[ORM\Embedded(columnPrefix: 'person')]
     public PersonId $donorId;
 
     #[ORM\Embedded(columnPrefix: '')]
-    public readonly Money $amount;
+    private readonly Money $amount;
 
     /**
      * @var string 18 digit salesforce ID of campaign
@@ -45,7 +45,7 @@ class RegularGivingMandate extends SalesforceWriteProxy
      * @var string 18 digit salesforce ID of charity
      */
     #[ORM\Column()]
-    public readonly string $charityId;
+    private readonly string $charityId;
 
     #[ORM\Column()]
     private readonly bool $giftAid;
@@ -225,5 +225,20 @@ class RegularGivingMandate extends SalesforceWriteProxy
     public function getCampaignId(): Salesforce18Id
     {
         return Salesforce18Id::ofCampaign($this->campaignId);
+    }
+
+    public function getUuid(): UuidInterface
+    {
+        return $this->uuid;
+    }
+
+    public function getAmount(): Money
+    {
+        return $this->amount;
+    }
+
+    public function getCharityId(): string
+    {
+        return $this->charityId;
     }
 }

--- a/src/Domain/RegularGivingMandateRepository.php
+++ b/src/Domain/RegularGivingMandateRepository.php
@@ -96,10 +96,10 @@ class RegularGivingMandateRepository
         }
 
         return array_values(array_map(function (RegularGivingMandate $mandate) use ($charities) {
-            $charityId = $mandate->charityId;
+            $charityId = $mandate->getCharityId();
             return [
                 $mandate,
-                $charities[$charityId] ?? throw new \Exception("Missing charity for mandate " . $mandate->uuid)
+                $charities[$charityId] ?? throw new \Exception("Missing charity for mandate " . $mandate->getUuid())
             ];
         },
             $mandates));

--- a/tests/Domain/MandateServiceTest.php
+++ b/tests/Domain/MandateServiceTest.php
@@ -7,6 +7,7 @@ use MatchBot\Domain\CampaignRepository;
 use MatchBot\Domain\DayOfMonth;
 use MatchBot\Domain\DonationRepository;
 use MatchBot\Domain\DonationSequenceNumber;
+use MatchBot\Domain\DonationService;
 use MatchBot\Domain\DonationStatus;
 use MatchBot\Domain\DonorAccount;
 use MatchBot\Domain\DonorAccountRepository;
@@ -46,6 +47,7 @@ class MandateServiceTest extends TestCase
             $this->donorAccountRepositoryProphecy->reveal(),
             $this->campaignRepositoryProphecy->reveal(),
             $this->createStub(EntityManagerInterface::class),
+            $this->createStub(DonationService::class),
         );
     }
     public function testMakingNextDonationForMandate(): void

--- a/tests/Domain/RegularGivingMandateTest.php
+++ b/tests/Domain/RegularGivingMandateTest.php
@@ -146,7 +146,7 @@ class RegularGivingMandateTest extends TestCase
             giftAid: true,
         );
 
-        $uuid = $mandate->uuid->toString();
+        $uuid = $mandate->getUuid()->toString();
 
         $now = new \DateTimeImmutable('2024-08-12', new \DateTimeZone('Europe/London'));
 


### PR DESCRIPTION
Fixing issues to allow automatic repeat payment donations to be collected:

- Setting up stripe payment intent & reserving funds when creating donation
- Replacing public readonly properties on mandate with private readonly properties. Public readonly led to crashes due to https://github.com/doctrine/orm/issues/9432 . 
- DonationService no longer readonly to allow doubling it in tests.