### PR TITLE
Refactor: Remove redundant doctrine mapping info, redusing risk of future bugs

### DIFF
--- a/src/Domain/Campaign.php
+++ b/src/Domain/Campaign.php
@@ -38,7 +38,7 @@ class Campaign extends SalesforceReadProxy
     /**
      * @var string  ISO 4217 code for the currency in which donations can be accepted and matching's organised.
      */
-    #[ORM\Column(type: 'string', length: 3)]
+    #[ORM\Column(length: 3)]
     protected ?string $currencyCode;
 
     /**
@@ -50,7 +50,7 @@ class Campaign extends SalesforceReadProxy
      * Default null because campaigns not recently updated in matchbot have not pulled this field from SF.
      * @psalm-suppress UnusedProperty
      */
-    #[ORM\Column(type: 'string', length: 64, nullable: true, options: ['default' => null])]
+    #[ORM\Column(length: 64, nullable: true, options: ['default' => null])]
     private ?string $status = null;
 
     /**
@@ -105,7 +105,7 @@ class Campaign extends SalesforceReadProxy
      * Custom message from the charity to donors thanking them for donating. Used here for regular giving
      * confirmation emails, also used from SF for ad-hoc giving thanks pages and emails.
      */
-    #[ORM\Column(type: 'string', length: 500, nullable: true, options: ['default' => null])]
+    #[ORM\Column(length: 500, nullable: true, options: ['default' => null])]
     private ?string $thankYouMessage;
 
     /**

--- a/src/Domain/CampaignFunding.php
+++ b/src/Domain/CampaignFunding.php
@@ -42,7 +42,7 @@ class CampaignFunding extends Model
     /**
      * @var string  ISO 4217 code for the currency in which all monetary values are denominated.
      */
-    #[ORM\Column(type: 'string', length: 3)]
+    #[ORM\Column(length: 3)]
     protected string $currencyCode;
 
     /**

--- a/src/Domain/Charity.php
+++ b/src/Domain/Charity.php
@@ -62,22 +62,22 @@ class Charity extends SalesforceReadProxy
     /**
      * URI of the charity's logo, hosted as part of the Big Give website.
      */
-    #[ORM\Column(type: 'string', length: 255, nullable: true)]
+    #[ORM\Column(length: 255, nullable: true)]
     protected ?string $logoUri = null;
 
     /**
      * URI of the charity's own website, for linking to.
      */
-    #[ORM\Column(type: 'string', length: 255, nullable: true)]
+    #[ORM\Column(length: 255, nullable: true)]
     protected ?string $websiteUri = null;
 
-    #[ORM\Column(type: 'string', length: 255, nullable: true)]
+    #[ORM\Column(length: 255, nullable: true)]
     protected ?string $phoneNumber = null;
 
     /**
      * Not using EmailAddress as embedded because of nullability requirement.
      */
-    #[ORM\Column(type: 'string', length: 255, nullable: true)]
+    #[ORM\Column(length: 255, nullable: true)]
     private ?string $emailAddress;
 
     #[ORM\Embedded(columnPrefix: 'address_')]
@@ -86,13 +86,13 @@ class Charity extends SalesforceReadProxy
     /**
      * @var string
      */
-    #[ORM\Column(type: 'string', length: 255, unique: true, nullable: true)]
+    #[ORM\Column(length: 255, unique: true, nullable: true)]
     protected ?string $stripeAccountId = null;
 
     /**
      * @var ?string
      */
-    #[ORM\Column(type: 'string', length: 7, unique: true, nullable: true)]
+    #[ORM\Column(length: 7, unique: true, nullable: true)]
     protected ?string $hmrcReferenceNumber = null;
 
     /**
@@ -101,13 +101,13 @@ class Charity extends SalesforceReadProxy
      *
      * @var key-of<self::REGULATORS> |null
      */
