### PR TITLE
MAT-400: Allow resending donation email to alternate email address

### DIFF
--- a/src/Application/Actions/Donations/ResendDonorThanksNotification.php
+++ b/src/Application/Actions/Donations/ResendDonorThanksNotification.php
@@ -9,10 +9,12 @@ use MatchBot\Client\BadRequestException;
 use MatchBot\Domain\DomainException\DomainRecordNotFoundException;
 use MatchBot\Domain\DonationNotifier;
 use MatchBot\Domain\DonationRepository;
+use MatchBot\Domain\EmailAddress;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\Uuid;
+use Slim\Exception\HttpBadRequestException;
 
 /**
  * For use by the Big Give (using SF as UI) when donors request a duplicate copy of a donation thanks email,
@@ -34,6 +36,24 @@ class ResendDonorThanksNotification extends Action
             throw new DomainRecordNotFoundException('Missing donation ID');
         }
 
+        try {
+            $requestBody = json_decode(
+                $request->getBody()->getContents(),
+                true,
+                512,
+                \JSON_THROW_ON_ERROR
+            );
+        } catch (\JsonException) {
+            throw new HttpBadRequestException($request, 'Cannot parse request body as JSON');
+        }
+        \assert(is_array($requestBody));
+
+        $sendToEmailParam = $requestBody['sendToEmailAddress'] ?? null;
+        \assert(is_string($sendToEmailParam) || is_null($sendToEmailParam));
+        $toEmailAddress = (is_string($sendToEmailParam) && trim($sendToEmailParam) !== '') ?
+            EmailAddress::of($sendToEmailParam) :
+            null;
+
         $donation = $this->donationRepository->findOneByUUID(Uuid::fromString($donationUUID));
         if (!$donation) {
             throw new DomainRecordNotFoundException('Donation not found');
@@ -43,7 +63,7 @@ class ResendDonorThanksNotification extends Action
             throw new BadRequestException('Donation status is not successful');
         }
 
-        $this->donationNotifier->notifyDonorOfDonationSuccess($donation);
+        $this->donationNotifier->notifyDonorOfDonationSuccess($donation, $toEmailAddress);
 
         return new JsonResponse(['message' => 'Notification sent to donor for ' . $donation->__toString()], 200);
     }

--- a/src/Application/Email/EmailMessage.php
+++ b/src/Application/Email/EmailMessage.php
@@ -36,4 +36,13 @@ readonly class EmailMessage
     {
         return new self('donor-donation-success', $emailAddress, $params);
     }
+
+    public function withToAddress(EmailAddress $to): self
+    {
+        return new self(
+            templateKey: $this->templateKey,
+            emailAddress: $to,
+            params: $this->params
+        );
+    }
 }

--- a/src/Domain/DonationNotifier.php
+++ b/src/Domain/DonationNotifier.php
@@ -87,8 +87,23 @@ class DonationNotifier
         ]);
     }
 
-    public function notifyDonorOfDonationSuccess(Donation $donation): void
+    /**
+     * Sends (Or resends) a donation thanks message to the donor of a donation. By default, uses the email
+     * address and all other details as recorded on the donation, but if $to is passed the email is sent
+     * to that address instead.
+     *
+     * @param Donation $donation
+     * @param EmailAddress|null $to
+     * @return void
+     */
+    public function notifyDonorOfDonationSuccess(Donation $donation, ?EmailAddress $to = null): void
     {
-        $this->mailer->send(self::emailMessageForCollectedDonation($donation));
+        $emailMessage = self::emailMessageForCollectedDonation($donation);
+
+        if ($to !== null) {
+            $emailMessage = $emailMessage->withToAddress($to);
+        }
+
+        $this->mailer->send($emailMessage);
     }
 }

--- a/tests/Application/Actions/Donations/ResendDonorThanksNotificationTest.php
+++ b/tests/Application/Actions/Donations/ResendDonorThanksNotificationTest.php
@@ -14,6 +14,7 @@ use MatchBot\Domain\DayOfMonth;
 use MatchBot\Domain\DonationNotifier;
 use MatchBot\Domain\DonationRepository;
 use MatchBot\Domain\DonorAccountRepository;
+use MatchBot\Domain\EmailAddress;
 use MatchBot\Domain\MandateCancellationType;
 use MatchBot\Domain\Money;
 use MatchBot\Domain\PersonId;
@@ -49,10 +50,17 @@ class ResendDonorThanksNotificationTest extends TestCase
 
         $donationRepositoryProphecy->findOneByUUID($donation->getUuid())->willReturn($donation);
 
-        $notifierProphecy->notifyDonorOfDonationSuccess($donation)->shouldBeCalled();
+        $notifierProphecy->notifyDonorOfDonationSuccess(
+            $donation,
+            EmailAddress::of('new-email@example.com')
+        )->shouldBeCalled();
 
         $response = $sut->__invoke(
-            new ServerRequest('POST', '/'),
+            new ServerRequest(
+                'METHOD-not-relevant-for-test-would-be-POST',
+                '/uri-not-relevant-for-test',
+                body: '{"sendToEmailAddress": "new-email@example.com"}'
+            ),
             new Response(),
             ['donationId' => $donation->getUUID()->toString()]
         );


### PR DESCRIPTION
To be used by us for support purposes if e.g. a donor makes a typo when entering their email address.