### PR TITLE
DON-1003: Don't attempt to send donations to Salesforce until after t…

### DIFF
--- a/src/Application/Messenger/DonationUpserted.php
+++ b/src/Application/Messenger/DonationUpserted.php
@@ -11,7 +11,7 @@ use Symfony\Component\Messenger\Bridge\AmazonSqs\MessageGroupAwareInterface;
  */
 class DonationUpserted implements MessageGroupAwareInterface
 {
-    protected function __construct(public string $uuid, public array $jsonSnapshot)
+    protected function __construct(public string $uuid, public array|null $jsonSnapshot)
     {
         Assertion::uuid($this->uuid);
     }

--- a/src/Application/Messenger/DonationUpserted.php
+++ b/src/Application/Messenger/DonationUpserted.php
@@ -22,10 +22,12 @@ class DonationUpserted implements MessageGroupAwareInterface
 
     public static function fromDonation(Donation $donation): self
     {
-        $jsonSnapshot = [
-            ...$donation->toSFApiModel(),
-            self::SNAPSHOT_TAKEN_AT => (new \DateTimeImmutable())->format('c')
-        ];
+        $jsonSnapshot = $donation->toSFApiModel();
+
+        if ($jsonSnapshot !== null) {
+            $jsonSnapshot[self::SNAPSHOT_TAKEN_AT] = (new \DateTimeImmutable())->format('c');
+        }
+
         return new self(
             uuid: $donation->getUuid()->toString(),
             jsonSnapshot: $jsonSnapshot,

--- a/src/Client/Donation.php
+++ b/src/Client/Donation.php
@@ -21,11 +21,16 @@ class Donation extends Common
      * @throws NotFoundException on missing campaign in a sandbox
      * @throws GuzzleException
      */
-    public function createOrUpdate(DonationUpserted $message): Salesforce18Id
+    public function createOrUpdate(DonationUpserted $message): ?Salesforce18Id
     {
+        $jsonSnapshot = $message->jsonSnapshot;
+        if ($jsonSnapshot === null) {
+            return null;
+        }
+
         return $this->postUpdateToSalesforce(
             $this->baseUri() . '/' . $message->uuid,
-            $message->jsonSnapshot,
+            $jsonSnapshot,
             $message->uuid,
             'donation',
         );

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -532,7 +532,11 @@ class Donation extends SalesforceWriteProxy
         }
     }
 
-    public function toSFApiModel(): array
+    /**
+     * @return array|null A representation of the donation suitable for sending to Salesforce, or null if this donation
+     * cannot be represented in SF in its current state.
+     */
+    public function toSFApiModel(): null|array
     {
         $data = [
             ...$this->toFrontEndApiModel(),
@@ -549,8 +553,14 @@ class Donation extends SalesforceWriteProxy
         unset($data['matchReservedAmount']);
 
         if ($this->mandate) {
+            $mandateSalesforceId = $this->mandate->getSalesforceId();
+
+            if ($mandateSalesforceId === null) {
+                return null; // we can't send the Donation to SF yet, as it can't be linked to its mandate.
+            }
+
             $data['mandate'] = [
-              'salesforceId' => $this->mandate->getSalesforceId(),
+              'salesforceId' => $mandateSalesforceId,
             ];
         }
 

--- a/src/Domain/DonationRepository.php
+++ b/src/Domain/DonationRepository.php
@@ -171,7 +171,12 @@ interface DonationRepository
     /**
      * @return list<Donation>
      */
-    public function findPendingAndPreAuthedForMandate(int $mandateId): array;
+    public function findPendingAndPreAuthedForMandate(UuidInterface $mandateId): array;
+
+    /**
+     * @return list<Donation>
+     */
+    public function findAllForMandate(UuidInterface $mandateId): array;
 
     /**
      * Returns a limited size list of donation fund tip donations that have been left unpaid for some time and

--- a/tests/Application/Actions/RegularGivingMandate/CancelAsAdminTest.php
+++ b/tests/Application/Actions/RegularGivingMandate/CancelAsAdminTest.php
@@ -120,7 +120,7 @@ class CancelAsAdminTest extends TestCase
     private function getMockDonationRepository(RegularGivingMandate $mandate): DonationRepository
     {
         $prophecy = $this->prophesize(DonationRepository::class);
-        $prophecy->findPendingAndPreAuthedForMandate($mandate->getId())
+        $prophecy->findPendingAndPreAuthedForMandate($mandate->getUuid())
             ->willReturn([]);
 
         return $prophecy->reveal();

--- a/tests/Domain/DonationTest.php
+++ b/tests/Domain/DonationTest.php
@@ -225,6 +225,7 @@ class DonationTest extends TestCase
         $this->assertArrayNotHasKey('originalPspFee', $donationData);
 
         $donationDataIncludingPrivate = $donation->toSFApiModel();
+        \assert($donationDataIncludingPrivate !== null);
         $this->assertEquals('1.22', $donationDataIncludingPrivate['originalPspFee']);
     }
 

--- a/tests/Domain/InMemoryDonationRepository.php
+++ b/tests/Domain/InMemoryDonationRepository.php
@@ -225,7 +225,12 @@ class InMemoryDonationRepository implements DonationRepository
         throw new \Exception("Method not implemented in test double");
     }
 
-    public function findPendingAndPreAuthedForMandate(int $mandateId): array
+    public function findPendingAndPreAuthedForMandate(UuidInterface $mandateId): array
+    {
+        throw new \Exception("Method not implemented in test double");
+    }
+
+    public function findAllForMandate(UuidInterface $mandateId): array
     {
         throw new \Exception("Method not implemented in test double");
     }

--- a/tests/Domain/RegularGivingServiceTest.php
+++ b/tests/Domain/RegularGivingServiceTest.php
@@ -578,7 +578,7 @@ class RegularGivingServiceTest extends TestCase
 
         $mandate = $this->getMandate(2, '2024-09-03T06:00:00 BST', 1);
 
-        $this->donationRepositoryProphecy->findPendingAndPreAuthedForMandate($mandate->getId())->willReturn([]);
+        $this->donationRepositoryProphecy->findPendingAndPreAuthedForMandate($mandate->getUuid())->willReturn([]);
         $sut->cancelMandate($mandate, 'Because I don\'t have any more money to give', MandateCancellationType::DonorRequestedCancellation);
 
         $this->assertEquals(MandateStatus::Cancelled, $mandate->getStatus());
@@ -593,7 +593,7 @@ class RegularGivingServiceTest extends TestCase
         $mandate = $this->getMandate(2, '2024-09-03T06:00:00 BST', 1);
 
         $donation = self::someDonation();
-        $this->donationRepositoryProphecy->findPendingAndPreAuthedForMandate($mandate->getId())->willReturn([$donation]);
+        $this->donationRepositoryProphecy->findPendingAndPreAuthedForMandate($mandate->getUuid())->willReturn([$donation]);
 
         $this->donationServiceProphecy->cancel($donation)->shouldBeCalled();
 


### PR DESCRIPTION
…he related mandate has a salesforce ID

Ideally I'd like to tell Salesforce to use the UUIds that matchbot generates to link donations to mandates, but I don't think that's possible. So we have to delay pushing the donations until after the mandate has an sfid.

This does also push all donations unecassarily on any later updates to a mandate, but I think that's not a big performance issue, and we can optimise it if necassary.