-    #[ORM\Column(type: 'string', length: 4, nullable: true)]
+    #[ORM\Column(length: 4, nullable: true)]
     protected ?string $regulator = null;
 
     /**
      * @var ?string
      */
-    #[ORM\Column(type: 'string', length: 10, nullable: true)]
+    #[ORM\Column(length: 10, nullable: true)]
     protected ?string $regulatorNumber = null;
 
     /**

--- a/src/Domain/Charity.php
+++ b/src/Domain/Charity.php
@@ -86,9 +86,6 @@ class Charity extends SalesforceReadProxy
     #[ORM\Column(length: 255, unique: true, nullable: true)]
     protected ?string $stripeAccountId = null;
 
-    /**
-     * @var ?string
-     */
     #[ORM\Column(length: 7, unique: true, nullable: true)]
     protected ?string $hmrcReferenceNumber = null;
 

--- a/src/Domain/Charity.php
+++ b/src/Domain/Charity.php
@@ -98,9 +98,6 @@ class Charity extends SalesforceReadProxy
     #[ORM\Column(length: 4, nullable: true)]
     protected ?string $regulator = null;
 
-    /**
-     * @var ?string
-     */
     #[ORM\Column(length: 10, nullable: true)]
     protected ?string $regulatorNumber = null;
 

--- a/src/Domain/Charity.php
+++ b/src/Domain/Charity.php
@@ -83,9 +83,6 @@ class Charity extends SalesforceReadProxy
     #[ORM\Embedded(columnPrefix: 'address_')]
     protected PostalAddress $postalAddress;
 
-    /**
-     * @var string
-     */
     #[ORM\Column(length: 255, unique: true, nullable: true)]
     protected ?string $stripeAccountId = null;
 

--- a/src/Domain/CommandLockKeys.php
+++ b/src/Domain/CommandLockKeys.php
@@ -18,13 +18,13 @@ class CommandLockKeys
      * @var string
      */
     #[ORM\Id]
-    #[ORM\Column(type: 'string', length: 64)]
+    #[ORM\Column(length: 64)]
     public string $key_id;
 
     /**
      * @var string
      */
-    #[ORM\Column(type: 'string', length: 44)]
+    #[ORM\Column(length: 44)]
     public string $key_token;
 
     /**

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -76,13 +76,13 @@ class Donation extends SalesforceWriteProxy
     /**
      * @var string  Which Payment Service Provider (PSP) is expected to (or did) process the donation.
      */
-    #[ORM\Column(type: 'string', length: 20)]
+    #[ORM\Column(length: 20)]
     protected string $psp;
 
     /**
      * @var ?DateTimeImmutable  When the donation first moved to status Collected, i.e. the donor finished paying.
      */
-    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    #[ORM\Column(nullable: true)]
     protected ?DateTimeImmutable $collectedAt = null;
 
     /**
@@ -90,13 +90,13 @@ class Donation extends SalesforceWriteProxy
      *
      * In the case of stripe (which is the only thing we support at present, this is the payment intent ID)
      */
-    #[ORM\Column(type: 'string', unique: true, nullable: true)]
+    #[ORM\Column(unique: true, nullable: true)]
     protected ?string $transactionId = null;
 
     /**
      * @var string|null PSP's charge ID assigned on their processing.
      */
-    #[ORM\Column(type: 'string', unique: true, nullable: true)]
+    #[ORM\Column(unique: true, nullable: true)]
     protected ?string $chargeId = null;
 
     /**
@@ -105,13 +105,13 @@ class Donation extends SalesforceWriteProxy
      *                  the Connected Account for the charity receiving the transferred
      *                  donation balance.
      */
-    #[ORM\Column(type: 'string', unique: true, nullable: true)]
+    #[ORM\Column(unique: true, nullable: true)]
     protected ?string $transferId = null;
 
     /**
      * @var string  ISO 4217 code for the currency in which all monetary values are denominated, e.g. 'GBP'.
      */
