### PR TITLE
MAT-390: Adjust matchbot:delete-stale-payment-details to also clear non-usable cards from passworded accounts

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -523,18 +523,6 @@ parameters:
 			path: tests/Application/Actions/Hooks/StripePaymentsUpdateTest.php
 
 		-
-			message: '#^Access to an undefined property Prophecy\\Prophecy\\ObjectProphecy\<Stripe\\StripeClient\>\:\:\$customers\.$#'
-			identifier: property.notFound
-			count: 1
-			path: tests/Application/Commands/DeleteStalePaymentDetailsTest.php
-
-		-
-			message: '#^Access to an undefined property Prophecy\\Prophecy\\ObjectProphecy\<Stripe\\StripeClient\>\:\:\$paymentMethods\.$#'
-			identifier: property.notFound
-			count: 1
-			path: tests/Application/Commands/DeleteStalePaymentDetailsTest.php
-
-		-
 			message: '#^Method MatchBot\\Tests\\Application\\Commands\\HandleOutOfSyncFundsTest\:\:getCampaignFundingRepoPropechy\(\) never returns MatchBot\\Domain\\CampaignFundingRepository so it can be removed from the return type\.$#'
 			identifier: return.unusedType
 			count: 1

--- a/src/Application/Commands/DeleteStalePaymentDetails.php
+++ b/src/Application/Commands/DeleteStalePaymentDetails.php
@@ -58,16 +58,7 @@ class DeleteStalePaymentDetails extends LockingCommand
         Customer|\stdClass $customer,
         ?DonorAccount $donorAccount
     ): int {
-        $metadata = $customer->metadata;
-
-        /** @psalm-suppress DocblockTypeContradiction */
-        if ($metadata instanceof \stdClass) {
-            // accounting for an awkard to change test.
-            $metadataArray = (array) $metadata;
-        } else {
-            $metadataArray = $metadata?->toArray();
-        }
-        $customerHasPasswordSet = ($metadataArray['hasPasswordSince'] ?? null) !== null;
+        $customerHasPasswordSet = ! \is_null($donorAccount);
 
         $methodsDeleted = 0;
 

--- a/src/Client/LiveStripeClient.php
+++ b/src/Client/LiveStripeClient.php
@@ -141,8 +141,8 @@ class LiveStripeClient implements Stripe
         return $this->stripeClient->customers->search($searchParams);
     }
 
-    #[\Override] public function listAllPaymentMethodsForTreasury(array $array): Collection
+    #[\Override] public function listAllPaymentMethodsForCustomer(StripeCustomerId $id, array $params): Collection
     {
-        return $this->stripeClient->paymentMethods->all(params: $array);
+        return $this->stripeClient->customers->allPaymentMethods($id->stripeCustomerId, params: $params);
     }
 }

--- a/src/Client/LiveStripeClient.php
+++ b/src/Client/LiveStripeClient.php
@@ -8,12 +8,14 @@ use MatchBot\Domain\StripeCustomerId;
 use MatchBot\Domain\StripePaymentMethodId;
 use Stripe\BalanceTransaction;
 use Stripe\Charge;
+use Stripe\Collection;
 use Stripe\ConfirmationToken;
 use Stripe\CustomerSession;
 use Stripe\Exception\ApiErrorException;
 use Stripe\Exception\InvalidArgumentException;
 use Stripe\PaymentIntent;
 use Stripe\PaymentMethod;
+use Stripe\SearchResult;
 use Stripe\SetupIntent;
 use Stripe\StripeClient;
 
@@ -127,5 +129,20 @@ class LiveStripeClient implements Stripe
     public function detatchPaymentMethod(StripePaymentMethodId $paymentMethodId): void
     {
         $this->stripeClient->paymentMethods->detach($paymentMethodId->stripePaymentMethodId);
+    }
+
+    #[\Override] public function updateCustomer(string $customerId, array $updateData): void
+    {
+        $this->stripeClient->customers->update($customerId, $updateData);
+    }
+
+    #[\Override] public function searchCustomers(array $searchParams): SearchResult
+    {
+        return $this->stripeClient->customers->search($searchParams);
+    }
+
+    #[\Override] public function listAllPaymentMethodsForTreasury(array $array): Collection
+    {
+        return $this->stripeClient->paymentMethods->all(params: $array);
     }
 }

--- a/src/Client/Stripe.php
+++ b/src/Client/Stripe.php
@@ -8,12 +8,14 @@ use MatchBot\Domain\StripeCustomerId;
 use MatchBot\Domain\StripePaymentMethodId;
 use Stripe\BalanceTransaction;
 use Stripe\Charge;
+use Stripe\Collection;
 use Stripe\ConfirmationToken;
 use Stripe\CustomerSession;
 use Stripe\Exception\ApiErrorException;
 use Stripe\Exception\InvalidRequestException;
 use Stripe\PaymentIntent;
 use Stripe\PaymentMethod;
+use Stripe\SearchResult;
 use Stripe\SetupIntent;
 
 /**
@@ -35,6 +37,11 @@ interface Stripe
      * @throws ApiErrorException
      */
     public function updatePaymentIntent(string $paymentIntentId, array $updateData): void;
