### PR TITLE
INFRA-138 – give SQS messages group IDs

### DIFF
--- a/src/Application/Messenger/CharityUpdated.php
+++ b/src/Application/Messenger/CharityUpdated.php
@@ -5,12 +5,13 @@ namespace MatchBot\Application\Messenger;
 use MatchBot\Domain\Charity;
 use MatchBot\Domain\Salesforce18Id;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\MessageDeduplicationAwareInterface;
+use Symfony\Component\Messenger\Bridge\AmazonSqs\MessageGroupAwareInterface;
 
 /**
  * Message dispatched when Salesforce tells us that something material to donation processing or
  * Gift Aid changed about the {@see Charity}.
  */
-readonly class CharityUpdated implements MessageDeduplicationAwareInterface
+readonly class CharityUpdated implements MessageDeduplicationAwareInterface, MessageGroupAwareInterface
 {
     public function __construct(public Salesforce18Id $charityAccountId, private ?string $requestTraceId)
     {
@@ -25,5 +26,10 @@ readonly class CharityUpdated implements MessageDeduplicationAwareInterface
     public function getMessageDeduplicationId(): ?string
     {
         return $this->requestTraceId;
+    }
+
+    public function getMessageGroupId(): ?string
+    {
+        return 'charity.updated.' . $this->charityAccountId->value;
     }
 }

--- a/src/Application/Messenger/DonationUpserted.php
+++ b/src/Application/Messenger/DonationUpserted.php
@@ -4,8 +4,9 @@ namespace MatchBot\Application\Messenger;
 
 use MatchBot\Domain\DomainException\MissingTransactionId;
 use MatchBot\Domain\Donation;
+use Symfony\Component\Messenger\Bridge\AmazonSqs\MessageGroupAwareInterface;
 
-class DonationUpserted extends AbstractStateChanged
+class DonationUpserted extends AbstractStateChanged implements MessageGroupAwareInterface
 {
     private function __construct(public string $uuid, public array $jsonSnapshot)
     {
@@ -21,5 +22,10 @@ class DonationUpserted extends AbstractStateChanged
             uuid: $donation->getUuid(),
             jsonSnapshot: $donation->toSFApiModel(),
         );
+    }
+
+    public function getMessageGroupId(): ?string
+    {
+        return 'donation.upserted.' . $this->uuid;
     }
 }

--- a/src/Application/Messenger/StripePayout.php
+++ b/src/Application/Messenger/StripePayout.php
@@ -2,14 +2,21 @@
 
 namespace MatchBot\Application\Messenger;
 
+use Symfony\Component\Messenger\Bridge\AmazonSqs\MessageGroupAwareInterface;
+
 /**
  * Model representing a Stripe Payout 'payout.paid' event for queued follow-up.
  */
-readonly class StripePayout
+readonly class StripePayout implements MessageGroupAwareInterface
 {
     public function __construct(
         public string $connectAccountId,
         public string $payoutId,
     ) {
+    }
+
+    public function getMessageGroupId(): ?string
+    {
+        return 'payout.paid.' . $this->connectAccountId;
     }
 }


### PR DESCRIPTION
Should allow conditional parallel processing; most notably, not holding up quick donation upserts behind slow payout reconciliations