-    #[ORM\Column(type: 'string', length: 3)]
+    #[ORM\Column(length: 3)]
     protected readonly string $currencyCode;
 
     /**
@@ -171,7 +171,7 @@ class Donation extends SalesforceWriteProxy
     #[ORM\Column(type: 'decimal', precision: 18, scale: 2)]
     protected string $originalPspFee = '0.00';
 
-    #[ORM\Column(type: 'string', enumType: DonationStatus::class)]
+    #[ORM\Column]
     protected DonationStatus $donationStatus = DonationStatus::Pending;
 
     /**
@@ -207,20 +207,20 @@ class Donation extends SalesforceWriteProxy
     /**
      * @var string|null  *Billing* country code.
      */
-    #[ORM\Column(type: 'string', length: 2, nullable: true)]
+    #[ORM\Column(length: 2, nullable: true)]
     protected ?string $donorCountryCode = null;
 
     /**
      * Ideally we would type this as ?EmailAddress instead of ?string but that will require changing
      * the column name to match the property inside the VO. Might be easy and worth doing.
      */
-    #[ORM\Column(type: 'string', nullable: true)]
+    #[ORM\Column(nullable: true)]
     protected ?string $donorEmailAddress = null;
 
-    #[ORM\Column(type: 'string', nullable: true)]
+    #[ORM\Column(nullable: true)]
     protected ?string $donorFirstName = null;
 
-    #[ORM\Column(type: 'string', nullable: true)]
+    #[ORM\Column(nullable: true)]
     protected ?string $donorLastName = null;
 
     /**
@@ -231,7 +231,7 @@ class Donation extends SalesforceWriteProxy
      *
      * @psalm-suppress PossiblyUnusedProperty - used in DQL
      */
-    #[ORM\Column(type: 'integer', nullable: true)]
+    #[ORM\Column(nullable: true)]
     protected ?int $mandateSequenceNumber = null;
 
     /**
@@ -251,19 +251,19 @@ class Donation extends SalesforceWriteProxy
      *
      * @var string|null
      */
-    #[ORM\Column(type: 'string', nullable: true, name: 'donorPostalAddress')]
+    #[ORM\Column(nullable: true, name: 'donorPostalAddress')]
     protected ?string $donorBillingPostcode = null;
 
     /**
      * @var string|null From residential address, if donor is claiming Gift Aid.
      */
-    #[ORM\Column(type: 'string', nullable: true)]
+    #[ORM\Column(nullable: true)]
     protected ?string $donorHomeAddressLine1 = null;
 
     /**
      * @var string|null From residential address, if donor is claiming Gift Aid.
      */
-    #[ORM\Column(type: 'string', nullable: true)]
+    #[ORM\Column(nullable: true)]
     protected ?string $donorHomePostcode = null;
 
     /**
@@ -287,7 +287,7 @@ class Donation extends SalesforceWriteProxy
     /**
      * @var bool    Whether Gift Aid was claimed on the 'tip' donation to the Big Give.
      */
-    #[ORM\Column(type: 'boolean', nullable: true)]
+    #[ORM\Column(nullable: true)]
     protected ?bool $tipGiftAid = null;
 
     /**
@@ -297,33 +297,33 @@ class Donation extends SalesforceWriteProxy
      *              because it's true.
      * @see Donation::$giftAid
      */
-    #[ORM\Column(type: 'boolean', nullable: true)]
+    #[ORM\Column(nullable: true)]
     protected ?bool $tbgShouldProcessGiftAid = null;
 
     /**
      * @psalm-suppress PossiblyUnusedProperty - used in DB queries
      * @var ?DateTimeImmutable When a queued message that should lead to a Gift Aid claim was sent.
      */
-    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    #[ORM\Column(nullable: true)]
     protected ?DateTimeImmutable $tbgGiftAidRequestQueuedAt = null;
 
     /**
      * @var ?DateTime   When a claim submission attempt was detected to have an error returned.
      */
