### PR TITLE
MAT-400 (ish): Set rawdata on campaign when inserting for first time

### DIFF
--- a/src/Domain/CampaignRepository.php
+++ b/src/Domain/CampaignRepository.php
@@ -113,6 +113,7 @@ class CampaignRepository extends SalesforceReadProxyRepository
             currencyCode: $campaignData['currencyCode'],
             isRegularGiving: $campaignData['isRegularGiving'] ?? false,
             regularGivingCollectionEnd: $regularGivingCollectionObject,
+            rawData: $campaignData
         );
         $campaign->setSalesforceLastPull(new \DateTime());
 


### PR DESCRIPTION
The rawData isn't actually likely to be used for anything automated, but worth having for ad-hoc queries, and to give us the option to use for migrations.