### PR TITLE
DON-1082 – fix stale tip cancellation

### DIFF
--- a/src/Application/Commands/CancelStaleDonationFundTips.php
+++ b/src/Application/Commands/CancelStaleDonationFundTips.php
@@ -48,7 +48,9 @@ class CancelStaleDonationFundTips extends LockingCommand
         $staleDonationTips = $this->donationRepository->findStaleDonationFundsTips($this->now);
 
         foreach ($staleDonationTips as $tipDonation) {
+            $this->entityManager->beginTransaction();
             $this->donationService->cancel($tipDonation);
+            $this->entityManager->commit();
             $output->writeln("Cancelled tip donation {$tipDonation->getUuid()}");
         }
 

--- a/src/Domain/DonationService.php
+++ b/src/Domain/DonationService.php
@@ -459,7 +459,9 @@ class DonationService
 
     /**
      * Sets donation to cancelled in matchbot db, releases match funds, cancels payment in stripe, and updates
-     * salesforce
+     * salesforce.
+     *
+     * Requires an open DB transaction.
      */
     public function cancel(Donation $donation): void
     {
@@ -480,7 +482,7 @@ class DonationService
             );
         }
 
-        $this->logger->info("Donor cancelled ID {$donation->getUuid()}");
+        $this->logger->info("Cancelled ID {$donation->getUuid()}");
 
         $donation->cancel();
 


### PR DESCRIPTION
`DonationService::cancel()` needs an open database transaction.