-    #[ORM\Column(type: 'datetime', nullable: true)]
+    #[ORM\Column(nullable: true)]
     protected ?DateTime $tbgGiftAidRequestFailedAt = null;
 
     /**
      * @var ?DateTime   When a claim was detected accepted via an async poll.
      */
-    #[ORM\Column(type: 'datetime', nullable: true)]
+    #[ORM\Column(nullable: true)]
     protected ?DateTime $tbgGiftAidRequestConfirmedCompleteAt = null;
 
     /**
      * @var ?string Provided by HMRC upon initial claim submission acknowledgement.
      *              Doesn't imply success.
      */
-    #[ORM\Column(type: 'string', nullable: true)]
+    #[ORM\Column(nullable: true)]
     protected ?string $tbgGiftAidRequestCorrelationId = null;
 
     /**
@@ -333,10 +333,10 @@ class Donation extends SalesforceWriteProxy
     #[ORM\Column(type: 'text', length: 65535, nullable: true)]
     protected ?string $tbgGiftAidResponseDetail = null;
 
-    #[ORM\Column(type: 'string', nullable: true)]
+    #[ORM\Column(nullable: true)]
     protected ?string $pspCustomerId = null;
 
-    #[ORM\Column(type: 'string', enumType: PaymentMethodType::class, nullable: true)]
+    #[ORM\Column(nullable: true)]
     protected ?PaymentMethodType $paymentMethodType = PaymentMethodType::Card;
 
     /**

--- a/src/Domain/DonorAccount.php
+++ b/src/Domain/DonorAccount.php
@@ -40,13 +40,13 @@ class DonorAccount extends Model
     #[ORM\Embedded(class: 'StripeCustomerId', columnPrefix: false)]
     public readonly StripeCustomerId $stripeCustomerId;
 
-    #[ORM\Column(type: 'string', length: 2, nullable: true)]
+    #[ORM\Column(length: 2, nullable: true)]
     private ?string $billingCountryCode = null;
 
     /**
      * From residential address, required if donor will claim Gift Aid.
      */
-    #[ORM\Column(type: 'string', length: 255, nullable: true)]
+    #[ORM\Column(length: 255, nullable: true)]
     private ?string $homeAddressLine1 = null;
 
     /**
@@ -54,14 +54,14 @@ class DonorAccount extends Model
      *
      * Not embedding postcode VO directly because Doctrine doesn't allow remapping field names.
      */
-    #[ORM\Column(type: 'string', nullable: true)]
+    #[ORM\Column(nullable: true)]
     protected ?string $homePostcode = null;
 
     /**
      * May be a post code or equivilent from anywhere in the world,
      * so we allow up to 15 chars which has been enough for all donors in the last 12 months.
      */
-    #[ORM\Column(type: 'string', nullable: true)]
+    #[ORM\Column(nullable: true)]
     protected ?string $billingPostcode = null;
 
     /**
@@ -71,7 +71,7 @@ class DonorAccount extends Model
      *
      * String not embeddable because ORM does not support nullable embeddables.
      */
-    #[ORM\Column(type: 'string', nullable: true, length: 255)]
+    #[ORM\Column(nullable: true, length: 255)]
     private ?string $regularGivingPaymentMethod = null;
 
     /**

--- a/src/Domain/Fund.php
+++ b/src/Domain/Fund.php
@@ -27,13 +27,13 @@ class Fund extends SalesforceReadProxy
     /**
      * FundType controlls allocation orders of campaign fundings. See docs on enum for details.
      */
-    #[ORM\Column(type: 'string', enumType: FundType::class)]
+    #[ORM\Column]
     private FundType $fundType;
 
     /**
      * @var string  ISO 4217 code for the currency used with this fund, and in which FundingWithdrawals are denominated.
      */
