### PR TITLE
DON-896: Add support for confirming donation by confirmation token ID…

### DIFF
--- a/src/Client/LiveStripeClient.php
+++ b/src/Client/LiveStripeClient.php
@@ -3,8 +3,10 @@
 namespace MatchBot\Client;
 
 use MatchBot\Domain\Donation;
+use MatchBot\Domain\StripeConformationTokenId;
 use MatchBot\Domain\StripeCustomerId;
 use MatchBot\Domain\StripePaymentMethodId;
+use Stripe\ConfirmationToken;
 use Stripe\CustomerSession;
 use Stripe\Exception\InvalidArgumentException;
 use Stripe\PaymentIntent;
@@ -39,6 +41,11 @@ class LiveStripeClient implements Stripe
     public function retrievePaymentIntent(string $paymentIntentId): PaymentIntent
     {
         return $this->stripeClient->paymentIntents->retrieve($paymentIntentId);
+    }
+
+    public function retrieveConfirmationToken(StripeConformationTokenId $confirmationTokenId): ConfirmationToken
+    {
+        return $this->stripeClient->confirmationTokens->retrieve($confirmationTokenId->stripeConfirmationTokenId);
     }
 
     public function createPaymentIntent(array $createPayload): PaymentIntent

--- a/src/Client/Stripe.php
+++ b/src/Client/Stripe.php
@@ -3,8 +3,10 @@
 namespace MatchBot\Client;
 
 use MatchBot\Domain\Donation;
+use MatchBot\Domain\StripeConformationTokenId;
 use MatchBot\Domain\StripeCustomerId;
 use MatchBot\Domain\StripePaymentMethodId;
+use Stripe\ConfirmationToken;
 use Stripe\CustomerSession;
 use Stripe\Exception\ApiErrorException;
 use Stripe\Exception\InvalidRequestException;
@@ -56,4 +58,6 @@ interface Stripe
     public function retrievePaymentMethod(StripePaymentMethodId $pmId): PaymentMethod;
 
     public function createCustomerSession(StripeCustomerId $stripeCustomerId): CustomerSession;
+
+    public function retrieveConfirmationToken(StripeConformationTokenId $confirmationTokenId): ConfirmationToken;
 }

--- a/src/Client/StubStripeClient.php
+++ b/src/Client/StubStripeClient.php
@@ -3,9 +3,11 @@
 namespace MatchBot\Client;
 
 use MatchBot\Domain\Donation;
+use MatchBot\Domain\StripeConformationTokenId;
 use MatchBot\Domain\StripeCustomerId;
 use MatchBot\Domain\StripePaymentMethodId;
 use Ramsey\Uuid\Uuid;
+use Stripe\ConfirmationToken;
 use Stripe\CustomerSession;
 use Stripe\PaymentIntent;
 use Stripe\PaymentMethod;
@@ -84,5 +86,10 @@ class StubStripeClient implements Stripe
     public function createCustomerSession(StripeCustomerId $stripeCustomerId): CustomerSession
     {
         return new CustomerSession();
+    }
+
+    public function retrieveConfirmationToken(StripeConformationTokenId $confirmationTokenId): ConfirmationToken
+    {
+        return new ConfirmationToken();
     }
 }

--- a/src/Domain/StripeConformationTokenId.php
+++ b/src/Domain/StripeConformationTokenId.php
@@ -18,7 +18,7 @@ readonly class StripeConformationTokenId
         $this->stripeConfirmationTokenId = $stripeConfirmationTokenId;
         Assertion::notEmpty($this->stripeConfirmationTokenId);
         Assertion::maxLength($this->stripeConfirmationTokenId, 255);
-        Assertion::regex($this->stripeConfirmationTokenId, '/^ctoken_[a-zA-Z0-9]+$/'); // e.g. pm_df64s36cf
+        Assertion::regex($this->stripeConfirmationTokenId, '/^ctoken_[a-zA-Z0-9]+$/'); // e.g. ctoken_1NnQUf2eZvKYlo2CIObdtbnb
     }
 
     /**

--- a/src/Domain/StripeConformationTokenId.php
+++ b/src/Domain/StripeConformationTokenId.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace MatchBot\Domain;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
+use MatchBot\Application\Assertion;
+
+#[Embeddable]
+readonly class StripeConformationTokenId
+{
+    #[Column(type: 'string')]
+    public readonly string $stripeConfirmationTokenId;
+
+    private function __construct(
+        string $stripeConfirmationTokenId
+    ) {
+        $this->stripeConfirmationTokenId = $stripeConfirmationTokenId;
+        Assertion::notEmpty($this->stripeConfirmationTokenId);
+        Assertion::maxLength($this->stripeConfirmationTokenId, 255);
+        Assertion::regex($this->stripeConfirmationTokenId, '/^ctoken_[a-zA-Z0-9]+$/'); // e.g. pm_df64s36cf
+    }
+
+    /**
+     * @param string $stripeID - must fit the pattern for a Stripe ID.
+     */
+    public static function of(string $stripeID): self
+    {
+        return new self($stripeID);
+    }
+}

--- a/src/Domain/StripeConformationTokenId.php
+++ b/src/Domain/StripeConformationTokenId.php
@@ -18,7 +18,9 @@ readonly class StripeConformationTokenId
         $this->stripeConfirmationTokenId = $stripeConfirmationTokenId;
         Assertion::notEmpty($this->stripeConfirmationTokenId);
         Assertion::maxLength($this->stripeConfirmationTokenId, 255);
-        Assertion::regex($this->stripeConfirmationTokenId, '/^ctoken_[a-zA-Z0-9]+$/'); // e.g. ctoken_1NnQUf2eZvKYlo2CIObdtbnb
+
+        // e.g. ctoken_1NnQUf2eZvKYlo2CIObdtbnb
+        Assertion::regex($this->stripeConfirmationTokenId, '/^ctoken_[a-zA-Z0-9]+$/');
     }
 
     /**

--- a/tests/Application/Actions/Donations/ConfirmTest.php
+++ b/tests/Application/Actions/Donations/ConfirmTest.php
@@ -388,7 +388,7 @@ class ConfirmTest extends TestCase
         $this->stripeProphecy->updatePaymentIntent(
             $paymentIntentId,
             $expectedMetadataUpdate
-        )->shouldBeCalled(); // should it though?
+        )->shouldBeCalled();
 
         if (is_string($confirmationTokenId)) {
             $confirmation = $this->stripeProphecy->confirmPaymentIntent(


### PR DESCRIPTION
… instead of payment method ID

See
https://docs.stripe.com/payments/payment-element/migration-ct?locale=en-GB and
https://docs.stripe.com/api/confirmation_tokens/object

Must be in prod before the related feature flag in frontend is enabled