### PR TITLE
DonationRepositoryTest minor tidying

### DIFF
--- a/tests/Domain/DonationRepositoryTest.php
+++ b/tests/Domain/DonationRepositoryTest.php
@@ -98,12 +98,12 @@ class DonationRepositoryTest extends TestCase
         $createPayload = new DonationCreate(
             currencyCode: 'USD',
             donationAmount: '123',
-            pspMethodType: PaymentMethodType::Card,
             projectId: 'testProject1234567',
             psp: 'stripe',
+            pspMethodType: PaymentMethodType::Card,
         );
 
-        $donation = $this->getRepo(null, false, $campaignRepoProphecy)
+        $donation = $this->getRepo(null, $campaignRepoProphecy)
             ->buildFromApiRequest($createPayload);
 
         $this->assertEquals('USD', $donation->getCurrencyCode());
@@ -132,9 +132,9 @@ class DonationRepositoryTest extends TestCase
         $createPayload = new DonationCreate(
             currencyCode: 'GBP',
             donationAmount: '123',
-            pspMethodType: PaymentMethodType::Card,
             projectId: 'testProject1234567',
             psp: 'stripe',
+            pspMethodType: PaymentMethodType::Card,
         );
 
         $donationRepository = $this->getRepo(
@@ -165,12 +165,12 @@ class DonationRepositoryTest extends TestCase
         $createPayload = new DonationCreate(
             currencyCode: 'CAD',
             donationAmount: '144.0',
-            pspMethodType: PaymentMethodType::Card,
             projectId: 'testProject1234567',
             psp: 'stripe',
+            pspMethodType: PaymentMethodType::Card,
         );
 
-        $this->getRepo(null, false, $campaignRepoProphecy)
+        $this->getRepo(campaignRepoProphecy: $campaignRepoProphecy)
             ->buildFromApiRequest($createPayload);
     }
 
@@ -194,7 +194,7 @@ class DonationRepositoryTest extends TestCase
         // N.B. tip to TBG should not change the amount the charity receives, and the tip
         // is not included in the core donation amount set by `setAmount()`.
         $donation = $this->getTestDonation('987.65');
-        ;
+
         $donation->setTipAmount('10.00');
         $donation->deriveFees(CardBrand::amex, null);
 
@@ -215,7 +215,7 @@ class DonationRepositoryTest extends TestCase
         // N.B. tip to TBG should not change the amount the charity receives, and the tip
         // is not included in the core donation amount set by `setAmount()`.
         $donation = $this->getTestDonation('987.65');
-        ;
+
         $donation->setTipAmount('10.00');
         $donation->deriveFees(CardBrand::visa, Country::fromAlpha2('US'));
 
@@ -235,7 +235,7 @@ class DonationRepositoryTest extends TestCase
         // N.B. tip to TBG should not change the amount the charity receives, and the tip
         // is not included in the core donation amount set by `setAmount()`.
         $donation = $this->getTestDonation('987.65');
-        ;
+
         $donation->setTipAmount('10.00');
         $donation->deriveFees(null, null);
 
@@ -255,7 +255,7 @@ class DonationRepositoryTest extends TestCase
         // N.B. tip to TBG should not change the amount the charity receives, and the tip
         // is not included in the core donation amount set by `setAmount()`.
         $donation = $this->getTestDonation('987.65');
-        ;
+
         $donation->setTipAmount('10.00');
 
         $donation->deriveFees(null, null);
@@ -276,7 +276,7 @@ class DonationRepositoryTest extends TestCase
     public function testStripeAmountForCharityWithoutTip(): void
     {
         $donation = $this->getTestDonation('987.65');
-        ;
+
         $donation->setTipAmount('0.00');
         $donation->deriveFees(null, null);
 
@@ -346,11 +346,8 @@ class DonationRepositoryTest extends TestCase
         );
 
         $repo = $this->getRepo(
-            null,
-            false,
-            null,
-            $matchingAdapterProphecy,
-            $lockFactoryProphecy,
+            matchingAdapterProphecy: $matchingAdapterProphecy,
+            lockFactoryProphecy: $lockFactoryProphecy,
         );
 
         $donation = $this->getTestDonation();
@@ -373,11 +370,8 @@ class DonationRepositoryTest extends TestCase
             ->shouldNotBeCalled();
 
         $repo = $this->getRepo(
-            null,
-            false,
-            null,
-            $matchingAdapterProphecy,
-            $lockFactoryProphecy,
+            matchingAdapterProphecy: $matchingAdapterProphecy,
+            lockFactoryProphecy: $lockFactoryProphecy,
         );
 
         $donation = $this->getTestDonation();
@@ -402,11 +396,8 @@ class DonationRepositoryTest extends TestCase
             ->shouldNotBeCalled();
 
         $repo = $this->getRepo(
-            null,
-            false,
-            null,
-            $matchingAdapterProphecy,
-            $lockFactoryProphecy,
+            matchingAdapterProphecy: $matchingAdapterProphecy,
+            lockFactoryProphecy: $lockFactoryProphecy,
         );
 
         $donation = $this->getTestDonation();
@@ -563,7 +554,6 @@ class DonationRepositoryTest extends TestCase
      */
     private function getRepo(
         ?ObjectProphecy $donationClientProphecy = null,
-        bool $vatLive = false,
         ?ObjectProphecy $campaignRepoProphecy = null,
         ?ObjectProphecy $matchingAdapterProphecy = null,
         ?ObjectProphecy $lockFactoryProphecy = null,


### PR DESCRIPTION
Primarily, make `getRepo()` calls slightly less unwieldy by removing unused arg and naming others at call time