### PR TITLE
DON-1119: Allow donor to complete 3D Secure authentication for fi…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,19 @@ services:
     networks:
       - matchbot
 
+  app-cron:
+    image: thebiggive/php:dev-8.3
+    command: bash -c 'while sleep 60; do (./matchbot matchbot:tick || echo "matchbot tick failed"); done'
+    volumes:
+      - .:/var/www/html
+    env_file:
+      - .env
+    depends_on:
+      - db
+      - redis
+    networks:
+      - matchbot
+
   db:
     image: mysql:8.0
     platform: linux/amd64

--- a/integrationTests/CallFrequentCommandsTest.php
+++ b/integrationTests/CallFrequentCommandsTest.php
@@ -6,6 +6,7 @@ use Aws\CloudWatch\CloudWatchClient;
 use MatchBot\Application\Commands\CallFrequentTasks;
 use MatchBot\Application\Commands\CancelStaleDonationFundTips;
 use MatchBot\Application\Commands\ExpireMatchFunds;
+use MatchBot\Application\Commands\ExpirePendingMandates;
 use MatchBot\Application\Commands\SendStatistics;
 use MatchBot\Application\Environment;
 use MatchBot\Domain\DonationRepository;
@@ -41,6 +42,8 @@ class CallFrequentCommandsTest extends IntegrationTest
             'matchbot:expire-match-funds starting!',
             'Released 0 donations\' matching',
             'matchbot:expire-match-funds complete!',
+            'matchbot:expire-pending-mandates starting!',
+            'matchbot:expire-pending-mandates complete!',
             'matchbot:cancel-stale-donation-fund-tips starting!',
             'matchbot:cancel-stale-donation-fund-tips complete!',
             'matchbot:tick complete!',
@@ -66,6 +69,8 @@ class CallFrequentCommandsTest extends IntegrationTest
             ),
             $this->getService(ExpireMatchFunds::class),
             $this->getService(CancelStaleDonationFundTips::class),
+            $this->getService(ExpirePendingMandates::class),
+
         ];
 
         foreach ($commands as $command) {

--- a/matchbot-cli.php
+++ b/matchbot-cli.php
@@ -9,6 +9,7 @@ use MatchBot\Application\Commands\ClaimGiftAid;
 use MatchBot\Application\Commands\Command;
 use MatchBot\Application\Commands\DeleteStalePaymentDetails;
 use MatchBot\Application\Commands\ExpireMatchFunds;
+use MatchBot\Application\Commands\ExpirePendingMandates;
 use MatchBot\Application\Commands\HandleOutOfSyncFunds;
 use MatchBot\Application\Commands\LockingCommand;
 use MatchBot\Application\Commands\PullIndividualCampaignFromSF;
@@ -46,14 +47,15 @@ $commands = array_map($psr11App->get(...), [
 
     DeleteStalePaymentDetails::class,
     ExpireMatchFunds::class,
+    ExpirePendingMandates::class,
     HandleOutOfSyncFunds::class,
-    PullIndividualCampaignFromSF::class,
 
+    PullIndividualCampaignFromSF::class,
     PullMetaCampaignFromSF::class,
     PushDonations::class,
     RedistributeMatchFunds::class,
-    ResetMatching::class,
 
+    ResetMatching::class,
     RetrospectivelyMatch::class,
     ScheduledOutOfSyncFundsCheck::class,
     SendStatistics::class,

--- a/src/Application/Actions/Donations/Confirm.php
+++ b/src/Application/Actions/Donations/Confirm.php
@@ -9,6 +9,7 @@ use MatchBot\Application\Assertion;
 use MatchBot\Application\LazyAssertionException;
 use MatchBot\Application\Messenger\DonationUpserted;
 use MatchBot\Client\NotFoundException;
+use MatchBot\Domain\DomainException\PaymentIntentNotSucceeded;
 use MatchBot\Domain\Donation;
 use MatchBot\Domain\DonationRepository;
 use MatchBot\Domain\DonationService;
@@ -146,6 +147,8 @@ EOF
                     'code' => $exception->getStripeCode(),
                 ],
             ], 500);
