### PR TITLE
MAT-400: Fix ORM crash on null embeddable property

### DIFF
--- a/src/Domain/CampaignRepository.php
+++ b/src/Domain/CampaignRepository.php
@@ -340,10 +340,10 @@ class CampaignRepository extends SalesforceReadProxyRepository
      *           country: ?string,
      *           postalCode: ?string} $postalAddress
      */
-    private function arrayToPostalAddress(?array $postalAddress): ?PostalAddress
+    private function arrayToPostalAddress(?array $postalAddress): PostalAddress
     {
         if (is_null($postalAddress)) {
-            return null;
+            return PostalAddress::null();
         }
 
         $postalAddress = array_map(
@@ -356,7 +356,7 @@ class CampaignRepository extends SalesforceReadProxyRepository
         if (is_null($postalAddress['line1'])) {
             Assertion::allNull($postalAddress);
 
-            return null;
+            return PostalAddress::null();
         }
 
         return PostalAddress::of(

--- a/src/Domain/Charity.php
+++ b/src/Domain/Charity.php
@@ -75,7 +75,7 @@ class Charity extends SalesforceReadProxy
     protected ?string $phoneNumber = null;
 
     #[ORM\Embedded(columnPrefix: 'address_')]
-    protected ?PostalAddress $postalAddress = null;
+    protected PostalAddress $postalAddress;
 
     /**
      * @var string
@@ -154,7 +154,7 @@ class Charity extends SalesforceReadProxy
             rawData: $rawData,
             time: new \DateTime('now'),
             phoneNumber: $phoneNumber,
-            address: $address,
+            address: $address ?? PostalAddress::null(),
         );
     }
 
@@ -263,8 +263,6 @@ class Charity extends SalesforceReadProxy
 
     /**
      *
-     * @param PostalAddress|null $address
-     * @param string|null $phoneNumber
      * @param array<string,mixed> $rawData Data about the charity as received directly from SF.
      *
      *@throws \UnexpectedValueException if $giftAidOnboardingStatus is not listed in self::POSSIBLE_GIFT_AID_STATUSES
@@ -281,7 +279,7 @@ class Charity extends SalesforceReadProxy
         array $rawData,
         DateTime $time,
         ?string $phoneNumber,
-        ?PostalAddress $address,
+        PostalAddress $address,
     ): void {
         $statusUnexpected = !is_null($giftAidOnboardingStatus)
             && !in_array($giftAidOnboardingStatus, self::POSSIBLE_GIFT_AID_STATUSES, true);
@@ -409,7 +407,7 @@ class Charity extends SalesforceReadProxy
         return $string;
     }
 
-    public function getPostalAddress(): ?PostalAddress
+    public function getPostalAddress(): PostalAddress
     {
         return $this->postalAddress;
     }

--- a/src/Domain/DonationNotifier.php
+++ b/src/Domain/DonationNotifier.php
@@ -76,7 +76,7 @@ class DonationNotifier
             'charityWebsite' => $charity->getWebsiteUri()?->__toString(),
 
             'charityPhoneNumber' => $charity->getPhoneNumber(),
-            'charityPostalAddress' => $charity->getPostalAddress()?->format(),
+            'charityPostalAddress' => $charity->getPostalAddress()->format(),
 
             // There are other params that are currently sent from SF but not officially required by mailer.
             // These should be added before this function is used in production, but the data for them is not yet

--- a/src/Domain/PostalAddress.php
+++ b/src/Domain/PostalAddress.php
@@ -9,10 +9,18 @@ use MatchBot\Application\Assertion;
 /**
  * Value object for convenience and organisation but with very minimal validation since data is
  * currently all entered via Salesforce so we can't throw back to the UI for any bad data.
+ *
+ * Allows all properties to be null as I think Doctrine won't allow the entire object to be replaced with null
  */
 #[Embeddable]
 readonly class PostalAddress
 {
+    #[Column(nullable: true)] public ?string $line1;
+    #[Column(nullable: true)] public ?string $line2;
+    #[Column(nullable: true)] public ?string $city;
+    #[Column(nullable: true)] public ?string $postalCode;
+    #[Column(nullable: true)] public ?string $country;
+
     public static function of(
         string $line1,
         ?string $line2,
@@ -24,18 +32,19 @@ readonly class PostalAddress
     }
 
     private function __construct(
-        #[Column(nullable: true)]
-        public string $line1,
-        #[Column(nullable: true)]
-        public ?string $line2,
-        #[Column(nullable: true)]
-        public ?string $city,
-        #[Column(nullable: true)]
-        public ?string $postalCode,
-        #[Column(nullable: true)]
-        public ?string $country,
+        ?string $line1,
+        ?string $line2,
+        ?string $city,
+        ?string $postalCode,
+        ?string $country,
     ) {
-        Assertion::betweenLength($line1, 1, 255);
+        $this->country = $country;
+        $this->postalCode = $postalCode;
+        $this->city = $city;
+        $this->line2 = $line2;
+        $this->line1 = $line1;
+
+        Assertion::nullOrbetweenLength($line1, 1, 255);
         Assertion::nullOrbetweenLength($line2, 1, 255);
         Assertion::nullOrbetweenLength($city, 1, 255);
         Assertion::nullOrbetweenLength($country, 1, 255);
@@ -46,12 +55,24 @@ readonly class PostalAddress
      * For now this follows the implementation in Salesforce - preserving any line breaks present inside the sections
      * but not adding them between. After the SF code is retired we might want to use line breaks between the sections.
      */
-    public function format(): string
+    public function format(): ?string
     {
         $nonBlankSections = array_filter(
             [$this->line1, $this->line2, $this->city, $this->postalCode, $this->country]
         );
 
+        if ($nonBlankSections === []) {
+            return null;
+        }
+
         return implode(", ", $nonBlankSections);
+    }
+
+    /**
+     * Used in place of null to work around ORM / relational DB limitations.
+     */
+    public static function null(): self
+    {
+        return new self(line1: null, line2: null, city: null, postalCode: null, country: null);
     }
 }

--- a/tests/Domain/CharityTest.php
+++ b/tests/Domain/CharityTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MatchBot\Tests\Domain;
 
 use MatchBot\Domain\Charity;
+use MatchBot\Domain\PostalAddress;
 use MatchBot\Tests\TestCase;
 use PHPUnit\Util\Test;
 
@@ -26,7 +27,7 @@ class CharityTest extends TestCase
             rawData: [],
             time: new \DateTime(),
             phoneNumber: null,
-            address: null
+            address: PostalAddress::null(),
         );
 
         $this->assertTrue($charity->getTbgApprovedToClaimGiftAid());
@@ -47,7 +48,7 @@ class CharityTest extends TestCase
             rawData: [],
             time: new \DateTime(),
             phoneNumber: null,
-            address: null
+            address: PostalAddress::null()
         );
 
         $this->assertFalse($charity->getTbgApprovedToClaimGiftAid());
@@ -69,7 +70,7 @@ class CharityTest extends TestCase
             rawData: [],
             time: new \DateTime(),
             phoneNumber: null,
-            address: null
+            address: PostalAddress::null()
         );
 
         $this->assertFalse($charity->getTbgApprovedToClaimGiftAid());
@@ -137,7 +138,7 @@ class CharityTest extends TestCase
             rawData: [],
             time: new \DateTime(),
             phoneNumber: null,
-            address: null,
+            address: PostalAddress::null(),
         );
 
         $this->assertSame($expected, $charity->isTbgClaimingGiftAid());


### PR DESCRIPTION
I think I misinterpreted this in the doctrine docs:

>  In case all fields in the embeddable are nullable, you might want to initialize the embeddable,
>  to avoid getting a null value instead of the embedded object.

I thought they meant if not all fields were nullable it wouldn't be necassary to initialize the embeddable because the ORM would recognise when a non-nullable field was null in the DB and make the entire embeddable null.

But I don't think it is doing anything that clever, looks like it always constructs an instance of the embeddable when hydrating an object, so it can never be null on an entity that's been loaded from the DB. If there's a null in the DB for a non-nullable property then that property doesn't get initialized and the app crashes when it tries to read it.

Don't know if would be better to not use embeddables for something like this that needs to be semantically if not technically nullable.