### PR TITLE
DON-1002: Copy donors marketing communcation prefs from regular givin…

### DIFF
--- a/src/Domain/RegularGivingMandate.php
+++ b/src/Domain/RegularGivingMandate.php
@@ -221,15 +221,18 @@ class RegularGivingMandate extends SalesforceWriteProxy
         bool $requireActiveMandate = true,
         \DateTimeImmutable $expectedActivationDate = null,
     ): Donation {
+        // comms prefs below (charityComms, championComms, optInTbgEmail) are all set to null, as it's only the 1st
+        // donation in the mandate that carries the donor's chosen marketing comms preferences to Salesforce.
+
         $donation = new Donation(
             amount: $this->donationAmount->toNumericString(),
             currencyCode: $this->donationAmount->currency->isoCode(),
             paymentMethodType: PaymentMethodType::Card,
             campaign: $campaign,
-            charityComms: false,
-            championComms: false,
+            charityComms: null,
+            championComms: null,
             pspCustomerId: $donor->stripeCustomerId->stripeCustomerId,
-            optInTbgEmail: false,
+            optInTbgEmail: null,
             donorName: $donor->donorName,
             emailAddress: $donor->emailAddress,
             countryCode: $donor->getBillingCountryCode(),
@@ -374,15 +377,17 @@ class RegularGivingMandate extends SalesforceWriteProxy
     {
         Assertion::same($campaign->getSalesforceId(), $this->campaignId);
 
+        // As this is the first donation in the mandate we give it a copy of the donor's Big Give and Charity comms
+        // preferences so that SF can pick them up.
         return new Donation(
             amount: $this->donationAmount->toNumericString(),
             currencyCode: $this->donationAmount->currency->isoCode(),
             paymentMethodType: PaymentMethodType::Card,
             campaign: $campaign,
-            charityComms: false,
-            championComms: false,
+            charityComms: $this->charityComms,
+            championComms: null,
             pspCustomerId: $donor->stripeCustomerId->stripeCustomerId,
-            optInTbgEmail: false,
+            optInTbgEmail: $this->tbgComms,
             donorName: $donor->donorName,
             emailAddress: $donor->emailAddress,
             countryCode: $donor->getBillingCountryCode(),

--- a/src/Domain/RegularGivingMandate.php
+++ b/src/Domain/RegularGivingMandate.php
@@ -172,8 +172,6 @@ class RegularGivingMandate extends SalesforceWriteProxy
             'contactUuid' => $this->donorId->id,
             'giftAid' => $this->giftAid,
             'donor' => $donor->toSfApiModel(),
-            'optInCharityEmail' => $this->charityComms,
-            'optInTbgEmail' => $this->tbgComms,
         ];
     }
 

--- a/tests/Domain/RegularGivingMandateTest.php
+++ b/tests/Domain/RegularGivingMandateTest.php
@@ -228,8 +228,6 @@ class RegularGivingMandateTest extends TestCase
               "dayOfMonth":12,
               "status":"Active",
               "activeFrom": "2024-08-12T06:00:00+00:00",
-              "optInCharityEmail": false,
-              "optInTbgEmail": false,
               "donor": {
                 "firstName": "Fred",
                 "lastName": "Do",


### PR DESCRIPTION
…g mandate to 1st donation linked to mandate

This should mean it gets picked at SF as it would for an ad-hoc donation and we won't have to change anything there.

Also setting the prefs on later donations in the mandate to null so that when those donations are pushed to SF they don't update any comms preferences - we wouldn't want to update preferences in the following months as it may no longer reflect the user's latest wishes.