### PR TITLE
Fix 'PropertyNotSetInConstructor' issues in CampaignFunding class

### DIFF
--- a/.psalm/psalm-baseline.xml
+++ b/.psalm/psalm-baseline.xml
@@ -200,15 +200,6 @@
       <code><![CDATA[$startDate]]></code>
     </PropertyNotSetInConstructor>
   </file>
-  <file src="src/Domain/CampaignFunding.php">
-    <PropertyNotSetInConstructor>
-      <code><![CDATA[$allocationOrder]]></code>
-      <code><![CDATA[$amount]]></code>
-      <code><![CDATA[$amountAvailable]]></code>
-      <code><![CDATA[$currencyCode]]></code>
-      <code><![CDATA[$fund]]></code>
-    </PropertyNotSetInConstructor>
-  </file>
   <file src="src/Domain/CampaignFundingRepository.php">
     <MixedInferredReturnType>
       <code><![CDATA[?CampaignFunding]]></code>

--- a/integrationTests/DonationRepositoryTest.php
+++ b/integrationTests/DonationRepositoryTest.php
@@ -176,7 +176,6 @@ class DonationRepositoryTest extends IntegrationTest
 
         $pledge = new Pledge(currencyCode: 'GBP', name: '');
         $campaignFunding = new CampaignFunding(
-            currencyCode: 'GBP',
             fund: $pledge,
             amount: '1.0',
             amountAvailable: '1.0',

--- a/integrationTests/DonationRepositoryTest.php
+++ b/integrationTests/DonationRepositoryTest.php
@@ -175,14 +175,13 @@ class DonationRepositoryTest extends IntegrationTest
         }
 
         $pledge = new Pledge(currencyCode: 'GBP', name: '');
-        $campaignFunding = new CampaignFunding();
-        $campaignFunding->setFund($pledge);
-        $campaignFunding->createdNow();
-        $campaignFunding->setFund($campaignFunding->getFund());
-        $campaignFunding->setAllocationOrder(100);
-        $campaignFunding->setCurrencyCode('GBP');
-        $campaignFunding->setAmount('1.0');
-        $campaignFunding->setAmountAvailable('1.0');
+        $campaignFunding = new CampaignFunding(
+            currencyCode: 'GBP',
+            fund: $pledge,
+            amount: '1.0',
+            amountAvailable: '1.0',
+            allocationOrder: 100,
+        );
         $fundingWithdrawal = new FundingWithdrawal($campaignFunding);
         $oldPendingDonation->addFundingWithdrawal($fundingWithdrawal);
         $fundingWithdrawal->setAmount('1');

--- a/src/Domain/CampaignFunding.php
+++ b/src/Domain/CampaignFunding.php
@@ -73,10 +73,28 @@ class CampaignFunding extends Model
     #[ORM\Column(type: 'integer')]
     protected int $allocationOrder;
 
-    public function __construct()
-    {
-        $this->campaigns = new ArrayCollection();
+    /**
+     * @param numeric-string $amount
+     * @param numeric-string $amountAvailable
+     */
+    public function __construct(
+        string $currencyCode,
+        Fund $fund,
+        string $amount,
+        string $amountAvailable,
+        int $allocationOrder
+    ) {
+        if ($allocationOrder < 0) {
+            throw new \LogicException('Allocation order must be a positive integer');
+        }
 
+        $this->currencyCode = $currencyCode;
+        $this->fund = $fund;
+        $this->amount = $amount;
+        $this->amountAvailable = $amountAvailable;
+        $this->allocationOrder = $allocationOrder;
+
+        $this->campaigns = new ArrayCollection();
         $this->createdNow();
     }
 
@@ -120,14 +138,6 @@ class CampaignFunding extends Model
     }
 
     /**
-     * @param Fund $fund
-     */
-    public function setFund(Fund $fund): void
-    {
-        $this->fund = $fund;
-    }
-
-    /**
      * Add a Campaign to those for which this CampaignFunding is available, *if* not already linked.
      *
      * @param Campaign $campaign
@@ -147,18 +157,6 @@ class CampaignFunding extends Model
     }
 
     /**
-     * @param int $allocationOrder
-     */
-    public function setAllocationOrder(int $allocationOrder): void
-    {
-        if ($allocationOrder < 0) {
-            throw new \LogicException('Allocation order must be a positive integer');
-        }
-
-        $this->allocationOrder = $allocationOrder;
-    }
-
-    /**
      * @return Fund
      */
     public function getFund(): Fund
@@ -169,10 +167,5 @@ class CampaignFunding extends Model
     public function getCurrencyCode(): string
     {
         return $this->currencyCode;
-    }
-
-    public function setCurrencyCode(string $currencyCode): void
-    {
-        $this->currencyCode = $currencyCode;
     }
 }

