### PR TITLE
Regression alarm fix: Always delay sending succesful donations to SF …

### DIFF
--- a/src/Application/Actions/Donations/Confirm.php
+++ b/src/Application/Actions/Donations/Confirm.php
@@ -159,7 +159,7 @@ EOF
         $this->entityManager->flush();
         $this->entityManager->commit();
 
-        $this->bus->dispatch(new Envelope(DonationUpserted::fromDonation($donation)));
+        $this->bus->dispatch(DonationUpserted::fromDonationEnveloped($donation));
 
         return new JsonResponse([
             'paymentIntent' => [

--- a/src/Application/Actions/Donations/RemoveGiftAidDeclaration.php
+++ b/src/Application/Actions/Donations/RemoveGiftAidDeclaration.php
@@ -43,7 +43,7 @@ class RemoveGiftAidDeclaration extends Action
         try {
             $donation->removeGiftAid($this->clock->now());
             $this->entityManager->flush();
-            $this->bus->dispatch(new Envelope(DonationUpserted::fromDonation($donation)));
+            $this->bus->dispatch(DonationUpserted::fromDonationEnveloped($donation));
         } catch (CannotRemoveGiftAid $exception) {
             // we can send the message back to SF but no-one will see it there, so also send to Stripe slack channel.
 

--- a/src/Application/Actions/Hooks/StripePaymentsUpdate.php
+++ b/src/Application/Actions/Hooks/StripePaymentsUpdate.php
@@ -456,12 +456,7 @@ class StripePaymentsUpdate extends Stripe
 
     private function queueSalesforceUpdate(Donation $donation): void
     {
-        $this->bus->dispatch(
-            new Envelope(
-                DonationUpserted::fromDonation($donation),
-                [new DelayStamp(3_000)], // 3s delay to reduce risk of Donation\Update trying to reverse status change.
-            )
-        );
+        $this->bus->dispatch(DonationUpserted::fromDonationEnveloped($donation));
     }
 
     private function handleCashBalanceUpdate(Event $event, Response $response): Response

--- a/src/Application/Commands/RetrospectivelyMatch.php
+++ b/src/Application/Commands/RetrospectivelyMatch.php
@@ -92,7 +92,7 @@ class RetrospectivelyMatch extends LockingCommand
 
             if (bccomp($amountAllocated, '0.00', 2) === 1) {
                 $this->entityManager->flush();
-                $this->bus->dispatch(new Envelope(DonationUpserted::fromDonation($donation)));
+                $this->bus->dispatch(DonationUpserted::fromDonationEnveloped($donation));
                 $numWithMatchingAllocated++;
                 $totalNewMatching = bcadd($totalNewMatching, $amountAllocated, 2);
 

--- a/src/Application/Matching/MatchFundsRedistributor.php
+++ b/src/Application/Matching/MatchFundsRedistributor.php
@@ -105,7 +105,7 @@ class MatchFundsRedistributor
             }
 
             $this->entityManager->flush();
-            $this->bus->dispatch(new Envelope(DonationUpserted::fromDonation($donation)));
+            $this->bus->dispatch(DonationUpserted::fromDonationEnveloped($donation));
             $donationsAmended++;
         }
 

--- a/src/Application/Messenger/Handler/MandateUpsertedHandler.php
+++ b/src/Application/Messenger/Handler/MandateUpsertedHandler.php
@@ -18,6 +18,7 @@ use Symfony\Component\Clock\Clock;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\RoutableMessageBus;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
 
 /**
  * Sends mandates to Salesforce.
@@ -54,8 +55,7 @@ readonly class MandateUpsertedHandler
 
             foreach ($donations as $donationInMandate) {
                 Assertion::notNull($donationInMandate->getMandate()?->getSalesforceId(), 'Expected mandate to have SF ID after push');
-                $donationUpserted = DonationUpserted::fromDonation($donationInMandate);
-                $this->bus->dispatch(new Envelope($donationUpserted));
+                $this->bus->dispatch(DonationUpserted::fromDonationEnveloped($donationInMandate));
             }
         } catch (BadRequestException | BadResponseException | NotFoundException $exception) {
             // no trace needed for these exception types.

--- a/src/Domain/DoctrineDonationRepository.php
+++ b/src/Domain/DoctrineDonationRepository.php
@@ -598,7 +598,7 @@ class DoctrineDonationRepository extends SalesforceProxyRepository implements Do
                 continue;
             }
 
-            $bus->dispatch(new Envelope(DonationUpserted::fromDonation($proxy)));
+            $bus->dispatch(DonationUpserted::fromDonationEnveloped($proxy));
         }
 
         $proxiesToUpdate = $this->findBy(
@@ -612,7 +612,7 @@ class DoctrineDonationRepository extends SalesforceProxyRepository implements Do
                 continue;
             }
 
-            $bus->dispatch(new Envelope(DonationUpserted::fromDonation($proxy)));
+            $bus->dispatch(DonationUpserted::fromDonationEnveloped($proxy));
         }
 
         return count($proxiesToCreate) + count($proxiesToUpdate);

--- a/src/Domain/DonationService.php
+++ b/src/Domain/DonationService.php
@@ -344,7 +344,7 @@ class DonationService
         }
 
         if ($dispatchUpdateMessage) {
-            $this->bus->dispatch(new Envelope(DonationUpserted::fromDonation($donation)));
+            $this->bus->dispatch(DonationUpserted::fromDonationEnveloped($donation));
         }
     }
 
@@ -569,9 +569,7 @@ class DonationService
             return;
         }
 
-        $donationUpserted = DonationUpserted::fromDonation($donation);
-        $envelope = new Envelope($donationUpserted);
-        $this->bus->dispatch($envelope);
+        $this->bus->dispatch(DonationUpserted::fromDonationEnveloped($donation));
     }
 
     /**


### PR DESCRIPTION
…by 3 seconds

Should make it very unlikely that SF tries to process the same donation in its sucessful state before it deals with its pending state. Pushing them in the wrong order generates an alarm.