### PR TITLE
Handle 404 campaign mandate pushes to SF only info log and stop future attempts

### DIFF
--- a/src/Application/Messenger/Handler/MandateUpsertedHandler.php
+++ b/src/Application/Messenger/Handler/MandateUpsertedHandler.php
@@ -63,6 +63,7 @@ readonly class MandateUpsertedHandler
             }
         } catch (NotFoundException $_exception) {
             // Thrown only for *sandbox* 404s -> quietly stop trying to push mandate to a removed campaign.
+            Assertion::notEq(\MatchBot\Application\Environment::Production, \MatchBot\Application\Environment::current());
             $this->logger->info(
                 "Marking 404 campaign Salesforce mandate {$message->uuid} as complete; won't push again."
             );

--- a/src/Client/Common.php
+++ b/src/Client/Common.php
@@ -99,7 +99,7 @@ abstract class Common
             $contents = $response->getBody()->getContents();
         } catch (RequestException $ex) {
             $this->logger->info("Client Push RequestException: {$ex->getMessage()}");
-            // Sandboxes that 404 on POST may be trying to sync up donations for non-existent campaigns and
+            // Sandboxes that 404 on POST may be trying to sync up donations or mandates for non-existent campaigns and
             // so have probably just been refreshed. In this case we want to update the local state of play
             // to stop them getting pushed, instead of treating this as an error. So throw this for appropriate
             // handling in the caller without an error level log. In production, 404s should not happen and


### PR DESCRIPTION
Should make post-refresh sandboxes quiet, similarly to how we handle this for donations