### PR TITLE
BG2-2797: Replace multiple SF API base URI env vars with single var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,10 +40,7 @@ JWT_DONATION_SECRET=myLocalJwtSecret
 JWT_ID_SECRET=myLocalIdSecret
 
 SALESFORCE_CLIENT_TIMEOUT=15
-SALESFORCE_API_BASE=https://sf-api-staging.thebiggivetest.org.uk/
-SALESFORCE_CAMPAIGN_API=https://sf-api-staging.thebiggivetest.org.uk/campaigns/services/apexrest/v1.0/campaigns
-SALESFORCE_DONATION_API=https://sf-api-staging.thebiggivetest.org.uk/donations/services/apexrest/v1.0/donations
-SALESFORCE_FUND_API=https://sf-api-staging.thebiggivetest.org.uk/funds/services/apexrest/v1.0/funds
+SALESFORCE_API_BASE=https://sf-api-staging.thebiggivetest.org.uk
 SALESFORCE_WEBHOOK_RECEIVER=https://sf-api-staging.thebiggivetest.org.uk/webhooks/services/apexrest/v2.0
 
 SALESFORCE_SECRET_KEY=topsecret

--- a/app/settings.php
+++ b/app/settings.php
@@ -19,15 +19,6 @@ return function (ContainerBuilder $containerBuilder) {
                 'global' => [
                     'timeout' => getenv('SALESFORCE_CLIENT_TIMEOUT'), // in seconds
                 ],
-                'campaign' => [
-                    'baseUri' => getenv('SALESFORCE_CAMPAIGN_API'),
-                ],
-                'donation' => [
-                    'baseUri' => getenv('SALESFORCE_DONATION_API'),
-                ],
-                'fund' => [
-                    'baseUri' => getenv('SALESFORCE_FUND_API'),
-                ],
                 'salesforce' => [
                     'baseUri' => getenv('SALESFORCE_API_BASE'),
                 ],

--- a/integrationTests/IntegrationTest.php
+++ b/integrationTests/IntegrationTest.php
@@ -126,6 +126,9 @@ abstract class IntegrationTest extends TestCase
             'mailer' => [
                 'baseUri' => 'dummy-mailer-base-uri',
             ],
+            'salesforce' => [
+                'baseUri' => 'dummy-salesforce-base-uri',
+            ],
         ];
     }
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -37,6 +37,7 @@
   <php>
     <env name="APP_ENV" value="test" force="true" />
     <env name="BASE_URI" value="https://unit-test-fake-subdomain.thebiggive.org.uk" force="true"/>
+    <env name="SALESFORCE_API_BASE" value="https://unit-test-fake-sf-sub.thebiggive.org.uk" force="true"/>
     <env name="ID_BASE_URI" value="https://unit-test-fake-id-sub.thebiggivetest.org.uk" force="true"/>
     <env name="JWT_DONATION_SECRET" value="unitTestJWTSecret" force="true"/>
     <env name="JWT_ID_SECRET" value="unitTestJWTSecret" force="true"/>

--- a/src/Client/Campaign.php
+++ b/src/Client/Campaign.php
@@ -46,7 +46,7 @@ class Campaign extends Common
      */
     public function getById(string $id, bool $withCache): array
     {
-        $uri = $this->getUri("{$this->getSetting('campaign', 'baseUri')}/$id", $withCache);
+        $uri = $this->getUri("{$this->baseUri()}/$id", $withCache);
         try {
             $response = $this->getHttpClient()->get($uri);
         } catch (RequestException $exception) {
@@ -109,5 +109,10 @@ class Campaign extends Common
         }
 
         return $campaigns;
+    }
+
+    protected function baseUri(): string
+    {
+        return $this->sfApiBaseUrl . '/campaigns/services/apexrest/v1.0/campaigns';
     }
 }

--- a/src/Client/Campaign.php
+++ b/src/Client/Campaign.php
@@ -111,7 +111,7 @@ class Campaign extends Common
         return $campaigns;
     }
 
-    protected function baseUri(): string
+    private function baseUri(): string
     {
         return $this->sfApiBaseUrl . '/campaigns/services/apexrest/v1.0/campaigns';
     }