+        } catch (PaymentIntentNotSucceeded $_e) {
+            // no-op - in this case we let the frontend handle any further action required
         }
 
         // Assuming Stripe calls worked, commit any changes that `deriveFees()` made to the EM-tracked `$donation`.

--- a/src/Application/Actions/Donations/Confirm.php
+++ b/src/Application/Actions/Donations/Confirm.php
@@ -148,7 +148,9 @@ EOF
                 ],
             ], 500);
         } catch (PaymentIntentNotSucceeded $_e) {
-            // no-op - in this case we let the frontend handle any further action required
+            // no-op - in this case we return the unsuccessful PI to the FE just like we would a successful one.
+            // FE handles it.
+            $updatedIntent = $_e->paymentIntent;
         }
 
         // Assuming Stripe calls worked, commit any changes that `deriveFees()` made to the EM-tracked `$donation`.

--- a/src/Application/Actions/RegularGivingMandate/Create.php
+++ b/src/Application/Actions/RegularGivingMandate/Create.php
@@ -164,6 +164,7 @@ class Create extends Action
             \assert($intent->status === PaymentIntent::STATUS_REQUIRES_ACTION);
 
             return new JsonResponse([
+                'mandate' => $exception->mandate?->toFrontEndApiModel($charity, $this->now),
                 'paymentIntent' => [
                     'status' => $intent->status,
                     'client_secret' =>  $intent->client_secret
@@ -186,6 +187,6 @@ class Create extends Action
         // when the mandate is active.
 
         $this->em->flush();
-        return new JsonResponse($mandate->toFrontEndApiModel($charity, $this->now), 201);
+        return new JsonResponse(['mandate' => $mandate->toFrontEndApiModel($charity, $this->now)], 201);
     }
 }

--- a/src/Application/Commands/CallFrequentTasks.php
+++ b/src/Application/Commands/CallFrequentTasks.php
@@ -7,6 +7,7 @@ namespace MatchBot\Application\Commands;
 use MatchBot\Application\Assertion;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -17,18 +18,29 @@ use Symfony\Component\Console\Output\OutputInterface;
 )]
 class CallFrequentTasks extends LockingCommand
 {
+    public const array COMMAND_CLASSES = [
+        SendStatistics::class,
+        ExpireMatchFunds::class,
+        ExpirePendingMandates::class,
+        CancelStaleDonationFundTips::class,
+    ];
+
     protected function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $app = $this->getApplication();
         \assert($app instanceof Application);
 
-        $commandNames = [
-            'matchbot:send-statistics',
-            'matchbot:expire-match-funds',
-            'matchbot:cancel-stale-donation-fund-tips',
-        ];
+        $commands = array_map(/**
+         * @param class-string<Command> $commandClass
+         */
+            function (string $commandClass) use ($app) {
+                $name = $commandClass::getDefaultName();
+                \assert($name !== null);
 
-        $commands = array_map($app->find(...), $commandNames);
+                return $app->find($name);
+            },
+            self::COMMAND_CLASSES
+        );
         Assertion::allIsInstanceOf($commands, Command::class);
 
         foreach ($commands as $command) {

--- a/src/Application/Commands/ExpirePendingMandates.php
+++ b/src/Application/Commands/ExpirePendingMandates.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Application\Commands;
+
+use MatchBot\Domain\DonationRepository;
+use MatchBot\Domain\DonationService;
+use MatchBot\Domain\MandateCancellationType;
+use MatchBot\Domain\RegularGivingMandateRepository;
+use MatchBot\Domain\RegularGivingService;
+use Psr\Clock\ClockInterface;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'matchbot:expire-pending-mandates',
+    description: "Cancels regular giving mandates left pending (e.g. while donor considered 3DS authentication)",
+)]
+class ExpirePendingMandates extends LockingCommand
+{
+    public function __construct(
+        private RegularGivingMandateRepository $regularGivingMandateRepository,
+        private RegularGivingService $regularGivingService,
+        private ClockInterface $clock,
+    ) {
+        parent::__construct();
+    }
+
+    protected function doExecute(InputInterface $input, OutputInterface $output): int
+    {
+        $fiveMinutes = new \DateInterval('PT5M');
+        $now = $this->clock->now();
+
+        $mandatesToCancel = $this->regularGivingMandateRepository->findAllPendingSinceBefore(
+            $now->sub($fiveMinutes)
+        );
+
+        foreach ($mandatesToCancel as $mandate) {
+            $this->regularGivingService->cancelMandate(
+                $mandate,
+                'pending mandate expired at ' . $now->format('c') . ", donor may have walked away from 3DS",
+                MandateCancellationType::FirstDonationUnsuccessful
+            );
+        };
+
+        return 0;
+    }
+}

