### PR TITLE
DON-1009: Fix error in \MatchBot\Domain\Money::fromNumericStringGBP

### DIFF
--- a/src/Domain/Money.php
+++ b/src/Domain/Money.php
@@ -115,9 +115,10 @@ readonly class Money implements \JsonSerializable, \Stringable
      */
     public static function fromNumericStringGBP(string $amount): self
     {
-        $amountInPence = $amount * 100;
+        $amountInPence = bcmul($amount, '100', 2);
+
         /** @psalm-suppress ImpureMethodCall */
-        Assertion::integerish($amountInPence);
+        Assertion::integerish((float) $amountInPence);
 
         return new self((int) $amountInPence, Currency::GBP);
     }


### PR DESCRIPTION
This was randomly throwing an assertion exception in a test when given the input "258.40" because multiplying by 100 using floating point gives 25,839.9999999999963, not exactly 25,840.

This would have caused a real bug, more seriously if the assertion was not there, since `(int)(100 * "258.40")` returns 25839 not the 25840 you'd expect.