### PR TITLE
DON-896: Fix issue with attempting to re-save saved payment methods

### DIFF
--- a/src/Domain/DonationService.php
+++ b/src/Domain/DonationService.php
@@ -488,13 +488,14 @@ class DonationService
         Assertion::string($cardBrand);
         Assertion::string($cardCountry);
 
-        $savePaymentMethod = $paymentMethodPreview['allow_redisplay'] === 'always';
+        // whether to save the method or not is controlled from client side. We don't need to control it here.
+        $savePaymentMethod = false;
 
         $this->doUpdateDonationFees(
             cardBrand: $cardBrand,
             donation: $donation,
             cardCountry: $cardBrand,
-            savePaymentMethod: $savePaymentMethod
+            savePaymentMethod: $savePaymentMethod,
         );
     }
 }


### PR DESCRIPTION
We saw an error on attempt to re-use a saved card:

Stripe\Exception\InvalidRequestException:

The `setup_future_usage` value on the ConfirmationToken you provided was null.  This is determined by the `setupFutureUsage` you provided when creating the `elements` object on your client. When the PaymentIntent/SetupIntent `setup_future_usage` value is set to on_session with a secret key, the only acceptable ConfirmationToken `setup_future_usage` values are on_session and off_session.