### PR TITLE
BG2-2774: Fix lower case currency code causing 500 error

### DIFF
--- a/src/Domain/Currency.php
+++ b/src/Domain/Currency.php
@@ -14,17 +14,18 @@ enum Currency: string
     case CAD = 'CAD';
     case SEK = 'SEK';
 
-    public static function fromIsoCode(mixed $isoCode): self
+    public static function fromIsoCode(string $isoCode): self
     {
         Assertion::length($isoCode, 3);
         Assertion::alnum($isoCode);
+        $isoCode = strtoupper($isoCode);
 
         // other currencies have some tests but are not fully supported
         if (! defined('RUNNING_UNIT_TESTS') && $isoCode !== 'GBP') {
             throw new \UnexpectedValueException("Unexpected Currency ISO Code " . $isoCode);
         }
 
-        return self::tryFrom(strtoupper($isoCode)) ??
+        return self::tryFrom($isoCode) ??
             throw new \UnexpectedValueException("Unexpected Currency ISO Code " . $isoCode);
     }
 


### PR DESCRIPTION
See comments on ticket today. Stripe sends the iso code as lower case.