### PR TITLE
MAT-386: Reduce allow viewing of donation thanks page for only eight …

### DIFF
--- a/src/Application/Auth/DonationToken.php
+++ b/src/Application/Auth/DonationToken.php
@@ -31,7 +31,7 @@ class DonationToken
         $claims = [
             'iss' => getenv('BASE_URI'),
             'iat' => time(),
-            'exp' => time() + (30 * 86400), // Expire in 30 days
+            'exp' => time() + 8 * 60 * 60, // eight hours
             'sub' => [
                 'donationId' => $donationId,
             ],


### PR DESCRIPTION
…hours, not 30 days

Improving confidentiality in case of donation on a shared computer, and donation history can now be seen via the account if logged in.

We will make some related copy changes on FE but I don't think it's critical for those to go out first.