-    #[ORM\Column(type: 'string', length: 3)]
+    #[ORM\Column(length: 3)]
     protected string $currencyCode;
 
     /**

--- a/src/Domain/Money.php
+++ b/src/Domain/Money.php
@@ -20,7 +20,7 @@ readonly class Money implements \JsonSerializable, \Stringable
     private function __construct(
         #[Column(type: 'integer')]
         public int $amountInPence,
-        #[Column(type: 'string', enumType: Currency::class)]
+        #[Column]
         public Currency $currency
     ) {
         Assertion::between(

--- a/src/Domain/RegularGivingMandate.php
+++ b/src/Domain/RegularGivingMandate.php
@@ -81,16 +81,16 @@ class RegularGivingMandate extends SalesforceWriteProxy
     #[ORM\Embedded(columnPrefix: false)]
     private DayOfMonth $dayOfMonth;
 
-    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    #[ORM\Column(nullable: true)]
     private ?\DateTimeImmutable $activeFrom = null;
 
-    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    #[ORM\Column(nullable: true)]
     private ?\DateTimeImmutable $donationsCreatedUpTo = null;
 
-    #[ORM\Column(type: 'string', enumType: MandateStatus::class)]
+    #[ORM\Column]
     private MandateStatus $status = MandateStatus::Pending;
 
-    #[ORM\Column(type: 'string', length: 50, enumType: MandateCancellationType::class, nullable: true)]
+    #[ORM\Column(length: 50, nullable: true)]
     private ?MandateCancellationType $cancellationType = null;
 
     /**
@@ -101,10 +101,10 @@ class RegularGivingMandate extends SalesforceWriteProxy
     #[ORM\Column()]
     private bool $isMatched;
 
-    #[ORM\Column(type: 'string', length: 500, nullable: true)]
+    #[ORM\Column(length: 500, nullable: true)]
     private ?string $cancellationReason = null;
 
-    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    #[ORM\Column(nullable: true)]
     private ?\DateTimeImmutable $cancelledAt = null;
 
     /**

--- a/src/Domain/SalesforceProxy.php
+++ b/src/Domain/SalesforceProxy.php
@@ -20,7 +20,7 @@ abstract class SalesforceProxy extends Model
      *
      * @var string|null Nullable because write proxies may be created before the first Salesforce push
      */
-    #[ORM\Column(type: 'string', length: 18, unique: true, nullable: true)]
+    #[ORM\Column(length: 18, unique: true, nullable: true)]
     protected ?string $salesforceId = null;
 
     /**

--- a/src/Domain/SalesforceReadProxy.php
+++ b/src/Domain/SalesforceReadProxy.php
@@ -17,7 +17,7 @@ abstract class SalesforceReadProxy extends SalesforceProxy
     /**
      * @psalm-suppress PossiblyUnusedProperty - used in DB queries
      */
-    #[ORM\Column(type: 'datetime', nullable: true)]
+    #[ORM\Column(nullable: true)]
     protected ?DateTime $salesforceLastPull = null;
 
     /**

--- a/src/Domain/SalesforceWriteProxy.php
+++ b/src/Domain/SalesforceWriteProxy.php
@@ -27,7 +27,7 @@ abstract class SalesforceWriteProxy extends SalesforceProxy
     /**
      * @psalm-suppress PossiblyUnusedProperty   Used for manual dev database checks.
      */
-    #[ORM\Column(type: 'datetime', nullable: true)]
+    #[ORM\Column(nullable: true)]
     protected ?DateTime $salesforceLastPush = null;
 
     /**


### PR DESCRIPTION
The success message at https://app.circleci.com/pipelines/github/thebiggive/matchbot/5348/workflows/e5387e49-278f-4d79-80d4-dc0ac1ed054c/jobs/17001/parallel-runs/0/steps/0-110 shows that the deleted tokens here don't affect the mapping as used by the ORM. Removing the redundant tokens reduces the risk of the mapping info getting out of sync with the actual PHP types in future.