### PR TITLE
Regression alarm fix: Clear entity manager at start of handling Manda…

### DIFF
--- a/src/Application/Messenger/Handler/MandateUpsertedHandler.php
+++ b/src/Application/Messenger/Handler/MandateUpsertedHandler.php
@@ -41,6 +41,17 @@ readonly class MandateUpsertedHandler
 
     public function __invoke(MandateUpserted $message): void
     {
+        /** This handler is part of a long-running process. If we don't clear the EM then we won't get an up to date
+         * picture of the donations attached to this mandate, which could be in memory here and we wouldn't know that
+         * it's updated in the database
+         * by another thread.
+         *
+         * Ideally we should probably do this in general before invoking any message handler, but it's not obvious to me
+         * how to do that, so just adding this line here for the moment to stop the immediate alarm and check if that is
+         * in fact the issue.
+         */
+        $this->entityManager->clear();
+
         $uuid = $message->uuid;
         $this->logger->info("MUH invoked for UUID: $uuid");
 


### PR DESCRIPTION
…teUpserted message

Otherwise it pulls an outdated donation from the thread's memory, instead of the up to date version from the database

I think this should stop the alarms we're currently seeing in regression and staging.