### PR TITLE
Fix missing migration issue on staging

### DIFF
--- a/src/Migrations/Version20240304105340.php
+++ b/src/Migrations/Version20240304105340.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240304105340 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'no-op migration';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // no-op
+        // Previous implementation deleted but skeleton of class restored as Doctrine Migrations doesn't
+        // like a migration being missing from files when its knows from the DB (in staging) that it was executed
+        // previously.
+    }
+
+    public function down(Schema $schema): void
+    {
+        // no-op
+    }
+}


### PR DESCRIPTION
See 934f886fa177c7f9 . Turns out I shouldn't have deleted the whole file, I should have just deleted or commented out the content of the migration. Doctrine Migrations tool doesn't like seeing migration files deleted.