+
+    /**
+     * @throws ApiErrorException
+     */
+    public function updateCustomer(string $customerId, array $updateData): void;
 
     /**
      * @throws ApiErrorException
@@ -73,4 +80,12 @@ interface Stripe
     public function retrievePaymentMethod(StripeCustomerId $customerId, StripePaymentMethodId $methodId): PaymentMethod;
 
     public function detatchPaymentMethod(StripePaymentMethodId $paymentMethodId): void;
+
+    public function searchCustomers(array $searchParams): SearchResult|Collection;
+
+    /**
+     * Returns a list of PaymentMethods for Treasury flows.
+     * @return \Stripe\Collection<\Stripe\PaymentMethod>
+     */
+    public function listAllPaymentMethodsForTreasury(array $array): Collection;
 }

--- a/src/Client/Stripe.php
+++ b/src/Client/Stripe.php
@@ -83,9 +83,5 @@ interface Stripe
 
     public function searchCustomers(array $searchParams): SearchResult|Collection;
 
-    /**
-     * Returns a list of PaymentMethods for Treasury flows.
-     * @return \Stripe\Collection<\Stripe\PaymentMethod>
-     */
-    public function listAllPaymentMethodsForTreasury(array $array): Collection;
+    public function listAllPaymentMethodsForCustomer(StripeCustomerId $id, array $params): Collection;
 }

--- a/src/Client/StubStripeClient.php
+++ b/src/Client/StubStripeClient.php
@@ -125,7 +125,7 @@ class StubStripeClient implements Stripe
         throw new \Exception("updateCustomer not implemented in stub- not currently used in load tests");
     }
 
-    #[\Override] public function listAllPaymentMethodsForTreasury(array $array): Collection
+    #[\Override] public function listAllPaymentMethodsForCustomer(StripeCustomerId $id, array $params): Collection
     {
         throw new \Exception("updateCustomer not implemented in stub- not currently used in load tests");
     }

--- a/src/Client/StubStripeClient.php
+++ b/src/Client/StubStripeClient.php
@@ -8,10 +8,12 @@ use MatchBot\Domain\StripePaymentMethodId;
 use Ramsey\Uuid\Uuid;
 use Stripe\BalanceTransaction;
 use Stripe\Charge;
+use Stripe\Collection;
 use Stripe\ConfirmationToken;
 use Stripe\CustomerSession;
 use Stripe\PaymentIntent;
 use Stripe\PaymentMethod;
+use Stripe\SearchResult;
 use Stripe\SetupIntent;
 use Stripe\StripeObject;
 
@@ -111,5 +113,20 @@ class StubStripeClient implements Stripe
     public function detatchPaymentMethod(StripePaymentMethodId $paymentMethodId): void
     {
         throw new \Exception("Detatch Payment Method not implemented in stub - not currently used in load tests");
+    }
+
+    #[\Override] public function updateCustomer(string $customerId, array $updateData): void
+    {
+        throw new \Exception("updateCustomer not implemented in stub- not currently used in load tests");
+    }
+
+    #[\Override] public function searchCustomers(array $searchParams): SearchResult
+    {
+        throw new \Exception("updateCustomer not implemented in stub- not currently used in load tests");
+    }
+
+    #[\Override] public function listAllPaymentMethodsForTreasury(array $array): Collection
+    {
+        throw new \Exception("updateCustomer not implemented in stub- not currently used in load tests");
     }
 }

--- a/src/Domain/StripePaymentMethodId.php
+++ b/src/Domain/StripePaymentMethodId.php
@@ -28,4 +28,13 @@ readonly class StripePaymentMethodId
     {
         return new self($stripeID);
     }
+
+    public function equals(StripePaymentMethodId|null $that): bool
+    {
+        if ($that === null) {
+            return false;
+        }
+
+        return $this->stripePaymentMethodId === $that->stripePaymentMethodId;
+    }
 }

--- a/tests/Application/Commands/DeleteStalePaymentDetailsTest.php
+++ b/tests/Application/Commands/DeleteStalePaymentDetailsTest.php
@@ -143,7 +143,11 @@ class DeleteStalePaymentDetailsTest extends TestCase
         $stripeClientProphecy = $this->prophesize(Stripe::class);
         $customer = new Customer('cus_some_cust_id');
         $customer->metadata = new StripeObject();
-        $customer->metadata['hasPasswordSince'] = 'any non null value';
+
+        // next line commented out because we failed to set this metadata for some customers in April and May
+        // 2025, so we should not rely on it. See ID-52
+        //
+        // $customer->metadata['hasPasswordSince'] = 'any non null value';
 
         $donorAccount = Identity::donorAccount();
         $donorAccount->setRegularGivingPaymentMethod(StripePaymentMethodId::of('pm_3'));


### PR DESCRIPTION
…command

Once changes from
https://github.com/thebiggive/donate-frontend/pull/1968 are operating in each environment I'm planning to adjust this command so that it can also detatch all the payment methods we don't have a use for from donors who *do* have passwords set. Should only be needed for as long as takes to get through all the donor accounts / stripe customers from before the date of the front end change.

Dry run mode should help us see what it will do in advance, in dev env even if nowhere else.