### PR TITLE
MAT-418 – fix `PersonId` embeddable's UUID type

### DIFF
--- a/src/Domain/PersonId.php
+++ b/src/Domain/PersonId.php
@@ -4,7 +4,6 @@ namespace MatchBot\Domain;
 
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Embeddable;
-use MatchBot\Application\Assertion;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
 
@@ -16,13 +15,11 @@ use Ramsey\Uuid\UuidInterface;
 class PersonId
 {
     #[Column(type: 'uuid')]
-    public readonly string $id;
+    public readonly UuidInterface $id;
 
-    private function __construct(
-        string $personId
-    ) {
-        $this->id = $personId;
-        Assertion::uuid($personId);
+    private function __construct(string $personId)
+    {
+        $this->id = Uuid::fromString($personId);
     }
 
     public static function of(string $personId): self


### PR DESCRIPTION
Previously, the UUID library would work because the actual database value is a string, but would find needless changes on mandates every time they were in the unit of work