### PR TITLE
MAT-393 – hold the existing funds release lock longer, to fix a race condition

### DIFF
--- a/src/Domain/DonationRepository.php
+++ b/src/Domain/DonationRepository.php
@@ -184,10 +184,6 @@ class DonationRepository extends SalesforceWriteProxyRepository
 
         $this->getEntityManager()->flush();
 
-        // After new funds are allocated, we want releasing them to be allowed without waiting for lock expiry, in case
-        // e.g. a donor changes their donation amount for a second time within that window.
-        $this->getFundsReleaseLock($donation)->release();
-
         return $amountNewlyMatched;
     }
 

--- a/src/Domain/DonationRepository.php
+++ b/src/Domain/DonationRepository.php
@@ -218,7 +218,7 @@ class DonationRepository extends SalesforceWriteProxyRepository
         $fundsReleaseLock = $this->getFundsReleaseLock($donation);
 
         try {
-            // We no longer `release()` the lock, holding it for the default 5 mins instead unless a thread newly
+            // We don't `release()` the lock, holding it for the default 5 mins instead unless a thread newly
             // allocates funds during that time. This avoids race condition bugs between explicit cancel actions by
             // donors and funds auto expiry.
             $gotLock = $fundsReleaseLock->acquire(false);

--- a/tests/Domain/DonationRepositoryTest.php
+++ b/tests/Domain/DonationRepositoryTest.php
@@ -326,7 +326,7 @@ class DonationRepositoryTest extends TestCase
     {
         $lockProphecy = $this->prophesize(LockInterface::class);
         $lockProphecy->acquire(false)->willReturn(true)->shouldBeCalledOnce();
-        $lockProphecy->release()->shouldBeCalledOnce();
+        $lockProphecy->release()->shouldNotBeCalled(); // We only do this on new funds allocation now.
 
         $lockFactoryProphecy = $this->prophesize(LockFactory::class);
         $lockFactoryProphecy->createLock(Argument::type('string'))

--- a/tests/Domain/DonationRepositoryTest.php
+++ b/tests/Domain/DonationRepositoryTest.php
@@ -329,7 +329,7 @@ class DonationRepositoryTest extends TestCase
         $lockProphecy->release()->shouldNotBeCalled(); // We only do this on new funds allocation now.
 
         $lockFactoryProphecy = $this->prophesize(LockFactory::class);
-        $lockFactoryProphecy->createLock(Argument::type('string'))
+        $lockFactoryProphecy->createLock(Argument::type('string'), 300.0)
             ->willReturn($lockProphecy->reveal())
             ->shouldBeCalledOnce();
 
@@ -363,7 +363,7 @@ class DonationRepositoryTest extends TestCase
         $lockProphecy->release()->shouldNotBeCalled();
 
         $lockFactoryProphecy = $this->prophesize(LockFactory::class);
-        $lockFactoryProphecy->createLock(Argument::type('string'))
+        $lockFactoryProphecy->createLock(Argument::type('string'), 300.0)
             ->willReturn($lockProphecy->reveal())
             ->shouldBeCalledOnce();
 
@@ -392,7 +392,7 @@ class DonationRepositoryTest extends TestCase
         $lockProphecy->release()->shouldNotBeCalled();
 
         $lockFactoryProphecy = $this->prophesize(LockFactory::class);
-        $lockFactoryProphecy->createLock(Argument::type('string'))
+        $lockFactoryProphecy->createLock(Argument::type('string'), 300.0)
             ->willReturn($lockProphecy->reveal())
             ->shouldBeCalledOnce();
 


### PR DESCRIPTION
Same goal as https://github.com/thebiggive/matchbot/pull/1105 but simpler and without introducing an extra lock.

Could do with testing, but probably better than the other option if I've not missed anything and it works.