### PR TITLE
Skip over new donations without transaction / payment intent IDs when…

### DIFF
--- a/src/Application/Messenger/DonationUpserted.php
+++ b/src/Application/Messenger/DonationUpserted.php
@@ -2,6 +2,7 @@
 
 namespace MatchBot\Application\Messenger;
 
+use MatchBot\Domain\DomainException\MissingTransactionId;
 use MatchBot\Domain\Donation;
 
 class DonationUpserted extends AbstractStateChanged
@@ -11,6 +12,9 @@ class DonationUpserted extends AbstractStateChanged
         parent::__construct($uuid, $jsonSnapshot);
     }
 
+    /**
+     * @throws MissingTransactionId
+     */
     public static function fromDonation(Donation $donation): self
     {
         return new self(

--- a/src/Domain/DomainException/MissingTransactionId.php
+++ b/src/Domain/DomainException/MissingTransactionId.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace MatchBot\Domain\DomainException;
+
+/**
+ * Thrown when a donation doesn't have a transaction ID, (i.e. stripe payment intent ID). This can happen
+ * if there was an error creating the stripe payment intent, e.g. because the account didn't have the required
+ * capabilities.
+ */
+class MissingTransactionId extends \LogicException
+{
+}


### PR DESCRIPTION
… pushing to SF

This happens if there was an error creating the payment intent ID. Currently it generates an alarming unhandled execption, this PR should reduce it to a warning.