### PR TITLE
Hotfix for sf pull type error

### DIFF
--- a/src/Domain/Campaign.php
+++ b/src/Domain/Campaign.php
@@ -238,7 +238,7 @@ class Campaign extends SalesforceReadProxy
     public function updateFromSfPull(
         Charity $charity,
         string $currencyCode,
-        string $status,
+        ?string $status,
         \DateTimeInterface $endDate,
         bool $isMatched,
         string $name,


### PR DESCRIPTION
Not sure why this is null though, I thought the data from sf would always include status. Not an issue for now for it to be null in matchbot.