### PR TITLE
DON-998: Add action to allow testing collection of regular giving funds via http

### DIFF
--- a/app/routes.php
+++ b/app/routes.php
@@ -83,6 +83,11 @@ return function (App $app) {
             ->add(PersonWithPasswordAuthMiddleware::class)
             ->add($ipMiddleware)
             ->add(RateLimitMiddleware::class);
+
+        $versionGroup->get(
+            '/test-donation-collection-for-date/{date}',
+            \MatchBot\Application\Actions\CollectRegularGivingForTest::class
+        );
     });
     // Authenticated through Stripe's SDK signature verification
     $app->post('/hooks/stripe', Hooks\StripePaymentsUpdate::class);

--- a/src/Application/Actions/CollectRegularGivingForTest.php
+++ b/src/Application/Actions/CollectRegularGivingForTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Application\Actions;
+
+use JetBrains\PhpStorm\Pure;
+use MatchBot\Application\Commands\TakeRegularGivingDonations;
+use MatchBot\Application\Environment;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Log\LoggerInterface;
+use Slim\Exception\HttpNotFoundException;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Lock\LockFactory;
+
+/**
+ * To test on dev machine, send GET request to e.g.
+ * http://localhost:30030/v1/test-donation-collection-for-date/
+ */
+class CollectRegularGivingForTest extends Action
+{
+    #[Pure]
+    public function __construct(
+        LoggerInterface $logger,
+        private TakeRegularGivingDonations $cliCommand,
+        private LockFactory $lockFactory,
+        private Environment $environment,
+    ) {
+        parent::__construct($logger);
+    }
+
+    protected function action(Request $request, Response $response, array $args): Response
+    {
+        if ($this->environment === Environment::Production) {
+            throw new HttpNotFoundException($request);
+        }
+
+        $date = $args['date'];
+
+        $this->cliCommand->setLockFactory($this->lockFactory);
+        $this->cliCommand->setLogger($this->logger);
+
+        $commandTest = new CommandTester($this->cliCommand);
+        $commandTest->execute(['--simulated-date'=> $date]);
+        $commandOutput = $commandTest->getDisplay();
+
+        $response =  $response->withHeader('Content-Type', 'text/plain');
+        $response->getBody()->write($commandOutput);
+
+        return $response;
+    }
+}

--- a/src/Application/Commands/TakeRegularGivingDonations.php
+++ b/src/Application/Commands/TakeRegularGivingDonations.php
@@ -21,6 +21,10 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+/**
+ * Discuses with noel - will implement something like
+ *  https://matchbot-staging.thebiggivetest.org.uk/v1/test-donation-collection-for-date/2024-02-20?secret=tyuyzsdfgdtjysseb
+ */
 #[AsCommand(
     name: 'matchbot:collect-regular-giving',
     description: "Takes money from donors that they have given us advance permission to take.",

--- a/src/Application/Commands/TakeRegularGivingDonations.php
+++ b/src/Application/Commands/TakeRegularGivingDonations.php
@@ -21,10 +21,6 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-/**
- * Discuses with noel - will implement something like
- *  https://matchbot-staging.thebiggivetest.org.uk/v1/test-donation-collection-for-date/2024-02-20?secret=tyuyzsdfgdtjysseb
- */
 #[AsCommand(
     name: 'matchbot:collect-regular-giving',
     description: "Takes money from donors that they have given us advance permission to take.",


### PR DESCRIPTION
To use, point your browser at URL such as

http://localhost:30030/v1/test-donation-collection-for-date/2020-03-01?secret=<secret>

and you should see something like:

```
Big Give Matchbot
============================================================================================

Actual current date: Thu, 09 Jan 2025 18:33:07
Running regular giving collection process with simulated timestamp Sun, 01 Mar 2020 00:00:00 


This endpoint is only available in test/dev environments, not in production.

--------------
matchbot:collect-regular-giving starting!
Simulating running on 2020-03-01 00:00:00

 0 mandates may have donations to create at this time                           

 0 donations are due to have Payment Intent set at this time                    

 0 donations are due to be confirmed at this time                               

matchbot:collect-regular-giving complete!
--------------
```