--- a/src/Client/Common.php
+++ b/src/Client/Common.php
@@ -13,15 +13,34 @@ abstract class Common
 {
     use HashTrait;
 
-    private array $clientSettings;
+    /**
+     * @var array{
+     *     salesforce: array{ baseUri: string},
+     *     global: array{timeout: string},
+     * }
+     */
+    private readonly array $clientSettings;
     private ?Client $httpClient = null;
+    protected readonly string $sfApiBaseUrl;
 
+    /**
+     * @param LoggerInterface $logger
+     *
+     * Suppress psalm issues in this function as Psalm seems to prefer to read the type of the param
+     * rather than the type of the property, and its awkward to type the array based param.
+     *
+     * @psalm-suppress MixedAssignment
+     * @psalm-suppress MixedArrayAccess
+     */
     public function __construct(
         array $settings,
         protected LoggerInterface $logger
     ) {
         $this->clientSettings = $settings['apiClient'];
+        $this->sfApiBaseUrl = $this->clientSettings['salesforce']['baseUri'];
     }
+
+    abstract protected function baseUri(): string;
 
     protected function getSetting(string $service, string $property): string
     {

--- a/src/Client/Common.php
+++ b/src/Client/Common.php
@@ -40,8 +40,6 @@ abstract class Common
         $this->sfApiBaseUrl = $this->clientSettings['salesforce']['baseUri'];
     }
 
-    abstract protected function baseUri(): string;
-
     protected function getSetting(string $service, string $property): string
     {
         return $this->clientSettings[$service][$property];

--- a/src/Client/Donation.php
+++ b/src/Client/Donation.php
@@ -21,10 +21,15 @@ class Donation extends Common
     public function createOrUpdate(DonationUpserted $message): Salesforce18Id
     {
         return $this->postUpdateToSalesforce(
-            $this->getSetting('donation', 'baseUri') . '/' . $message->uuid,
+            $this->baseUri() . '/' . $message->uuid,
             $message->jsonSnapshot,
             $message->uuid,
             'donation',
         );
+    }
+
+    protected function baseUri(): string
+    {
+        return $this->sfApiBaseUrl . '/donations/services/apexrest/v1.0/donations';
     }
 }

--- a/src/Client/Donation.php
+++ b/src/Client/Donation.php
@@ -28,7 +28,7 @@ class Donation extends Common
         );
     }
 
-    protected function baseUri(): string
+    private function baseUri(): string
     {
         return $this->sfApiBaseUrl . '/donations/services/apexrest/v1.0/donations';
     }

--- a/src/Client/Fund.php
+++ b/src/Client/Fund.php
@@ -34,7 +34,7 @@ class Fund extends Common
      */
     public function getForCampaign(string $campaignId): array
     {
-        $response = $this->getHttpClient()->get("{$this->getSetting('campaign', 'baseUri')}/$campaignId/funds");
+        $response = $this->getHttpClient()->get("{$this->baseUri()}/$campaignId/funds");
 
         if ($response->getStatusCode() !== 200) {
             throw new NotFoundException('Campaign not found');
@@ -53,5 +53,10 @@ class Fund extends Common
             'json' => $fundMessage->jsonSnapshot,
             'headers' => $this->getVerifyHeaders(json_encode($fundMessage->jsonSnapshot)),
         ]);
+    }
+
+    protected function baseUri(): string
+    {
+        return $this->baseUri() . '/funds/services/apexrest/v1.0/funds';
     }
 }

--- a/src/Client/Fund.php
+++ b/src/Client/Fund.php
@@ -55,7 +55,7 @@ class Fund extends Common
         ]);
     }
 
-    protected function baseUri(): string
+    private function baseUri(): string
     {
         return $this->baseUri() . '/funds/services/apexrest/v1.0/funds';
     }

--- a/src/Client/Mailer.php
+++ b/src/Client/Mailer.php
@@ -70,7 +70,7 @@ class Mailer extends Common
         return hash_hmac('sha256', trim($body), $this->getSetting('mailer', 'sendSecret'));
     }
 
-    protected function baseUri(): string
+    private function baseUri(): string
     {
         return $this->getSetting('mailer', 'baseUri');
     }

--- a/src/Client/Mailer.php
+++ b/src/Client/Mailer.php
@@ -17,8 +17,7 @@ class Mailer extends Common
     public function sendEmail(array $requestBody): void
     {
         try {
-            $baseUri = $this->getSetting('mailer', 'baseUri');
-            $uri = $baseUri . '/v1/send';
+            $uri = $this->baseUri() . '/v1/send';
             $response = $this->getHttpClient()->post(
                 $uri,
                 [
@@ -69,5 +68,10 @@ class Mailer extends Common
     private function hash(string $body): string
     {
         return hash_hmac('sha256', trim($body), $this->getSetting('mailer', 'sendSecret'));
+    }
+
+    protected function baseUri(): string
+    {
+        return $this->getSetting('mailer', 'baseUri');
     }
 }

--- a/src/Client/Mandate.php
+++ b/src/Client/Mandate.php
@@ -24,10 +24,15 @@ class Mandate extends Common
     public function createOrUpdate(MandateUpserted $message): Salesforce18Id
     {
         return $this->postUpdateToSalesforce(
-            $this->getSetting('salesforce', 'baseUri') . '/donations/services/apexrest/v1.0/mandates/' . $message->uuid,
+            $this->baseUri() . $message->uuid,
             $message->jsonSnapshot,
             $message->uuid,
             'mandate',
         );
+    }
+
+    protected function baseUri(): string
+    {
+        return $this->sfApiBaseUrl . '/donations/services/apexrest/v1.0/mandates/';
     }
 }

--- a/src/Client/Mandate.php
+++ b/src/Client/Mandate.php
@@ -31,7 +31,7 @@ class Mandate extends Common
         );
     }
 
-    protected function baseUri(): string
+    private function baseUri(): string
     {
         return $this->sfApiBaseUrl . '/donations/services/apexrest/v1.0/mandates/';
     }


### PR DESCRIPTION
I did think about whether to merge the Campaign, Donation, Fund and Mandate clients into one, which might also be a good simplification, and would make it easier to pass the shared base URI as a constructor param.