### PR TITLE
DON-1082: Start auto-running donation funds expired tip cancellation …

### DIFF
--- a/integrationTests/CallFrequentCommandsTest.php
+++ b/integrationTests/CallFrequentCommandsTest.php
@@ -41,8 +41,8 @@ class CallFrequentCommandsTest extends IntegrationTest
             'matchbot:expire-match-funds starting!',
             'Released 0 donations\' matching',
             'matchbot:expire-match-funds complete!',
-//            'matchbot:cancel-stale-donation-fund-tips starting!', // commented out temporarily
-//            'matchbot:cancel-stale-donation-fund-tips complete!',
+            'matchbot:cancel-stale-donation-fund-tips starting!',
+            'matchbot:cancel-stale-donation-fund-tips complete!',
             'matchbot:tick complete!',
             '',
         ]);

--- a/src/Application/Commands/CallFrequentTasks.php
+++ b/src/Application/Commands/CallFrequentTasks.php
@@ -25,8 +25,7 @@ class CallFrequentTasks extends LockingCommand
         $commandNames = [
             'matchbot:send-statistics',
             'matchbot:expire-match-funds',
-//            'matchbot:cancel-stale-donation-fund-tips', <-- this new one is erroring in prod. Commenting out for
-// now to fix in the morning
+            'matchbot:cancel-stale-donation-fund-tips',
         ];
 
         $commands = array_map($app->find(...), $commandNames);


### PR DESCRIPTION
…code again

I think we should have done this about 20 days ago but forgot. Looks like the reason we had to comment out this line previously was fixed in https://github.com/thebiggive/matchbot/pull/1061 - and that already reverted the hotfix commenting the lines out but maybe something went wrong with the merge of that into main so these lines stayed commented out.