### PR TITLE
DON-1106 – map properties needed for Donation Create to save Gift Aid info

### DIFF
--- a/src/Application/HttpModels/DonationCreate.php
+++ b/src/Application/HttpModels/DonationCreate.php
@@ -41,7 +41,11 @@ readonly class DonationCreate
         public ?string $tipAmount = '0.00',
         ?string $firstName = null,
         ?string $lastName = null,
-        ?string $emailAddress = null
+        ?string $emailAddress = null,
+        public ?bool $giftAid = null,
+        public ?bool $tipGiftAid = null,
+        public ?string $homeAddress = null,
+        public ?string $homePostcode = null,
     ) {
         $this->emailAddress = (! is_null($emailAddress) && ! ($emailAddress === '')) ?
             EmailAddress::of($emailAddress) :

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -172,7 +172,6 @@ class Donation extends SalesforceWriteProxy
 
     /**
      * Whether the Donor has asked for Gift Aid to be claimed about this donation.
-     * @var bool
      */
     #[ORM\Column()]
     protected bool $giftAid = false;
@@ -357,6 +356,10 @@ class Donation extends SalesforceWriteProxy
         ?string $tipAmount,
         ?RegularGivingMandate $mandate,
         ?DonationSequenceNumber $mandateSequenceNumber,
+        ?bool $giftAid = null,
+        ?bool $tipGiftAid = null,
+        ?string $homeAddress = null,
+        ?string $homePostcode = null,
     ) {
         $this->setUuid(Uuid::uuid4());
         $this->fundingWithdrawals = new ArrayCollection();
@@ -389,6 +392,10 @@ class Donation extends SalesforceWriteProxy
         $this->setDonorName($donorName);
         $this->setDonorEmailAddress($emailAddress);
 
+        $this->giftAid = $giftAid ?? false;
+        $this->tipGiftAid = $tipGiftAid;
+        $this->donorHomeAddressLine1 = $homeAddress;
+        $this->donorHomePostcode = $homePostcode;
 
         // We probably don't need to test for all these, just replicationg behaviour of `empty` that was used before.
         if ($countryCode !== '' && $countryCode !== null && $countryCode !== '0') {
@@ -425,6 +432,12 @@ class Donation extends SalesforceWriteProxy
             tipAmount: $donationData->tipAmount,
             mandate: null,
             mandateSequenceNumber: null,
+            giftAid: $donationData->giftAid,
+            // Not meaningfully used yet (typical donations set it on Update instead; Donation Funds
+            // tips don't have a "tip" because the donation is to BG), but map just in case.
+            tipGiftAid: $donationData->tipGiftAid,
+            homeAddress: $donationData->homeAddress,
+            homePostcode: $donationData->homePostcode,
         );
     }
 

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -356,7 +356,7 @@ class Donation extends SalesforceWriteProxy
         ?string $tipAmount,
         ?RegularGivingMandate $mandate,
         ?DonationSequenceNumber $mandateSequenceNumber,
-        ?bool $giftAid = null,
+        bool $giftAid = false,
         ?bool $tipGiftAid = null,
         ?string $homeAddress = null,
         ?string $homePostcode = null,
@@ -392,7 +392,7 @@ class Donation extends SalesforceWriteProxy
         $this->setDonorName($donorName);
         $this->setDonorEmailAddress($emailAddress);
 
-        $this->giftAid = $giftAid ?? false;
+        $this->giftAid = $giftAid;
         $this->tipGiftAid = $tipGiftAid;
         $this->donorHomeAddressLine1 = $homeAddress;
         $this->donorHomePostcode = $homePostcode;
@@ -432,7 +432,10 @@ class Donation extends SalesforceWriteProxy
             tipAmount: $donationData->tipAmount,
             mandate: null,
             mandateSequenceNumber: null,
-            giftAid: $donationData->giftAid,
+            // Main form starts off with this null on init in the API model, so effectively it's ignored here
+            // then as `false` is also the constructor's default. Donation Funds tips should send a bool value
+            // from the start.
+            giftAid: $donationData->giftAid ?? false,
             // Not meaningfully used yet (typical donations set it on Update instead; Donation Funds
             // tips don't have a "tip" because the donation is to BG), but map just in case.
             tipGiftAid: $donationData->tipGiftAid,


### PR DESCRIPTION
Needed for Donation Funds "tips" to Big Give to have the correct info saved without an Update.

Targeting `develop` as I don't expect we would choose to merge this much before noon tomorrow anyway.

Feels like ideally we'd add tests too but I'm not sure what would be a valuable one as the gap we missed here sort of sits between apps. Maybe expanding the scope of (or adding) a regression test is the best option.