### PR TITLE
DON-998: Send human readable error message in case of insufficent fun…

### DIFF
--- a/src/Application/Actions/RegularGivingMandate/Create.php
+++ b/src/Application/Actions/RegularGivingMandate/Create.php
@@ -100,7 +100,7 @@ class Create extends Action
             return $this->validationError(
                 $response,
                 $e->getMessage(),
-                null,
+                'Sorry, we were not able to take your regular donation as there are insufficient match funds available',
                 false,
             );
         }

--- a/src/Domain/RegularGivingService.php
+++ b/src/Domain/RegularGivingService.php
@@ -132,6 +132,8 @@ readonly class RegularGivingService
             foreach ($donations as $donation) {
                 $this->donationService->enrollNewDonation($donation);
                 if (!$donation->isFullyMatched()) {
+                    // @todo-regular-giving:
+                    // see ticket DON-1003 - that will require us to not throw here if the donor doesn't mind their donations being unmatched.
                     throw new NotFullyMatched(
                         "Donation could not be fully matched, need to match {$donation->getAmount()}," .
                         " only matched {$donation->getFundingWithdrawalTotal()}"


### PR DESCRIPTION
…ds for regular giving matching

I think I'd rather have the microcopy in frontend with most microcopy instead of in matchbot, but afaik we don't have any system set up for sending a machine readable error cause idnentifier in responses