### PR TITLE
DON-896: Don't show payment methods with redisplay set to limited on …

### DIFF
--- a/src/Application/Actions/GetPaymentMethods.php
+++ b/src/Application/Actions/GetPaymentMethods.php
@@ -10,6 +10,7 @@ use MatchBot\Application\Auth\PersonWithPasswordAuthMiddleware;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Log\LoggerInterface;
+use Stripe\PaymentMethod;
 use Stripe\StripeClient;
 
 class GetPaymentMethods extends Action
@@ -38,6 +39,15 @@ class GetPaymentMethods extends Action
             ['type' => 'card'],
         );
 
-        return $this->respondWithData($response, $paymentMethods);
+        $paymentMethodArray = $paymentMethods->toArray()['data'];
+        \assert(is_array($paymentMethodArray));
+
+        // exclude payment methods with 'allow_redisplay' set to limited:
+        $displayableMethods = array_filter(
+            $paymentMethodArray,
+            static fn(array $paymentMethod) => in_array($paymentMethod['allow_redisplay'], ['always', 'unspecified'])
+        );
+
+        return $this->respondWithData($response, ['data' => $displayableMethods]);
     }
 }

--- a/tests/Application/Actions/GetPaymentMethodsTest.php
+++ b/tests/Application/Actions/GetPaymentMethodsTest.php
@@ -7,6 +7,7 @@ namespace MatchBot\Tests\Application\Actions;
 use DI\Container;
 use MatchBot\Tests\TestCase;
 use MatchBot\Tests\TestData;
+use Stripe\Collection;
 use Stripe\Service\CustomerService;
 use Stripe\StripeClient;
 
@@ -21,19 +22,19 @@ class GetPaymentMethodsTest extends TestCase
         $stripeCustomersProphecy = $this->prophesize(CustomerService::class);
         $stripeCustomersProphecy->allPaymentMethods('cus_aaaaaaaaaaaa11', ['type' => 'card'])
             ->shouldBeCalledOnce()
-            ->willReturn([
-                'data' => [
-                    [
-                        'id' => 'pm_123',
-                        'card' => [
-                            'brand' => 'visa',
-                            'last4' => '4242',
-                            'exp_month' => 1,
-                            'exp_year' => 2022,
-                        ],
+            ->willReturn(Collection::constructFrom(['data' => [
+                [
+                    'id' => 'pm_123',
+                    'allow_redisplay' => 'always',
+                    'card' => [
+                        'brand' => 'visa',
+                        'last4' => '4242',
+                        'exp_month' => 1,
+                        'exp_year' => 2022,
                     ],
                 ],
-            ]);
+            ],
+            ]));
 
         $stripeClientProphecy = $this->prophesize(StripeClient::class);
         // supressing deprecation notices for now on setting properties dynamically. Risk is low doing this in test


### PR DESCRIPTION
…account page

I'm not 100% sure why stripe keeps these cards attached to the customer
- we may want to auto-delete them like we auto-delete all cards for passwordless customers.