--- a/src/Application/Commands/SendStatistics.php
+++ b/src/Application/Commands/SendStatistics.php
@@ -59,13 +59,13 @@ class SendStatistics extends LockingCommand
             $notNullMetrics[] = $completionRate;
         }
 
-        try {
+        if ($this->environment === Environment::Local) {
+            $output->writeln("Skipping stats send to cloudwatch from local dev env");
+        } else {
             $this->cloudWatchClient->putMetricData([
                 'Namespace' => 'TbgMatchBot',
                 'MetricData' => $notNullMetrics,
             ]);
-        } catch (\Throwable $e) {
-            $output->writeln('<error>' . $e->getMessage() . '</error>');
         }
 
         $count = count($notNullMetrics);

--- a/src/Application/Commands/TakeRegularGivingDonations.php
+++ b/src/Application/Commands/TakeRegularGivingDonations.php
@@ -161,7 +161,7 @@ class TakeRegularGivingDonations extends LockingCommand
                     continue;
                 } catch (RegularGivingCollectionEndPassed) {
                     continue;
-                } catch (PaymentIntentNotSucceeded) {
+                } catch (PaymentIntentNotSucceeded $exception) {
                     $io->error('PaymentIntentNotSucceeded, skipping donation: ' . $exception->getMessage());
                     continue;
                 }

--- a/src/Application/Commands/TakeRegularGivingDonations.php
+++ b/src/Application/Commands/TakeRegularGivingDonations.php
@@ -9,6 +9,7 @@ use DI\Container;
 use Doctrine\ORM\EntityManagerInterface;
 use MatchBot\Application\Environment;
 use MatchBot\Domain\DomainException\MandateNotActive;
+use MatchBot\Domain\DomainException\PaymentIntentNotSucceeded;
 use MatchBot\Domain\DomainException\RegularGivingCollectionEndPassed;
 use MatchBot\Domain\DomainException\RegularGivingDonationToOldToCollect;
 use MatchBot\Domain\DomainException\WrongCampaignType;