--- a/src/Domain/CampaignFunding.php
+++ b/src/Domain/CampaignFunding.php
@@ -74,11 +74,10 @@ class CampaignFunding extends Model
     protected int $allocationOrder;
 
     /**
-     * @param numeric-string $amount
      * @param numeric-string $amountAvailable
+     * @param numeric-string $amount
      */
     public function __construct(
-        string $currencyCode,
         Fund $fund,
         string $amount,
         string $amountAvailable,
@@ -88,8 +87,8 @@ class CampaignFunding extends Model
             throw new \LogicException('Allocation order must be a positive integer');
         }
 
-        $this->currencyCode = $currencyCode;
         $this->fund = $fund;
+        $this->currencyCode = $fund->getCurrencyCode();
         $this->amount = $amount;
         $this->amountAvailable = $amountAvailable;
         $this->allocationOrder = $allocationOrder;

--- a/src/Domain/FundRepository.php
+++ b/src/Domain/FundRepository.php
@@ -112,7 +112,6 @@ class FundRepository extends SalesforceReadProxyRepository
             } else {
                 // Not a previously existing campaign -> create one and set balances without checking for existing ones.
                 $campaignFunding = new CampaignFunding(
-                    currencyCode: $fund->getCurrencyCode(),
                     fund: $fund,
                     amount: $amountForCampaign,
                     amountAvailable: $amountForCampaign,

--- a/src/Domain/FundRepository.php
+++ b/src/Domain/FundRepository.php
@@ -111,18 +111,13 @@ class FundRepository extends SalesforceReadProxyRepository
                 }
             } else {
                 // Not a previously existing campaign -> create one and set balances without checking for existing ones.
-                $campaignFunding = new CampaignFunding();
-                $campaignFunding->createdNow();
-                $campaignFunding->setFund($fund);
-                $campaignFunding->setCurrencyCode($fund->getCurrencyCode());
-                $campaignFunding->setAmountAvailable($amountForCampaign);
-                $campaignFunding->setAmount($amountForCampaign);
-            }
-
-            if ($fund instanceof Pledge) {
-                $campaignFunding->setAllocationOrder(100);
-            } else {
-                $campaignFunding->setAllocationOrder(200);
+                $campaignFunding = new CampaignFunding(
+                    currencyCode: $fund->getCurrencyCode(),
+                    fund: $fund,
+                    amount: $amountForCampaign,
+                    amountAvailable: $amountForCampaign,
+                    allocationOrder: $fund instanceof Pledge ? 100 : 200,
+                );
             }
 
             // Make the CampaignFunding available to the Campaign. This method is immutable and won't add duplicates

