### PR TITLE
Allow collecting regular giving donation after campaign close

### DIFF
--- a/src/Application/Commands/TakeRegularGivingDonations.php
+++ b/src/Application/Commands/TakeRegularGivingDonations.php
@@ -8,7 +8,6 @@ use Assert\AssertionFailedException;
 use DI\Container;
 use Doctrine\ORM\EntityManagerInterface;
 use MatchBot\Application\Environment;
-use MatchBot\Domain\DomainException\CampaignNotOpen;
 use MatchBot\Domain\DomainException\MandateNotActive;
 use MatchBot\Domain\DomainException\RegularGivingCollectionEndPassed;
 use MatchBot\Domain\DomainException\RegularGivingDonationToOldToCollect;
@@ -110,7 +109,7 @@ class TakeRegularGivingDonations extends LockingCommand
                 } else {
                     $io->writeln("no donation created for {$mandate} as collection end date passed");
                 }
-            } catch (AssertionFailedException | CampaignNotOpen | WrongCampaignType $e) {
+            } catch (AssertionFailedException | WrongCampaignType $e) {
                 $io->error($e->getMessage());
                 $this->logger->error($e->getMessage());
             }
@@ -177,7 +176,7 @@ class TakeRegularGivingDonations extends LockingCommand
     }
 
     /**
-     * @throws CampaignNotOpen|WrongCampaignType|AssertionFailedException
+     * @throws WrongCampaignType|AssertionFailedException
      */
     private function makeDonationForMandate(RegularGivingMandate $mandate): ?Donation
     {

--- a/src/Domain/Campaign.php
+++ b/src/Domain/Campaign.php
@@ -59,9 +59,19 @@ class Campaign extends SalesforceReadProxy
     #[ORM\Column(type: 'string')]
     protected string $name;
 
+    /**
+     * The first moment when donors should be able to make a donation, or a regular giving mandate
+     **/
     #[ORM\Column(type: 'datetime')]
     protected DateTimeInterface $startDate;
 
+    /**
+     * The last moment when donors should be able to make an ad-hoc donation, or create a new
+     * regular giving mandate.
+     *
+     * @see self::$regularGivingCollectionEnd
+     * @var DateTimeInterface
+     */
     #[ORM\Column(type: 'datetime')]
     protected DateTimeInterface $endDate;
 
@@ -92,6 +102,9 @@ class Campaign extends SalesforceReadProxy
      * Date at which we want to stop collecting payments for this regular giving campaign. Must be null if
      * this is not regular giving, will also be null if this is regular giving and we plan to continue collecting
      * donations indefinitely.
+     *
+     * Creating new mandates may have stopped at an earlier date:
+     * @see self::$endDate
      */
     #[ORM\Column(nullable: true)]
     protected ?\DateTimeImmutable $regularGivingCollectionEnd;
@@ -357,7 +370,7 @@ class Campaign extends SalesforceReadProxy
      */
     public function checkIsReadyToAcceptDonation(Donation $donation, \DateTimeImmutable $at): void
     {
-        if (!$this->isOpen($at)) {
+        if (! $this->isRegularGiving() && !$this->isOpen($at)) {
             throw new CampaignNotOpen("Campaign {$this->getSalesforceId()} is not open");
         }
 


### PR DESCRIPTION
Dealing with alarms seen on slack today. For regular giving campaign close should only stop *new* regular giving signups, not get in the way way of us collecting donations based on existing mandates. We only stop that when \MatchBot\Domain\Campaign::$regularGivingCollectionEnd is past.