@@ -159,6 +160,9 @@ class TakeRegularGivingDonations extends LockingCommand
                     $io->info($exception->getMessage());
                     continue;
                 } catch (RegularGivingCollectionEndPassed) {
+                    continue;
+                } catch (PaymentIntentNotSucceeded) {
+                    $io->error('PaymentIntentNotSucceeded, skipping donation: ' . $exception->getMessage());
                     continue;
                 }
             } catch (\Exception $exception) {

--- a/src/Domain/DoctrineDonationRepository.php
+++ b/src/Domain/DoctrineDonationRepository.php
@@ -185,6 +185,7 @@ class DoctrineDonationRepository extends SalesforceProxyRepository implements Do
             ->innerJoin('d.fundingWithdrawals', 'fw')
             ->where('d.donationStatus IN (:expireWithStatuses)')
             ->andWhere('d.createdAt < :expireBefore')
+            ->andWhere('d.mandate is null')
             ->groupBy('d.id')
             ->setParameter('expireWithStatuses', [DonationStatus::Pending->value, DonationStatus::Cancelled->value])
             ->setParameter('expireBefore', $cutoff)

--- a/src/Domain/DomainException/PaymentIntentNotSucceeded.php
+++ b/src/Domain/DomainException/PaymentIntentNotSucceeded.php
@@ -2,10 +2,14 @@
 
 namespace MatchBot\Domain\DomainException;
 
+use MatchBot\Domain\RegularGivingMandate;
 use Stripe\PaymentIntent;
 
 class PaymentIntentNotSucceeded extends \Exception
 {
+    /** Todo - remove this property and probably whole exception, use return values instead of throwing. */
+    public ?RegularGivingMandate $mandate = null;
+
     public function __construct(
         public readonly PaymentIntent $paymentIntent,
         string $message,

--- a/src/Domain/DomainException/PaymentIntentNotSucceeded.php
+++ b/src/Domain/DomainException/PaymentIntentNotSucceeded.php
@@ -4,7 +4,8 @@ namespace MatchBot\Domain\DomainException;
 
 use Stripe\PaymentIntent;
 
-class PaymentIntentNotSucceeded extends \Exception {
+class PaymentIntentNotSucceeded extends \Exception
+{
     public function __construct(
         public readonly PaymentIntent $paymentIntent,
         string $message,

--- a/src/Domain/DomainException/PaymentIntentNotSucceeded.php
+++ b/src/Domain/DomainException/PaymentIntentNotSucceeded.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace MatchBot\Domain\DomainException;
+
+use Stripe\PaymentIntent;
+
+class PaymentIntentNotSucceeded extends \Exception {
+    public function __construct(
+        public readonly PaymentIntent $paymentIntent,
+        string $message,
+    ) {
+        parent::__construct($message, 0, null);
+    }
+}

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -221,6 +221,9 @@ class Donation extends SalesforceWriteProxy
      * Null only iff this is a one-off, non regular-giving donation.
      *
      * @psalm-suppress PossiblyUnusedProperty - used in DQL
+     *
+     * // if this is 1 then when the donation is collected {@see DonationService::updateDonationStatusFromSucessfulCharge}
+     * we can do the needful of activating the mandate.
      */
     #[ORM\Column(type: 'integer', nullable: true)]
     protected ?int $mandateSequenceNumber = null;
@@ -1400,8 +1403,8 @@ class Donation extends SalesforceWriteProxy
     }
 
     /**
-     * Updates status to `Cancelled`. Note that in most cases you will need to do more than just update the status,
-     * so consider calling DonationService::cancel() rather than this directly.
+     * Updates status to {@see DonationStatus::Cancelled}. Note that in most cases you will need to do more than just update the status,
+     * so consider calling {@see DonationService::cancel()} rather than this directly.
      */
     public function cancel(): void
     {

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -221,9 +221,6 @@ class Donation extends SalesforceWriteProxy
      * Null only iff this is a one-off, non regular-giving donation.
      *
      * @psalm-suppress PossiblyUnusedProperty - used in DQL
-     *
-     * // if this is 1 then when the donation is collected {@see DonationService::updateDonationStatusFromSucessfulCharge}
-     * we can do the needful of activating the mandate.
      */
     #[ORM\Column(type: 'integer', nullable: true)]
     protected ?int $mandateSequenceNumber = null;

--- a/src/Domain/DonationService.php
+++ b/src/Domain/DonationService.php
@@ -673,7 +673,6 @@ class DonationService
                 $paymentIntent,
                 "Payment Intent not succeded, status is {$paymentIntent->status}",
             );
-
         }
     }
 

--- a/src/Domain/DonationService.php
+++ b/src/Domain/DonationService.php
@@ -541,7 +541,7 @@ class DonationService
                 );
 
                 if ($returnError) {
-                    throw new CouldNotCancelStripePaymentIntent();
+                    throw new CouldNotCancelStripePaymentIntent(previous: $exception);
                 } // Else likely double-send -> fall through to normal return the donation as-is.
             }
         }