--- a/tests/Application/Actions/Donations/CreateTest.php
+++ b/tests/Application/Actions/Donations/CreateTest.php
@@ -1074,13 +1074,12 @@ class CreateTest extends TestCase
 
     private static function someCampaignFunding(): CampaignFunding
     {
-        $campaignFunding = new CampaignFunding(
+        return new CampaignFunding(
             fund: new Pledge('GBP', 'some pledge'),
             amount: '8.00',
             amountAvailable: '8.00',
             allocationOrder: 100,
         );
-        return $campaignFunding;
     }
 
     /**

--- a/tests/Application/Actions/Donations/CreateTest.php
+++ b/tests/Application/Actions/Donations/CreateTest.php
@@ -1075,7 +1075,6 @@ class CreateTest extends TestCase
     private static function someCampaignFunding(): CampaignFunding
     {
         $campaignFunding = new CampaignFunding(
-            currencyCode: 'GBP',
             fund: new Pledge('GBP', 'some pledge'),
             amount: '8.00',
             amountAvailable: '8.00',

--- a/tests/Application/Actions/Donations/CreateTest.php
+++ b/tests/Application/Actions/Donations/CreateTest.php
@@ -11,6 +11,7 @@ use MatchBot\Application\Actions\ActionPayload;
 use MatchBot\Application\HttpModels\DonationCreate;
 use MatchBot\Application\Messenger\DonationUpserted;
 use MatchBot\Application\Persistence\RetrySafeEntityManager;
+use MatchBot\Client\Fund;
 use MatchBot\Client\Stripe;
 use MatchBot\Domain\Campaign;
 use MatchBot\Domain\CampaignFunding;
@@ -20,6 +21,8 @@ use MatchBot\Domain\DonationRepository;
 use MatchBot\Domain\DonationStatus;
 use MatchBot\Domain\DonorAccountRepository;
 use MatchBot\Domain\FundingWithdrawal;
+use MatchBot\Domain\FundRepository;
+use MatchBot\Domain\Pledge;
 use MatchBot\Domain\StripeCustomerId;
 use MatchBot\Tests\TestCase;
 use MatchBot\Tests\TestData;
@@ -1071,10 +1074,13 @@ class CreateTest extends TestCase
 
     private static function someCampaignFunding(): CampaignFunding
     {
-        $campaignFunding = new CampaignFunding();
-        $campaignFunding->setAmount('8.00');
-        $campaignFunding->setCurrencyCode('GBP');
-
+        $campaignFunding = new CampaignFunding(
+            currencyCode: 'GBP',
+            fund: new Pledge('GBP', 'some pledge'),
+            amount: '8.00',
+            amountAvailable: '8.00',
+            allocationOrder: 100,
+        );
         return $campaignFunding;
     }
 

--- a/tests/Application/Commands/HandleOutOfSyncFundsTest.php
+++ b/tests/Application/Commands/HandleOutOfSyncFundsTest.php
@@ -9,6 +9,7 @@ use MatchBot\Application\Matching\Adapter;
 use MatchBot\Domain\CampaignFunding;
 use MatchBot\Domain\CampaignFundingRepository;
 use MatchBot\Domain\FundingWithdrawalRepository;
+use MatchBot\Domain\Pledge;
 use MatchBot\Tests\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -206,40 +207,57 @@ class HandleOutOfSyncFundsTest extends TestCase
 
     private function getFundingInSync(): CampaignFunding
     {
-        $fundingInSync = new CampaignFunding();
+        $fundingInSync = new CampaignFunding(
+            currencyCode: 'GBP',
+            fund: new Pledge('GBP', 'some pledge'),
+            amount: '123.45',
+            amountAvailable: '80.01',
+            allocationOrder: 100,
+        );
         $fundingInSync->setId(1);
-        $fundingInSync->setAmount('123.45');
-        $fundingInSync->setAmountAvailable('80.01');
 
         return $fundingInSync;
     }
 
     private function getFundingOverMatched(): CampaignFunding
     {
-        $fundingOverMatched = new CampaignFunding();
+        $fundingOverMatched = new CampaignFunding(
+            currencyCode: 'GBP',
+            fund: new Pledge('GBP', 'some pledge'),
+            amount:'150',
+            amountAvailable: '99.0',
+            allocationOrder:  100
+        );
+
         $fundingOverMatched->setId(2);
-        $fundingOverMatched->setAmount('150');
-        $fundingOverMatched->setAmountAvailable('99.00');
 
         return $fundingOverMatched;
     }
 
     private function getFundingUnderMatched(): CampaignFunding
     {
-        $fundingUnderMatched = new CampaignFunding();
+        $fundingUnderMatched = new CampaignFunding(
+            currencyCode: 'GBP',
+            fund: new Pledge('GBP', 'some pledge'),
+            amount:'987.65',
+            amountAvailable: '487.65',
+            allocationOrder:  100
+        );
         $fundingUnderMatched->setId(3);
-        $fundingUnderMatched->setAmount('987.65');
-        $fundingUnderMatched->setAmountAvailable('487.65');
 
         return $fundingUnderMatched;
     }
 
     private function getFundingUnderMatchedWithNothingAllocated(): CampaignFunding
     {
-        $fundingUnderMatchedWithZero = new CampaignFunding();
+        $fundingUnderMatchedWithZero = new CampaignFunding(
+            currencyCode: 'GBP',
+            fund: new Pledge('GBP', 'some pledge'),
+            amount:'1000.00',
+            amountAvailable: '1000.00',
+            allocationOrder:  100
+        );
         $fundingUnderMatchedWithZero->setId(4);
-        $fundingUnderMatchedWithZero->setAmount('1000.00');
-        $fundingUnderMatchedWithZero->setAmountAvailable('1000.00');
 
         return $fundingUnderMatchedWithZero;
     }

--- a/tests/Application/Commands/HandleOutOfSyncFundsTest.php
+++ b/tests/Application/Commands/HandleOutOfSyncFundsTest.php
@@ -208,7 +208,6 @@ class HandleOutOfSyncFundsTest extends TestCase
     private function getFundingInSync(): CampaignFunding
     {
         $fundingInSync = new CampaignFunding(
-            currencyCode: 'GBP',
             fund: new Pledge('GBP', 'some pledge'),
             amount: '123.45',
             amountAvailable: '80.01',
@@ -222,11 +221,10 @@ class HandleOutOfSyncFundsTest extends TestCase
     private function getFundingOverMatched(): CampaignFunding
     {
         $fundingOverMatched = new CampaignFunding(
-            currencyCode: 'GBP',
             fund: new Pledge('GBP', 'some pledge'),
-            amount:'150',
+            amount: '150',
             amountAvailable: '99.0',
-            allocationOrder:  100
+            allocationOrder: 100
         );
 
         $fundingOverMatched->setId(2);
@@ -237,11 +235,10 @@ class HandleOutOfSyncFundsTest extends TestCase
     private function getFundingUnderMatched(): CampaignFunding
     {
         $fundingUnderMatched = new CampaignFunding(
-            currencyCode: 'GBP',
             fund: new Pledge('GBP', 'some pledge'),
-            amount:'987.65',
+            amount: '987.65',
             amountAvailable: '487.65',
-            allocationOrder:  100
+            allocationOrder: 100
         );
         $fundingUnderMatched->setId(3);
 
@@ -251,11 +248,10 @@ class HandleOutOfSyncFundsTest extends TestCase
     private function getFundingUnderMatchedWithNothingAllocated(): CampaignFunding
     {
         $fundingUnderMatchedWithZero = new CampaignFunding(
-            currencyCode: 'GBP',
             fund: new Pledge('GBP', 'some pledge'),
-            amount:'1000.00',
+            amount: '1000.00',
             amountAvailable: '1000.00',
-            allocationOrder:  100
+            allocationOrder: 100
         );
         $fundingUnderMatchedWithZero->setId(4);
 

--- a/tests/Application/Commands/RedistributeMatchFundsTest.php
+++ b/tests/Application/Commands/RedistributeMatchFundsTest.php
@@ -179,13 +179,14 @@ class RedistributeMatchFundsTest extends TestCase
     {
         $pledgeAmount = '101.00';
         $pledge = new Pledge(currencyCode: 'GBP', name: '');
-        $pledgeFunding = new CampaignFunding();
-        $pledgeFunding->setAmount($pledgeAmount);
-        $pledgeFunding->setAmountAvailable($pledgeAmount);
-        $pledgeFunding->setAllocationOrder(100);
-        $pledgeFunding->setFund($pledge);
 
-        return $pledgeFunding;
+        return new CampaignFunding(
+            currencyCode: 'GBP',
+            fund: $pledge,
+            amount: $pledgeAmount,
+            amountAvailable: $pledgeAmount,
+            allocationOrder: 100,
+        );
     }
 
     private function getTenPoundChampionMatchedDonation(): Donation
@@ -201,12 +202,13 @@ class RedistributeMatchFundsTest extends TestCase
         $donation->setTransactionId('pi_tenPound123');
 
         $championFund = new ChampionFund(currencyCode: 'GBP', name: '');
-        $campaignFunding = new CampaignFunding();
-        $campaignFunding->setAmount($donationAmount);
-        // We're bypassing normal allocation helpers and will set up the FundingWithdrawal to the test donation below.
-        $campaignFunding->setAmountAvailable('0');
-        $campaignFunding->setAllocationOrder(200);
-        $campaignFunding->setFund($championFund);
+        $campaignFunding = new CampaignFunding(
+            currencyCode: 'GBP',
+            fund: $championFund,
+            amount: $donationAmount,
+            amountAvailable: '0',
+            allocationOrder:  200,
+        );
 
         $championFundWithdrawal = new FundingWithdrawal($campaignFunding);
         $championFundWithdrawal->setAmount($donationAmount);

--- a/tests/Application/Commands/RedistributeMatchFundsTest.php
+++ b/tests/Application/Commands/RedistributeMatchFundsTest.php
@@ -181,7 +181,6 @@ class RedistributeMatchFundsTest extends TestCase
         $pledge = new Pledge(currencyCode: 'GBP', name: '');
 
         return new CampaignFunding(
-            currencyCode: 'GBP',
             fund: $pledge,
             amount: $pledgeAmount,
             amountAvailable: $pledgeAmount,
@@ -203,11 +202,10 @@ class RedistributeMatchFundsTest extends TestCase
 
         $championFund = new ChampionFund(currencyCode: 'GBP', name: '');
         $campaignFunding = new CampaignFunding(
-            currencyCode: 'GBP',
             fund: $championFund,
             amount: $donationAmount,
             amountAvailable: '0',
-            allocationOrder:  200,
+            allocationOrder: 200,
         );
 
         $championFundWithdrawal = new FundingWithdrawal($campaignFunding);

--- a/tests/Application/Commands/ResetMatchingTest.php
+++ b/tests/Application/Commands/ResetMatchingTest.php
@@ -27,7 +27,6 @@ class ResetMatchingTest extends TestCase
         $fund->setSalesforceLastPull(new \DateTime());
 
         $campaignFunding = new CampaignFunding(
-            currencyCode: 'GBP',
             fund: $fund,
             amount: '400',
             amountAvailable: '400',

--- a/tests/Application/Commands/ResetMatchingTest.php
+++ b/tests/Application/Commands/ResetMatchingTest.php
@@ -26,10 +26,13 @@ class ResetMatchingTest extends TestCase
         $fund->setSalesforceId('sfFundId123');
         $fund->setSalesforceLastPull(new \DateTime());
 
-        $campaignFunding = new CampaignFunding();
-        $campaignFunding->setFund($fund);
-        $campaignFunding->setAmount('400');
-        $campaignFunding->setAllocationOrder(200);
+        $campaignFunding = new CampaignFunding(
+            currencyCode: 'GBP',
+            fund: $fund,
+            amount: '400',
+            amountAvailable: '400',
+            allocationOrder: 200,
+        );
 
         $matchingAdapterProphecy = $this->prophesize(Matching\Adapter::class);
         $matchingAdapterProphecy->delete($campaignFunding)->shouldBeCalledOnce();

--- a/tests/Application/Matching/AdapterTest.php
+++ b/tests/Application/Matching/AdapterTest.php
@@ -7,6 +7,7 @@ use MatchBot\Application\Matching\LessThanRequestedAllocatedException;
 use MatchBot\Application\Matching\Adapter;
 use MatchBot\Application\Matching\TerminalLockException;
 use MatchBot\Domain\CampaignFunding;
+use MatchBot\Domain\Pledge;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -45,9 +46,14 @@ class AdapterTest extends TestCase
 
     public function testItReturnsAmountAvailableFromAFundingNotInStorage(): void
     {
-        $funding = new CampaignFunding();
+        $funding = new CampaignFunding(
+            currencyCode: 'GBP',
+            fund: new Pledge('GBP', 'some pledge'),
+            amount: '10000',
+            amountAvailable: '12.53',
+            allocationOrder: 100,
+        );
         $funding->setId(1);
-        $funding->setAmountAvailable('12.53');
 
         $amountAvaialble = $this->sut->getAmountAvailable($funding);
 
@@ -56,9 +62,14 @@ class AdapterTest extends TestCase
 
     public function testItAddsAmountForFunding(): void
     {
-        $funding = new CampaignFunding();
+        $funding = new CampaignFunding(
+            currencyCode: 'GBP',
+            fund: new Pledge('GBP', 'some pledge'),
+            amount: '1000',
+            amountAvailable: '50',
+            allocationOrder: 100,
+        );
         $funding->setId(1);
-        $funding->setAmountAvailable('50');
         $this->sut->addAmount($funding, '12.53');
         $this->entityManagerProphecy->persist($funding)->shouldBeCalled();
 
@@ -72,9 +83,14 @@ class AdapterTest extends TestCase
 
     public function testItSubtractsAmountForFunding(): void
     {
-            $funding = new CampaignFunding();
+            $funding = new CampaignFunding(
+                currencyCode: 'GBP',
+                fund: new Pledge('GBP', 'some pledge'),
+                amount: '1000',
+                amountAvailable: '50',
+                allocationOrder: 100,
+            );
             $funding->setId(1);
-            $funding->setAmountAvailable('50');
             $amountToSubtract = "10.10";
 
             $this->entityManagerProphecy->persist($funding)->shouldBeCalled();
@@ -88,9 +104,14 @@ class AdapterTest extends TestCase
 
     public function testItReleasesFundsInCaseOfRaceCondition(): void
     {
-                $funding = new CampaignFunding();
+                $funding = new CampaignFunding(
+                    currencyCode: 'GBP',
+                    fund: new Pledge('GBP', 'some pledge'),
+                    amount: '1000',
+                    amountAvailable: '50',
+                    allocationOrder: 100,
+                );
                 $funding->setId(1);
-                $funding->setAmountAvailable('50');
                 $amountToSubtract = "30";
 
             $this->entityManagerProphecy->persist($funding)->shouldBeCalled();
@@ -119,7 +140,13 @@ class AdapterTest extends TestCase
             return $this->storage->decrBy($key, 40_00);
         });
 
-        $funding = new CampaignFunding();
+        $funding = new CampaignFunding(
+            currencyCode: 'GBP',
+            fund: new Pledge('GBP', 'some pledge'),
+            amount: '1000',
+            amountAvailable: '50',
+            allocationOrder: 100,
+        );
         $funding->setId(53);
         $funding->setAmountAvailable('50');
         $amountToSubtract = "30";
@@ -151,9 +178,14 @@ class AdapterTest extends TestCase
 
     public function testItDeletesCampaignFundingData(): void
     {
-        $funding = new CampaignFunding();
+        $funding = new CampaignFunding(
+            currencyCode: 'GBP',
+            fund: new Pledge('GBP', 'some pledge'),
+            amount: '1000',
+            amountAvailable: '1',
+            allocationOrder: 100,
+        );
         $funding->setId(1);
-        $funding->setAmountAvailable('1');
         $this->entityManagerProphecy->persist($funding)->shouldBeCalled();
         $this->sut->addAmount($funding, '5');
 
@@ -167,9 +199,14 @@ class AdapterTest extends TestCase
     public function testItReleasesNewlyAllocatedFunds(): void
     {
         // arrange
-        $funding = new CampaignFunding();
+        $funding = new CampaignFunding(
+            currencyCode: 'GBP',
+            fund: new Pledge('GBP', 'some pledge'),
+            amount: '1000',
+            amountAvailable: '50',
+            allocationOrder: 100,
+        );
         $funding->setId(1);
-        $funding->setAmountAvailable('50');
         $amountToSubtract = "10.10";
 
         $this->entityManagerProphecy->persist($funding)->shouldBeCalled();

--- a/tests/Application/Matching/AdapterTest.php
+++ b/tests/Application/Matching/AdapterTest.php
@@ -47,7 +47,6 @@ class AdapterTest extends TestCase
     public function testItReturnsAmountAvailableFromAFundingNotInStorage(): void
     {
         $funding = new CampaignFunding(
-            currencyCode: 'GBP',
             fund: new Pledge('GBP', 'some pledge'),
             amount: '10000',
             amountAvailable: '12.53',
@@ -63,7 +62,6 @@ class AdapterTest extends TestCase
     public function testItAddsAmountForFunding(): void
     {
         $funding = new CampaignFunding(
-            currencyCode: 'GBP',
             fund: new Pledge('GBP', 'some pledge'),
             amount: '1000',
             amountAvailable: '50',
@@ -84,7 +82,6 @@ class AdapterTest extends TestCase
     public function testItSubtractsAmountForFunding(): void
     {
             $funding = new CampaignFunding(
-                currencyCode: 'GBP',
                 fund: new Pledge('GBP', 'some pledge'),
                 amount: '1000',
                 amountAvailable: '50',
@@ -105,7 +102,6 @@ class AdapterTest extends TestCase
     public function testItReleasesFundsInCaseOfRaceCondition(): void
     {
                 $funding = new CampaignFunding(
-                    currencyCode: 'GBP',
                     fund: new Pledge('GBP', 'some pledge'),
                     amount: '1000',
                     amountAvailable: '50',
@@ -141,7 +137,6 @@ class AdapterTest extends TestCase
         });
 
         $funding = new CampaignFunding(
-            currencyCode: 'GBP',
             fund: new Pledge('GBP', 'some pledge'),
             amount: '1000',
             amountAvailable: '50',
@@ -179,7 +174,6 @@ class AdapterTest extends TestCase
     public function testItDeletesCampaignFundingData(): void
     {
         $funding = new CampaignFunding(
-            currencyCode: 'GBP',
             fund: new Pledge('GBP', 'some pledge'),
             amount: '1000',
             amountAvailable: '1',
@@ -200,7 +194,6 @@ class AdapterTest extends TestCase
     {
         // arrange
         $funding = new CampaignFunding(
-            currencyCode: 'GBP',
             fund: new Pledge('GBP', 'some pledge'),
             amount: '1000',
             amountAvailable: '50',

--- a/tests/Domain/DonationRepositoryMatchFundsAllocationTest.php
+++ b/tests/Domain/DonationRepositoryMatchFundsAllocationTest.php
@@ -101,11 +101,10 @@ class DonationRepositoryMatchFundsAllocationTest extends TestCase
     public function testItAllocates1From1For1(): void
     {
         $campaignFunding = new CampaignFunding(
-            currencyCode: 'GBP',
             fund: new Pledge('GBP', 'some pledge'),
             amount: '1000',
             amountAvailable: '1',
-            allocationOrder:  100
+            allocationOrder: 100
         );
         $campaignFunding->setId(1);
 
@@ -183,20 +182,18 @@ class DonationRepositoryMatchFundsAllocationTest extends TestCase
         string $withdrawl1AmountExpected
     ): void {
         $campaignFunding0 = new CampaignFunding(
-            currencyCode: 'GBP',
             fund: new Pledge('GBP', 'some pledge'),
             amount: '1000',
             amountAvailable: $funding0Available,
-            allocationOrder:  100
+            allocationOrder: 100
         );
         $campaignFunding0->setId(0);
 
         $campaignFunding1 = new CampaignFunding(
-            currencyCode: 'GBP',
             fund: new Pledge('GBP', 'some pledge'),
             amount: '1000',
             amountAvailable: $funding1Available,
-            allocationOrder:  100
+            allocationOrder: 100
         );
         $campaignFunding1->setId(1);
 
@@ -243,11 +240,10 @@ class DonationRepositoryMatchFundsAllocationTest extends TestCase
     public function testItAllocates1From2For2When1AlreadyMatched(): void
     {
         $campaignFunding = new CampaignFunding(
-            currencyCode: 'GBP',
             fund: new Pledge('GBP', 'some pledge'),
             amount: '1000',
             amountAvailable: '1.0',
-            allocationOrder:  100
+            allocationOrder: 100
         );
         $campaignFunding->setId(1);
 
@@ -289,11 +285,10 @@ class DonationRepositoryMatchFundsAllocationTest extends TestCase
     public function testItRejectsFundingInWrongCurrency(): void
     {
         $campaignFunding = new CampaignFunding(
-            currencyCode: 'USD',
-            fund: new Pledge('GBP', 'some pledge'),
+            fund: new Pledge('USD', 'some pledge'),
             amount: '1000',
-            amountAvailable: '1.0',
-            allocationOrder:  100
+            amountAvailable: '1',
+            allocationOrder: 100
         );
 
         $this->campaignFundingsRepositoryProphecy->getAvailableFundings($this->campaign)->willReturn([

--- a/tests/Domain/DonationRepositoryMatchFundsAllocationTest.php
+++ b/tests/Domain/DonationRepositoryMatchFundsAllocationTest.php
@@ -12,6 +12,7 @@ use MatchBot\Domain\Donation;
 use MatchBot\Domain\DonationRepository;
 use MatchBot\Domain\FundingWithdrawal;
 use MatchBot\Domain\PaymentMethodType;
+use MatchBot\Domain\Pledge;
 use MatchBot\Tests\Application\Matching\ArrayMatchingStorage;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -99,9 +100,13 @@ class DonationRepositoryMatchFundsAllocationTest extends TestCase
      */
     public function testItAllocates1From1For1(): void
     {
-        $campaignFunding = new CampaignFunding();
-        $campaignFunding->setCurrencyCode('GBP');
-        $campaignFunding->setAmountAvailable('1.0');
+        $campaignFunding = new CampaignFunding(
+            currencyCode: 'GBP',
+            fund: new Pledge('GBP', 'some pledge'),
+            amount: '1000',
+            amountAvailable: '1',
+            allocationOrder:  100
+        );
         $campaignFunding->setId(1);
 
         $this->campaignFundingsRepositoryProphecy->getAvailableFundings($this->campaign)->willReturn([
@@ -177,14 +182,22 @@ class DonationRepositoryMatchFundsAllocationTest extends TestCase
         string $withdrawal0AmountExpected,
         string $withdrawl1AmountExpected
     ): void {
-        $campaignFunding0 = new CampaignFunding();
-        $campaignFunding0->setCurrencyCode('GBP');
-        $campaignFunding0->setAmountAvailable($funding0Available);
+        $campaignFunding0 = new CampaignFunding(
+            currencyCode: 'GBP',
+            fund: new Pledge('GBP', 'some pledge'),
+            amount: '1000',
+            amountAvailable: $funding0Available,
+            allocationOrder:  100
+        );
         $campaignFunding0->setId(0);
 
-        $campaignFunding1 = new CampaignFunding();
-        $campaignFunding1->setCurrencyCode('GBP');
-        $campaignFunding1->setAmountAvailable($funding1Available);
+        $campaignFunding1 = new CampaignFunding(
+            currencyCode: 'GBP',
+            fund: new Pledge('GBP', 'some pledge'),
+            amount: '1000',
+            amountAvailable: $funding1Available,
+            allocationOrder:  100
+        );
         $campaignFunding1->setId(1);
 
 
@@ -229,9 +242,13 @@ class DonationRepositoryMatchFundsAllocationTest extends TestCase
 
     public function testItAllocates1From2For2When1AlreadyMatched(): void
     {
-        $campaignFunding = new CampaignFunding();
-        $campaignFunding->setCurrencyCode('GBP');
-        $campaignFunding->setAmountAvailable('1.0');
+        $campaignFunding = new CampaignFunding(
+            currencyCode: 'GBP',
+            fund: new Pledge('GBP', 'some pledge'),
+            amount: '1000',
+            amountAvailable: '1.0',
+            allocationOrder:  100
+        );
         $campaignFunding->setId(1);
 
         $this->campaignFundingsRepositoryProphecy->getAvailableFundings($this->campaign)->willReturn([
@@ -271,9 +288,13 @@ class DonationRepositoryMatchFundsAllocationTest extends TestCase
 
     public function testItRejectsFundingInWrongCurrency(): void
     {
-        $campaignFunding = new CampaignFunding();
-        $campaignFunding->setCurrencyCode('USD');
-        $campaignFunding->setAmountAvailable('1.0');
+        $campaignFunding = new CampaignFunding(
+            currencyCode: 'USD',
+            fund: new Pledge('GBP', 'some pledge'),
+            amount: '1000',
+            amountAvailable: '1.0',
+            allocationOrder:  100
+        );
 
         $this->campaignFundingsRepositoryProphecy->getAvailableFundings($this->campaign)->willReturn([
             $campaignFunding

--- a/tests/Domain/DonationTest.php
+++ b/tests/Domain/DonationTest.php
@@ -186,10 +186,13 @@ class DonationTest extends TestCase
     {
         $pledge = new Pledge(currencyCode: 'GBP', name: '');
 
-        $campaignFunding = new CampaignFunding();
-        $campaignFunding->setCurrencyCode('GBP');
-        $campaignFunding->setAmountAvailable('1.23');
-        $campaignFunding->setFund($pledge);
+        $campaignFunding = new CampaignFunding(
+            currencyCode: 'GBP',
+            fund: $pledge,
+            amount: '1000',
+            amountAvailable: '1.23',
+            allocationOrder: 100,
+        );
 
         $fundingWithdrawal = new FundingWithdrawal($campaignFunding);
         $fundingWithdrawal->setAmount('1.23');
@@ -229,8 +232,13 @@ class DonationTest extends TestCase
     {
         $donation = $this->getTestDonation();
 
-        $campaignFunding = new CampaignFunding();
-        $campaignFunding->setFund(new ChampionFund(currencyCode: 'GBP', name: ''));
+        $campaignFunding = new CampaignFunding(
+            currencyCode: 'GBP',
+            fund: new ChampionFund(currencyCode: 'GBP', name: ''),
+            amount: '1000',
+            amountAvailable: '1000',
+            allocationOrder:  100,
+        );
         $withdrawal0 = new FundingWithdrawal($campaignFunding);
         $withdrawal0->setAmount('1');
 
@@ -250,14 +258,24 @@ class DonationTest extends TestCase
     public function testItSumsAmountsMatchedByAllFunds(): void
     {
         $donation = $this->getTestDonation();
-        $campaignFunding0 = new CampaignFunding();
-        $campaignFunding0->setFund(new ChampionFund(currencyCode: 'GBP', name: ''));
+        $campaignFunding0 = new CampaignFunding(
+            currencyCode: 'GBP',
+            fund: new ChampionFund(currencyCode: 'GBP', name: ''),
+            amount: '1000',
+            amountAvailable: '1000',
+            allocationOrder:  100,
+        );
 
         $withdrawal0 = new FundingWithdrawal($campaignFunding0);
         $withdrawal0->setAmount('1');
 
-        $campaignFunding1 = new CampaignFunding();
-        $campaignFunding1->setFund(new Pledge(currencyCode: 'GBP', name: ''));
+        $campaignFunding1 = new CampaignFunding(
+            currencyCode: 'GBP',
+            fund: new ChampionFund(currencyCode: 'GBP', name: ''),
+            amount: '1000',
+            amountAvailable: '1000',
+            allocationOrder:  100,
+        );
         $withdrawal1 = new FundingWithdrawal($campaignFunding1);
         $withdrawal1->setAmount('2');
 

--- a/tests/Domain/DonationTest.php
+++ b/tests/Domain/DonationTest.php
@@ -187,7 +187,6 @@ class DonationTest extends TestCase
         $pledge = new Pledge(currencyCode: 'GBP', name: '');
 
         $campaignFunding = new CampaignFunding(
-            currencyCode: 'GBP',
             fund: $pledge,
             amount: '1000',
             amountAvailable: '1.23',
@@ -233,11 +232,10 @@ class DonationTest extends TestCase
         $donation = $this->getTestDonation();
 
         $campaignFunding = new CampaignFunding(
-            currencyCode: 'GBP',
             fund: new ChampionFund(currencyCode: 'GBP', name: ''),
             amount: '1000',
             amountAvailable: '1000',
-            allocationOrder:  100,
+            allocationOrder: 100,
         );
         $withdrawal0 = new FundingWithdrawal($campaignFunding);
         $withdrawal0->setAmount('1');
@@ -259,22 +257,20 @@ class DonationTest extends TestCase
     {
         $donation = $this->getTestDonation();
         $campaignFunding0 = new CampaignFunding(
-            currencyCode: 'GBP',
             fund: new ChampionFund(currencyCode: 'GBP', name: ''),
             amount: '1000',
             amountAvailable: '1000',
-            allocationOrder:  100,
+            allocationOrder: 100,
         );
 
         $withdrawal0 = new FundingWithdrawal($campaignFunding0);
         $withdrawal0->setAmount('1');
 
         $campaignFunding1 = new CampaignFunding(
-            currencyCode: 'GBP',
             fund: new ChampionFund(currencyCode: 'GBP', name: ''),
             amount: '1000',
             amountAvailable: '1000',
-            allocationOrder:  100,
+            allocationOrder: 100,
         );
         $withdrawal1 = new FundingWithdrawal($campaignFunding1);
         $withdrawal1->setAmount('2');

--- a/tests/Domain/FundRepositoryTest.php
+++ b/tests/Domain/FundRepositoryTest.php
@@ -272,13 +272,13 @@ class FundRepositoryTest extends TestCase
 
     private function getExistingCampaignFunding(bool $shared): CampaignFunding
     {
-        $campaignFunding = new CampaignFunding();
-        $campaignFunding->setFund($this->getExistingFund($shared));
-        $campaignFunding->setAmount('400');
-        $campaignFunding->setAllocationOrder(200);
-        $campaignFunding->setCurrencyCode('GBP');
-
-        return $campaignFunding;
+        return new CampaignFunding(
+            currencyCode: 'GBP',
+            fund: $this->getExistingFund($shared),
+            amount: '400',
+            amountAvailable: '1000',
+            allocationOrder:  200,
+        );
     }
 
     /**

--- a/tests/Domain/FundRepositoryTest.php
+++ b/tests/Domain/FundRepositoryTest.php
@@ -273,11 +273,10 @@ class FundRepositoryTest extends TestCase
     private function getExistingCampaignFunding(bool $shared): CampaignFunding
     {
         return new CampaignFunding(
-            currencyCode: 'GBP',
             fund: $this->getExistingFund($shared),
             amount: '400',
             amountAvailable: '1000',
-            allocationOrder:  200,
+            allocationOrder: 200,
         );
     }
 


### PR DESCRIPTION
This refactoring PR does technically add more lines than it removes, but the added lines are substantially simpler than the removed lines.