### PR TITLE
DON-896: Don't redisplay payment cards if user explicity rejected opt…

### DIFF
--- a/src/Client/LiveStripeClient.php
+++ b/src/Client/LiveStripeClient.php
@@ -88,7 +88,7 @@ class LiveStripeClient implements Stripe
                 'payment_element' => [
                     'enabled' => true,
                     'features' => [
-                        'payment_method_allow_redisplay_filters' => ['always', 'limited', 'unspecified'],
+                        'payment_method_allow_redisplay_filters' => ['always', 'unspecified'],
                         'payment_method_redisplay' => 'enabled',
                         'payment_method_redisplay_limit' => 10, // default 3, 10 is max stripe allows.
                         'payment_method_remove' => 'disabled', // default value


### PR DESCRIPTION
…ion to allow redisplay

Keeping the 'unspecified' option should mean we continue to display cards collected before this ticket, but removing 'limited' should mean we stop displaying cards collected where the donor saw a "Save payment details for future purchases" box and chose not to tick it.