--- a/src/Domain/DonationService.php
+++ b/src/Domain/DonationService.php
@@ -315,7 +315,6 @@ class DonationService
      */
     public function enrollNewDonation(Donation $donation, bool $attemptMatching): void
     {
-
         $campaign = $donation->getCampaign();
 
         $at = new \DateTimeImmutable();
@@ -797,6 +796,7 @@ class DonationService
     /**
      * Checks that a campaign has a Stripe Account ID and if not attempts to find one in SF.
      *
+     * @throws StripeAccountIdNotSetForAccount
      * @todo consider if any of this method is required - or if we do or can ensure that Stripe Account ID is always
      * set in matchbot before the donation is attempted.
      */

--- a/src/Domain/DonationService.php
+++ b/src/Domain/DonationService.php
@@ -336,7 +336,7 @@ class DonationService
 
         // Regular Giving enrolls donations with `DonationStatus::PreAuthorized`, which get Payment Intents later instead.
         if ($donation->getPsp() === 'stripe' && $donation->getDonationStatus() === DonationStatus::Pending) {
-            $this->loadCampaignsStripeId($campaign, $donation);
+            $this->loadCampaignsStripeId($campaign);
             $this->createPaymentIntent($donation);
         }
 
@@ -800,7 +800,7 @@ class DonationService
      * @todo consider if any of this method is required - or if we do or can ensure that Stripe Account ID is always
      * set in matchbot before the donation is attempted.
      */
-    private function loadCampaignsStripeId(Campaign $campaign, Donation $donation): void
+    private function loadCampaignsStripeId(Campaign $campaign): void
     {
         $stripeAccountId = $campaign->getCharity()->getStripeAccountId();
         if ($stripeAccountId === null || $stripeAccountId === '') {
@@ -816,9 +816,6 @@ class DonationService
                 ));
                 throw new StripeAccountIdNotSetForAccount();
             }
-
-            // Else we found new Stripe info and can proceed
-            $donation->setCampaign($campaign);
         }
     }
 }

--- a/src/Domain/DonationService.php
+++ b/src/Domain/DonationService.php
@@ -482,6 +482,7 @@ class DonationService
      *
      * Call this from inside a transaction and with a locked donation to avoid double releasing funds associated with
      * the donation.
+     * @throws CouldNotCancelStripePaymentIntent
      */
     public function cancel(Donation $donation): void
     {

--- a/src/Domain/RegularGivingMandateRepository.php
+++ b/src/Domain/RegularGivingMandateRepository.php
@@ -4,6 +4,7 @@ namespace MatchBot\Domain;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
+use MatchBot\Application\Assertion;
 use Ramsey\Uuid\UuidInterface;
 
 /**
@@ -118,5 +119,26 @@ class RegularGivingMandateRepository
             ];
         },
             $mandates));
+    }
+
+    /**
+     * @return list<RegularGivingMandate>
+     */
+    public function findAllPendingSinceBefore(\DateTimeImmutable $latestCreationDate): array
+    {
+        $pending = MandateStatus::Pending->value;
+
+        $query = $this->em->createQuery(<<<DQL
+                SELECT r FROM MatchBot\Domain\RegularGivingMandate r 
+                WHERE r.status = '{$pending}'
+                AND r.createdAt <= :latestCreationDate
+            DQL
+        );
+        $query->setParameter('latestCreationDate', $latestCreationDate);
+        $query->setMaxResults(20);
+
+        /** @var list<RegularGivingMandate> $mandates */
+        $mandates = $query->getResult();
+        return $mandates;
     }
 }

--- a/src/Domain/RegularGivingService.php
+++ b/src/Domain/RegularGivingService.php
@@ -399,6 +399,7 @@ readonly class RegularGivingService
      *
      * @param RegularGivingMandate $mandate - must have been persisted, i.e. have an ID set.
      * @throws NonCancellableStatus
+     * @throws CouldNotCancelStripePaymentIntent
      */
     public function cancelMandate(
         RegularGivingMandate $mandate,
@@ -419,11 +420,7 @@ readonly class RegularGivingService
         );
 
         foreach ($cancellableDonations as $donation) {
-            try {
-                $this->donationService->cancel($donation); // could not cancel
-            } catch (CouldNotCancelStripePaymentIntent $exception) {
-                // no-op
-            }
+            $this->donationService->cancel($donation);
         }
 
         $this->entityManager->flush();

--- a/src/Domain/RegularGivingService.php
+++ b/src/Domain/RegularGivingService.php
@@ -111,8 +111,6 @@ readonly class RegularGivingService
             $donor->setBillingPostcode($billingPostCode);
         }
 
