### PR TITLE
Also catch `MissingConstructorArgumentsException` and `AssertionFailedException` on Donation Update deserialise

### DIFF
--- a/src/Application/Actions/Donations/Update.php
+++ b/src/Application/Actions/Donations/Update.php
@@ -10,6 +10,7 @@ use JetBrains\PhpStorm\Pure;
 use MatchBot\Application\Actions\Action;
 use MatchBot\Application\Actions\ActionError;
 use MatchBot\Application\Actions\ActionPayload;
+use MatchBot\Application\AssertionFailedException;
 use MatchBot\Application\HttpModels;
 use MatchBot\Application\Messenger\DonationUpserted;
 use MatchBot\Client\Stripe;
@@ -80,8 +81,12 @@ class Update extends Action
                 HttpModels\Donation::class,
                 'json'
             );
-        } catch (UnexpectedValueException | MissingConstructorArgumentsException | TypeError $exception) {
-            // UnexpectedValueException is the Serializer one, not the global one
+        } catch (
+            UnexpectedValueException | // the Serializer one, not the global one
+            AssertionFailedException |
+            MissingConstructorArgumentsException |
+            TypeError $exception
+        ) {
             $this->logger->info("Donation Update non-serialisable payload was: $body");
 
             $message = 'Donation Update data deserialise error';
@@ -93,14 +98,6 @@ class Update extends Action
                 $message,
                 empty($body), // Suspected bot / junk traffic sometimes sends blank payload.
             );
-        }
-
-        if (
-            getenv('APP_ENV') !== 'production' &&
-            str_starts_with($donationData->donorName?->first ?? '', 'Please throw')
-        ) {
-            $this->logger->critical("Testing a critical log message for BG2-2297");
-            throw new \Exception("{$donationData->donorName?->first} requested an exception for test purposes");
         }
 
         if (!isset($donationData->status)) {

--- a/src/Application/Actions/Donations/Update.php
+++ b/src/Application/Actions/Donations/Update.php
@@ -30,6 +30,7 @@ use Stripe\PaymentIntent;
 use Symfony\Component\Clock\ClockInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\RoutableMessageBus;
+use Symfony\Component\Serializer\Exception\MissingConstructorArgumentsException;
 use Symfony\Component\Serializer\Exception\UnexpectedValueException;
 use Symfony\Component\Serializer\SerializerInterface;
 use TypeError;
@@ -79,7 +80,7 @@ class Update extends Action
                 HttpModels\Donation::class,
                 'json'
             );
-        } catch (UnexpectedValueException | TypeError $exception) {
+        } catch (UnexpectedValueException | MissingConstructorArgumentsException | TypeError $exception) {
             // UnexpectedValueException is the Serializer one, not the global one
             $this->logger->info("Donation Update non-serialisable payload was: $body");
 


### PR DESCRIPTION
With our latest libs & constructor, this is now what happens if you leave out e.g. donation amount (missing constructor arg) or provide an invalid format email address (assertion valid).

We want an HTTP 400 and warning log for both of these, not 500 and error.