### PR TITLE
DON-955: Make attempt to create regular giving mandate for closed cam…

### DIFF
--- a/src/Application/Actions/RegularGivingMandate/Create.php
+++ b/src/Application/Actions/RegularGivingMandate/Create.php
@@ -12,6 +12,7 @@ use MatchBot\Application\Environment;
 use MatchBot\Application\HttpModels\MandateCreate;
 use MatchBot\Application\Security\Security;
 use MatchBot\Domain\CampaignRepository;
+use MatchBot\Domain\DomainException\CampaignNotOpen;
 use MatchBot\Domain\DomainException\DonationNotCollected;
 use MatchBot\Domain\DomainException\NotFullyMatched;
 use MatchBot\Domain\DomainException\WrongCampaignType;
@@ -133,6 +134,13 @@ class Create extends Action
                 reduceSeverity: false,
                 errorType: ActionError::INSUFFICIENT_MATCH_FUNDS,
                 errorData: ['maxMatchable' => $maxMatchable],
+            );
+        } catch (CampaignNotOpen $e) {
+            return $this->validationError(
+                $response,
+                logMessage: $e->getMessage(),
+                publicMessage: "Sorry, the {$campaign->getCampaignName()} campaign is not open at this time.",
+                reduceSeverity: false,
             );
         } catch (DonationNotCollected $e) {
             return $this->validationError(


### PR DESCRIPTION
…paign a 400 error not 500

This partly related to DON-955 but actually needed more widely, to stop alarms we're getting now in staging alarms chanel and also for things like donors attempting to donate before a campaign is open.

The microcopy introduced probably could be better but few people should see it - once we have controls in FE to stop people attempting to make do this for a close campaign it should only appear to people who load the form before a campaign is closed and then attempt to submit after it closes.