-        this.stripe.handleNextAction
-
         $donor->assertHasRequiredInfoForRegularGiving();
 
         $mandate = new RegularGivingMandate(

--- a/src/Domain/RegularGivingService.php
+++ b/src/Domain/RegularGivingService.php
@@ -184,7 +184,7 @@ readonly class RegularGivingService
             try {
                 $methodId = $this->confirmWithNewPaymentMethod($firstDonation, $confirmationTokenId);
             } catch (PaymentIntentNotSucceeded $e) {
-                $intent = $e->paymentIntent;
+                throw $e;
                 // this is where things get more complicated - we need to return the intent to the client so they
                 // can call `stripe.handleNextAction` if required, and then wait for a callback from Stripe to tell
                 // us if the intent eventually succeeds. Given that it might be simpler to always stop and wait

--- a/src/Domain/RegularGivingService.php
+++ b/src/Domain/RegularGivingService.php
@@ -195,6 +195,7 @@ readonly class RegularGivingService
             }
         } catch (PaymentIntentNotSucceeded $e) {
             $this->entityManager->flush();
+            $e->mandate = $mandate;
             if ($e->paymentIntent->status === PaymentIntent::STATUS_REQUIRES_ACTION) {
                 throw $e;
             }

--- a/tests/Application/Actions/Hooks/StripePaymentsUpdateTest.php
+++ b/tests/Application/Actions/Hooks/StripePaymentsUpdateTest.php
@@ -15,6 +15,8 @@ use MatchBot\Domain\DonationRepository;
 use MatchBot\Domain\DonationService;
 use MatchBot\Domain\DonationStatus;
 use MatchBot\Domain\DonorAccountRepository;
+use MatchBot\Domain\RegularGivingMandateRepository;
+use MatchBot\Domain\RegularGivingService;
 use MatchBot\Tests\Domain\InMemoryDonationRepository;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -40,6 +42,7 @@ class StripePaymentsUpdateTest extends StripeTest
         \assert($container instanceof Container);
         $container->set(EntityManagerInterface::class, $this->createStub(EntityManagerInterface::class));
         $container->set(CampaignRepository::class, $this->createStub(CampaignRepository::class));
+        $container->set(RegularGivingMandateRepository::class, $this->createStub(RegularGivingMandateRepository::class));
 
         $this->donationRepository = new InMemoryDonationRepository();
         $container->set(DonationRepository::class, $this->donationRepository);

--- a/tests/Domain/DonationServiceTest.php
+++ b/tests/Domain/DonationServiceTest.php
@@ -274,10 +274,15 @@ class DonationServiceTest extends TestCase
             'application_fee_amount' => '52',
         ])->shouldBeCalledOnce();
 
+        $paymentIntent = new PaymentIntent($paymentIntentId);
+        $paymentIntent->status = PaymentIntent::STATUS_SUCCEEDED;
+
         $this->stripeProphecy->confirmPaymentIntent($paymentIntentId, [
             'confirmation_token' => $confirmationTokenId->stripeConfirmationTokenId,
             'capture_method' => 'automatic',
-        ])->shouldBeCalledOnce();
+        ])
+            ->willReturn($paymentIntent)
+            ->shouldBeCalledOnce();
 
         // act
         $this->getDonationService()->confirmOnSessionDonation($donation, $confirmationTokenId);


### PR DESCRIPTION
I think this is good to merge as-is, although there's some more stuff we could do:

- Tidy up by never activating a mandate during the confirm request from frontend, and relying only on activation based on charge event from Stripe. We have to be able to do the latter for 3DS mandates so may as well do for all. That also means we can remove the new exception and just use return values.

- Add controller that FE can use to cancel the mandate when 3DS fails. In theory it could use `\MatchBot\Application\Actions\RegularGivingMandate\Cancel` but I think it's better to keep that for cancellation explicitly invoked by donor after mandate fully activated.

- Auto cancel pending mandate when same donor requests a new mandate for same campaign. May do this as part of a separate upcoming ticket.

- Decide if we're OK with updating the home address & postcode of a donor based on a new mandate even if they fail or walk away from 3DS authentication. I think it's fine to update it and quite a bit more work to have both the new and old details persisted during the time they're looking at the 3DS screen.

- Decide if we're happy with 5 minutes as the limit for a donor to complete 3DS authentication

- Add some tests.