### PR TITLE
MAT-377 – message push enhancements: improve traceability, reduce chance of unhelpful reverts

### DIFF
--- a/app/dependencies.php
+++ b/app/dependencies.php
@@ -20,6 +20,7 @@ use MatchBot\Application\Messenger\Handler\CharityUpdatedHandler;
 use MatchBot\Application\Messenger\Handler\DonationUpsertedHandler;
 use MatchBot\Application\Messenger\Handler\GiftAidResultHandler;
 use MatchBot\Application\Messenger\Handler\StripePayoutHandler;
+use MatchBot\Application\Messenger\Middleware\AddOrLogMessageId;
 use MatchBot\Application\Messenger\StripePayout;
 use MatchBot\Application\Messenger\Transport\ClaimBotTransport;
 use MatchBot\Application\Notifier\StripeChatterInterface;
@@ -327,6 +328,7 @@ return function (ContainerBuilder $containerBuilder) {
 
             return new MessageBus([
                 new AddFifoStampMiddleware(),
+                new AddOrLogMessageId($logger),
                 $sendMiddleware,
                 $handleMiddleware,
             ]);

--- a/src/Application/Messenger/Middleware/AddOrLogMessageId.php
+++ b/src/Application/Messenger/Middleware/AddOrLogMessageId.php
@@ -17,6 +17,7 @@ readonly class AddOrLogMessageId implements MiddlewareInterface
     {
     }
 
+    /** @psalm-suppress PossiblyUnusedReturnValue sig must match interface */
     public function handle(Envelope $envelope, StackInterface $stack): Envelope
     {
         $existingMessageIdStamp = $envelope->last(MessageId::class);

--- a/src/Application/Messenger/Middleware/AddOrLogMessageId.php
+++ b/src/Application/Messenger/Middleware/AddOrLogMessageId.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Application\Messenger\Middleware;
+
+use MatchBot\Application\Messenger\DonationUpserted;
+use MatchBot\Application\Messenger\Stamp\MessageId;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+
+readonly class AddOrLogMessageId implements MiddlewareInterface
+{
+    public function __construct(private LoggerInterface $logger)
+    {
+    }
+
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        $existingMessageIdStamp = $envelope->last(MessageId::class);
+        if ($existingMessageIdStamp === null) {
+            $stamp = new MessageId();
+            $envelope = $envelope->with($stamp);
+            $this->logAddedMessageId($envelope, $stamp->getMessageId());
+        } else {
+            $this->logReceivedMessageId($envelope, $existingMessageIdStamp->getMessageId());
+        }
+
+        return $stack->next()->handle($envelope, $stack);
+    }
+
+    private function logAddedMessageId(Envelope $envelope, string $messageId): void
+    {
+        $message = $envelope->getMessage();
+        $log = sprintf('AddOrLogMessageId stamped %s with message ID: %s', get_class($message), $messageId);
+        $logWithUUID = $this->appendUUIDIfApplicable($message, $log);
+        $this->logger->info($logWithUUID);
+    }
+
+    private function logReceivedMessageId(Envelope $envelope, string $messageId): void
+    {
+        $message = $envelope->getMessage();
+        $log = sprintf('AddOrLogMessageId received %s with message ID: %s', get_class($message), $messageId);
+        $logWithUUID = $this->appendUUIDIfApplicable($message, $log);
+        $this->logger->info($logWithUUID);
+    }
+
+    private function appendUUIDIfApplicable(object $message, string $log): string
+    {
+        if ($message instanceof DonationUpserted) {
+            $log .= ' (Donation UUID: ' . $message->uuid . ')';
+        }
+
+        return $log;
+    }
+}

--- a/src/Application/Messenger/Middleware/AddOrLogMessageId.php
+++ b/src/Application/Messenger/Middleware/AddOrLogMessageId.php
@@ -17,7 +17,7 @@ readonly class AddOrLogMessageId implements MiddlewareInterface
     {
     }
 
-    /** @psalm-suppress PossiblyUnusedReturnValue sig must match interface */
+    /** @psalm-suppress PossiblyUnusedReturnValue Messenger uses value; our test doesn't */
     public function handle(Envelope $envelope, StackInterface $stack): Envelope
     {
         $existingMessageIdStamp = $envelope->last(MessageId::class);

--- a/src/Application/Messenger/Stamp/MessageId.php
+++ b/src/Application/Messenger/Stamp/MessageId.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Application\Messenger\Stamp;
+
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Messenger\Stamp\StampInterface;
+
+class MessageId implements StampInterface
+{
+    private UuidInterface $messageId;
+
+    public function __construct()
+    {
+        $this->messageId = Uuid::uuid4();
+    }
+
+    public function getMessageId(): string
+    {
+        return $this->messageId->toString();
+    }
+}

--- a/src/Application/Messenger/Stamp/MessageId.php
+++ b/src/Application/Messenger/Stamp/MessageId.php
@@ -8,7 +8,7 @@ use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\Messenger\Stamp\StampInterface;
 
-class MessageId implements StampInterface
+readonly class MessageId implements StampInterface
 {
     private UuidInterface $messageId;
 

--- a/tests/Application/Messenger/Middleware/AddOrLogMessageIdTest.php
+++ b/tests/Application/Messenger/Middleware/AddOrLogMessageIdTest.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+namespace MatchBot\Tests\Application\Messenger\Middleware;
+
+use MatchBot\Application\Messenger\Middleware\AddOrLogMessageId;
+use MatchBot\Application\Messenger\DonationUpserted;
+use MatchBot\Application\Messenger\Stamp\MessageId;
+use MatchBot\Tests\Application\DonationTestDataTrait;
+use MatchBot\Tests\TestCase;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\StackMiddleware;
+
+class AddOrLogMessageIdTest extends TestCase
+{
+    use DonationTestDataTrait;
+
+    public function testAddsMessageIdStamp(): void
+    {
+        $loggerProphecy = $this->prophesize(LoggerInterface::class);
+        $this->expectLog(
+            $loggerProphecy,
+            'AddOrLogMessageId stamped MatchBot\Application\Messenger\DonationUpserted ' .
+                'with message ID: ',
+        );
+
+        $middleware = new AddOrLogMessageId($loggerProphecy->reveal());
+
+        $envelope = new Envelope(DonationUpserted::fromDonation($this->getTestDonation()));
+        $middleware->handle($envelope, $this->createStack($middleware));
+    }
+
+    public function testLogsReceivedMessageId(): void
+    {
+        $loggerProphecy = $this->prophesize(LoggerInterface::class);
+        $this->expectLog(
+            $loggerProphecy,
+            'AddOrLogMessageId received MatchBot\Application\Messenger\DonationUpserted ' .
+                'with message ID: ',
+        );
+        $middleware = new AddOrLogMessageId($loggerProphecy->reveal());
+
+        $envelope = new Envelope(DonationUpserted::fromDonation($this->getTestDonation()));
+        $envelope = $envelope->with(new MessageId());
+        $middleware->handle($envelope, $this->createStack($middleware));
+    }
+
+    /**
+     * @param ObjectProphecy<LoggerInterface> $logger
+     */
+    private function expectLog(ObjectProphecy $logger, string $startOfMessage): void
+    {
+        $logger->info(Argument::containingString($startOfMessage))->shouldBeCalledOnce();
+    }
+
+    private function createStack(AddOrLogMessageId $middleware): StackMiddleware
+    {
+        return new StackMiddleware([$middleware]);
+    }
+}

--- a/tests/Application/Messenger/Middleware/AddOrLogMessageIdTest.php
+++ b/tests/Application/Messenger/Middleware/AddOrLogMessageIdTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MatchBot\Tests\Application\Messenger\Middleware;


### PR DESCRIPTION
* [Delay handling of Stripe payment webhooks' queued messages](https://github.com/thebiggive/matchbot/commit/b15ba32c85a029b9a7a0aa1eda1722f2ed050d71); May reduce the risk of these important updates being superseded unhelpfully by overlapping ones
* Give all messages unique IDs
* Log those ID with all sends & receives
* Log donation UUID alongside where applicable

~~I've not tested the middleware yet, so draft for now.~~