### PR TITLE
DON-896: Create stripe customer session with donation

### DIFF
--- a/.psalm/psalm-baseline.xml
+++ b/.psalm/psalm-baseline.xml
@@ -253,7 +253,6 @@
     <ArgumentTypeCoercion>
       <code><![CDATA[$amount]]></code>
       <code><![CDATA[$feeAmountFromPercentageComponent]]></code>
-      <code><![CDATA[$grossFeeAmount]]></code>
       <code><![CDATA[$this->amount]]></code>
       <code><![CDATA[$this->amount]]></code>
       <code><![CDATA[$this->amount]]></code>
@@ -262,9 +261,6 @@
       <code><![CDATA[$this->getFeeVatPercentage()]]></code>
       <code><![CDATA[$this->getFeeVatPercentage()]]></code>
     </ArgumentTypeCoercion>
-    <RiskyTruthyFalsyComparison>
-      <code><![CDATA[$this->feePercentageOverride]]></code>
-    </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/Application/Handlers/HttpErrorHandler.php">
     <PropertyNotSetInConstructor>
@@ -273,12 +269,6 @@
       <code><![CDATA[HttpErrorHandler]]></code>
       <code><![CDATA[HttpErrorHandler]]></code>
     </PropertyNotSetInConstructor>
-  </file>
-  <file src="src/Application/HttpModels/DonationCreatedResponse.php">
-    <MissingConstructor>
-      <code><![CDATA[$donation]]></code>
-      <code><![CDATA[$jwt]]></code>
-    </MissingConstructor>
   </file>
   <file src="src/Application/Matching/Adapter.php">
     <ArgumentTypeCoercion>
@@ -303,9 +293,6 @@
     </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/Application/Messenger/Handler/StripePayoutHandler.php">
-    <DeprecatedInterface>
-      <code><![CDATA[StripePayoutHandler]]></code>
-    </DeprecatedInterface>
     <DocblockTypeContradiction>
       <code><![CDATA[is_string($source_transfer)]]></code>
     </DocblockTypeContradiction>
@@ -329,18 +316,6 @@
     </MoreSpecificReturnType>
   </file>
   <file src="src/Client/Campaign.php">
-    <MixedArrayAccess>
-      <code><![CDATA[$campaignResponse['ready']]]></code>
-    </MixedArrayAccess>
-    <MixedAssignment>
-      <code><![CDATA[$campaignResponse]]></code>
-    </MixedAssignment>
-    <MixedInferredReturnType>
-      <code><![CDATA[array]]></code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement>
-      <code><![CDATA[$campaignResponse]]></code>
-    </MixedReturnStatement>
     <PossiblyNullReference>
       <code><![CDATA[getStatusCode]]></code>
     </PossiblyNullReference>
@@ -464,7 +439,6 @@
       <code><![CDATA[$this->getCharityFee()]]></code>
       <code><![CDATA[$this->getCharityFeeGross()]]></code>
       <code><![CDATA[$this->getCharityFeeVat()]]></code>
-      <code><![CDATA[$this->getFeeCoverAmount()]]></code>
       <code><![CDATA[$this->getTipAmount()]]></code>
       <code><![CDATA[$this->getTipAmount()]]></code>
     </ArgumentTypeCoercion>
@@ -473,14 +447,12 @@
     </PossiblyNullPropertyAssignmentValue>
     <PropertyNotSetInConstructor>
       <code><![CDATA[$campaign]]></code>
-      <code><![CDATA[$psp]]></code>
       <code><![CDATA[Donation]]></code>
       <code><![CDATA[Donation]]></code>
     </PropertyNotSetInConstructor>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[!$this->transactionId]]></code>
       <code><![CDATA[$cardBrand]]></code>
-      <code><![CDATA[empty($donationData->countryCode)]]></code>
       <code><![CDATA[empty($donationMessage->house_no)]]></code>
       <code><![CDATA[empty($this->getDonorFirstName())]]></code>
       <code><![CDATA[empty($this->getDonorLastName())]]></code>
@@ -587,9 +559,6 @@
       <code><![CDATA[$proxy->getSalesforceId()]]></code>
       <code><![CDATA[$proxy->getSalesforceId()]]></code>
     </PossiblyNullOperand>
-    <RiskyTruthyFalsyComparison>
-      <code><![CDATA[!$proxy->getSalesforceId()]]></code>
-    </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/Domain/TimestampsTrait.php">
     <MissingConstructor>

--- a/src/Application/HttpModels/DonationCreatedResponse.php
+++ b/src/Application/HttpModels/DonationCreatedResponse.php
@@ -8,8 +8,15 @@ namespace MatchBot\Application\HttpModels;
  * Donation created plus auth JWS model, for responses after a donation is created.
  * @psalm-suppress PossiblyUnusedProperty - used in frontend.
  */
-class DonationCreatedResponse
+readonly class DonationCreatedResponse
 {
-    public array $donation;
-    public string $jwt;
+    public function __construct(
+        public array $donation,
+        public string $jwt,
+        /**
+         * @see https://docs.stripe.com/api/customer_sessions/object#customer_session_object-client_secret
+         */
+        public string $stripeSessionSecret,
+    ) {
+    }
 }

--- a/src/Client/LiveStripeClient.php
+++ b/src/Client/LiveStripeClient.php
@@ -3,7 +3,9 @@
 namespace MatchBot\Client;
 
 use MatchBot\Domain\Donation;
+use MatchBot\Domain\StripeCustomerId;
 use MatchBot\Domain\StripePaymentMethodId;
