### PR TITLE
MAT-400: Switch on sending donation thanks notifications directly not…

### DIFF
--- a/app/dependencies.php
+++ b/app/dependencies.php
@@ -568,7 +568,6 @@ return function (ContainerBuilder $containerBuilder) {
                     rateLimiterFactory: $rateLimiterFactory,
                     donorAccountRepository: $c->get(DonorAccountRepository::class),
                     bus: $c->get(RoutableMessageBus::class),
-                    environment: $c->get(Environment::class),
                     donationNotifier: $c->get(DonationNotifier::class),
                 );
             }

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -54,11 +54,7 @@ class Donation extends SalesforceWriteProxy
      */
     public const string OVERSEAS = 'OVERSEAS';
 
-    /*
-     * @todo-mat-400: Replace date below with something shortly after the code will be deployed to prod
-     * to enable this feature.
-     */
-    public const string MAT_400_ENABLE_TIMESTAMP = '3000-01-01T00:00:00+00:00';
+    public const string MAT_400_ENABLE_TIMESTAMP = '2025-03-18T14:30:00+00:00';
 
     private array $possiblePSPs = ['stripe'];
 

--- a/tests/Application/Actions/Donations/ConfirmTest.php
+++ b/tests/Application/Actions/Donations/ConfirmTest.php
@@ -89,7 +89,6 @@ class ConfirmTest extends TestCase
                 ),
                 donorAccountRepository: $this->createStub(DonorAccountRepository::class),
                 bus: $this->createStub(RoutableMessageBus::class),
-                environment: Environment::Test,
                 donationNotifier: $this->createStub(DonationNotifier::class),
             )
         );

--- a/tests/Application/Actions/Donations/UpdateHandlesLockExceptionTest.php
+++ b/tests/Application/Actions/Donations/UpdateHandlesLockExceptionTest.php
@@ -224,7 +224,6 @@ class UpdateHandlesLockExceptionTest extends TestCase
                 ),
                 donorAccountRepository: $this->createStub(DonorAccountRepository::class),
                 bus: $this->messageBusProphecy->reveal(),
-                environment: Environment::Test,
                 donationNotifier: $this->createStub(DonationNotifier::class),
             ),
         );

--- a/tests/Domain/DonationServiceTest.php
+++ b/tests/Domain/DonationServiceTest.php
@@ -209,7 +209,6 @@ class DonationServiceTest extends TestCase
             rateLimiterFactory: new RateLimiterFactory(['id' => 'stub', 'policy' => 'no_limit'], new InMemoryStorage()),
             donorAccountRepository: $this->donorAccountRepoProphecy->reveal(),
             bus: $this->createStub(RoutableMessageBus::class),
-            environment: Environment::Test,
             donationNotifier: $this->createStub(DonationNotifier::class),
         );
     }

--- a/tests/TestData/StripeWebhook/ch_succeeded.json
+++ b/tests/TestData/StripeWebhook/ch_succeeded.json
@@ -1,5 +1,6 @@
 {
-  "created": 1326853478,
+  "_comment": "Timestamp below is Tue Mar 18 2025 14:30:01 GMT+0000",
+  "created": 1742308201,
   "livemode": false,
   "id": "evt_00000000000000",
   "type": "charge.succeeded",
@@ -32,7 +33,7 @@
       },
       "calculated_statement_descriptor": "THE BIG GIVE",
       "captured": true,
-      "created": 1594646323,
+      "created": 1742308201,
       "currency": "gbp",
       "customer": null,
       "description": null,


### PR DESCRIPTION
… via salesforce

This is set to enable for any donations confirmed after 2.30pm today. In principle should deploy before that, although I think it may actually be fine to deploy at any point after that as well to turn on immediatly - I think I was wrong to think we need to use the collectedAt date and it's actually fine to just replace `$donation->getCollectedAt() > new \DateTimeImmutable(Donation::MAT_400_ENABLE_TIMESTAMP` with a hard-coded true.