### PR TITLE
DON-1090: Revert "DON-896: Show allo attached payment methods on acco…

### DIFF
--- a/src/Application/Actions/GetPaymentMethods.php
+++ b/src/Application/Actions/GetPaymentMethods.php
@@ -10,6 +10,7 @@ use MatchBot\Application\Auth\PersonWithPasswordAuthMiddleware;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Log\LoggerInterface;
+use Stripe\PaymentMethod;
 use Stripe\StripeClient;
 
 class GetPaymentMethods extends Action
@@ -38,6 +39,15 @@ class GetPaymentMethods extends Action
             ['type' => 'card'],
         );
 
-        return $this->respondWithData($response, $paymentMethods);
+        $paymentMethodArray = $paymentMethods->toArray()['data'];
+        \assert(is_array($paymentMethodArray));
+
+        // exclude payment methods with 'allow_redisplay' set to limited:
+        $displayableMethods = array_values(array_filter(
+            $paymentMethodArray,
+            static fn(array $paymentMethod) => in_array($paymentMethod['allow_redisplay'], ['always', 'unspecified'])
+        ));
+
+        return $this->respondWithData($response, ['data' => $displayableMethods]);
     }
 }

--- a/tests/Application/Actions/GetPaymentMethodsTest.php
+++ b/tests/Application/Actions/GetPaymentMethodsTest.php
@@ -7,6 +7,7 @@ namespace MatchBot\Tests\Application\Actions;
 use DI\Container;
 use MatchBot\Tests\TestCase;
 use MatchBot\Tests\TestData;
+use Stripe\Collection;
 use Stripe\Service\CustomerService;
 use Stripe\StripeClient;
 
@@ -21,19 +22,19 @@ class GetPaymentMethodsTest extends TestCase
         $stripeCustomersProphecy = $this->prophesize(CustomerService::class);
         $stripeCustomersProphecy->allPaymentMethods('cus_aaaaaaaaaaaa11', ['type' => 'card'])
             ->shouldBeCalledOnce()
-            ->willReturn([
-                'data' => [
-                    [
-                        'id' => 'pm_123',
-                        'card' => [
-                            'brand' => 'visa',
-                            'last4' => '4242',
-                            'exp_month' => 1,
-                            'exp_year' => 2022,
-                        ],
+            ->willReturn(Collection::constructFrom(['data' => [
+                [
+                    'id' => 'pm_123',
+                    'allow_redisplay' => 'always',
+                    'card' => [
+                        'brand' => 'visa',
+                        'last4' => '4242',
+                        'exp_month' => 1,
+                        'exp_year' => 2022,
                     ],
                 ],
-            ]);
+            ],
+            ]));
 
         $stripeClientProphecy = $this->prophesize(StripeClient::class);
         // supressing deprecation notices for now on setting properties dynamically. Risk is low doing this in test


### PR DESCRIPTION
…unt page"

This reverts commit 38eac6e58da9ffb941e464aa7112242ae58d8140.

Payment methods are being saved from the new stripe payment element even if "Save payment details for future purchases" is not ticked - the tick box controls the "setup_future_usage" value on the card, not whether or it it is actually saved. Since if the cards are not setup for future usage they will not appear on payment forms it doesn't make sense to show them on the my account page.

We can also look into auto detatching them.