+use Stripe\CustomerSession;
 use Stripe\Exception\InvalidArgumentException;
 use Stripe\PaymentIntent;
 use Stripe\PaymentMethod;
@@ -48,7 +50,10 @@ class LiveStripeClient implements Stripe
     {
         // "A PaymentMethod must be attached a customer to be updated." In tests so far, Stripe seems to permit
         // repeated attachments to the same customer.
-        $this->stripeClient->paymentMethods->attach($paymentMethodId, ['customer' => $donation->getPspCustomerId()]);
+        $this->stripeClient->paymentMethods->attach(
+            $paymentMethodId,
+            ['customer' => $donation->getPspCustomerId()?->stripeCustomerId]
+        );
 
         // Address etc. is set up in Stripe.js already. Adding these values which we collect on the
         // donation separately helps with support queries and maybe with fraud signals.
@@ -66,5 +71,27 @@ class LiveStripeClient implements Stripe
     public function retrievePaymentMethod(StripePaymentMethodId $pmId): PaymentMethod
     {
         return $this->stripeClient->paymentMethods->retrieve($pmId->stripePaymentMethodId);
+    }
+
+    public function createCustomerSession(StripeCustomerId $stripeCustomerId): CustomerSession
+    {
+        return $this->stripeClient->customerSessions->create([
+            'customer' => $stripeCustomerId->stripeCustomerId,
+            'components' => [
+                'payment_element' => [
+                    'enabled' => true,
+                    'features' => [
+                        'payment_method_allow_redisplay_filters' => ['always', 'limited', 'unspecified'],
+                        'payment_method_redisplay' => 'enabled',
+                        'payment_method_redisplay_limit' => 10, // default 3, 10 is max stripe allows.
+                        'payment_method_remove' => 'disabled', // default value
+                        'payment_method_save' => 'enabled',
+
+                        // off-session (regular) payment methods will have be saved separately:
+                        'payment_method_save_usage' => 'on_session',
+                    ],
+                ]
+            ],
+        ]);
     }
 }

--- a/src/Client/Stripe.php
+++ b/src/Client/Stripe.php
@@ -3,7 +3,9 @@
 namespace MatchBot\Client;
 
 use MatchBot\Domain\Donation;
+use MatchBot\Domain\StripeCustomerId;
 use MatchBot\Domain\StripePaymentMethodId;
+use Stripe\CustomerSession;
 use Stripe\Exception\ApiErrorException;
 use Stripe\Exception\InvalidRequestException;
 use Stripe\PaymentIntent;
@@ -52,4 +54,6 @@ interface Stripe
     public function updatePaymentMethodBillingDetail(string $paymentMethodId, Donation $donation): void;
 
     public function retrievePaymentMethod(StripePaymentMethodId $pmId): PaymentMethod;
+
+    public function createCustomerSession(StripeCustomerId $stripeCustomerId): CustomerSession;
 }

--- a/src/Client/StubStripeClient.php
+++ b/src/Client/StubStripeClient.php
@@ -3,8 +3,10 @@
 namespace MatchBot\Client;
 
 use MatchBot\Domain\Donation;
+use MatchBot\Domain\StripeCustomerId;
 use MatchBot\Domain\StripePaymentMethodId;
 use Ramsey\Uuid\Uuid;
+use Stripe\CustomerSession;
 use Stripe\PaymentIntent;
 use Stripe\PaymentMethod;
 
@@ -77,5 +79,10 @@ class StubStripeClient implements Stripe
         $paymentMethod->card = (object)['brand' => 'visa', 'country' => 'GB'];
 
         return $paymentMethod;
+    }
+
+    public function createCustomerSession(StripeCustomerId $stripeCustomerId): CustomerSession
+    {
+        return new CustomerSession();
     }
 }

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -564,7 +564,7 @@ class Donation extends SalesforceWriteProxy
             'optInTbgEmail' => $this->getTbgComms(),
             'projectId' => $this->getCampaign()->getSalesforceId(),
             'psp' => $this->getPsp(),
-            'pspCustomerId' => $this->getPspCustomerId(),
+            'pspCustomerId' => $this->getPspCustomerId()?->stripeCustomerId,
             'pspMethodType' => $this->getPaymentMethodType()?->value,
             'refundedTime' => $this->refundedAt?->format(DateTimeInterface::ATOM),
             'status' => $this->getDonationStatus(),
@@ -1133,9 +1133,17 @@ class Donation extends SalesforceWriteProxy
         $this->tbgGiftAidResponseDetail = $tbgGiftAidResponseDetail;
     }
 
-    public function getPspCustomerId(): ?string
+    public function getPspCustomerId(): ?StripeCustomerId
     {
-        return $this->pspCustomerId;
+        if ($this->pspCustomerId === null) {
+            return null;
+        };
+
+        if ($this->psp !== 'stripe') {
+            throw new \RuntimeException('Unexpected PSP');
+        }
+
+        return StripeCustomerId::of($this->pspCustomerId);
     }
 
     public function setPspCustomerId(?string $pspCustomerId): void

--- a/tests/Domain/DonationServiceTest.php
+++ b/tests/Domain/DonationServiceTest.php
@@ -28,7 +28,7 @@ use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
 
 class DonationServiceTest extends TestCase
 {
-    private const CUSTOMER_ID = 'CUSTOMER_ID';
+    private const CUSTOMER_ID = 'cus_CUSTOMERID';
     private DonationService $sut;
 
     /** @var \Prophecy\Prophecy\ObjectProphecy<Stripe> */


### PR DESCRIPTION
Passing the customer session client secret to frontend will allow the donor to view their saved cards and select one for use.