### PR TITLE
Regular giving fix: Find preauthorized donations to confirm without t…

### DIFF
--- a/src/Domain/DoctrineDonationRepository.php
+++ b/src/Domain/DoctrineDonationRepository.php
@@ -766,7 +766,6 @@ class DoctrineDonationRepository extends SalesforceProxyRepository implements Do
             SELECT donation from Matchbot\Domain\Donation donation JOIN donation.mandate mandate
             WHERE donation.donationStatus = '$preAuthorized'
             AND mandate.status = '$active'
-            AND donation.transactionId is not null
             AND donation.preAuthorizationDate <= :atDateTime
         DQL
         );


### PR DESCRIPTION
…ransaction IDs

Since some time we haven't been creating transaction IDs (i.e. payment intents) for preauthorized donations until we're ready to confirm, since Stripe doesn't support holding payment intents for much more than a few hours.