### PR TITLE
MAT-384: Don't recalculate donation fees after payment

### DIFF
--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -1383,11 +1383,6 @@ class Donation extends SalesforceWriteProxy
 
         $this->chargeId = $chargeId;
         $this->transferId = $transferId;
-
-        if ($cardBrand !== null) {
-            $this->deriveFees($cardBrand, $cardCountry);
-        }
-
         $this->donationStatus = DonationStatus::Collected;
         $this->collectedAt = (new \DateTimeImmutable("@$chargeCreationTimestamp"));
         $this->setOriginalPspFeeFractional($originalFeeFractional);

--- a/src/Domain/DonationService.php
+++ b/src/Domain/DonationService.php
@@ -179,6 +179,12 @@ class DonationService
         StripeConfirmationTokenId $tokenId
     ): \Stripe\PaymentIntent {
         $this->updateDonationFeesFromConfirmationToken($tokenId, $donation);
+
+        // We flush now to make sure the actual fees we're charging are recorded. If there's any DB error at this point
+        // we prefer to crash without collecting the donation over collecting the donation without a proper record
+        // or what we're charging.
+        $this->entityManager->flush();
+
         return $this->confirm($donation, $tokenId);
     }
 


### PR DESCRIPTION
Need consider both MAT-384 and the old ticket MAT-330

We want to make sure we keep the donation fees as charged in the database, not anything recalculated after the payment.

In theory both these should be the same but in case of any errors or future changes to charging structure priority should be given to recording the fee we calculated to pass to stripe to control what we actually chaged, not a later calculation of what we should have charged.

In case there's a DB error and we can't save the donation fee update we will let the process crash without collecting and it will be up to the donor to try again hopefully that will be very rare.

There's a new call to flush changes to DB in DonationService but this shouldn't increase load much since it means the later flush in the Confirm action will have little or no work to do as the Doctrine UoW will see that there are no new changes.