### PR TITLE
Disable foreign key checks as required during DB migrations.

### DIFF
--- a/src/Migrations/Version20250506171748.php
+++ b/src/Migrations/Version20250506171748.php
@@ -16,15 +16,23 @@ final class Version20250506171748 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $this->addSql('SET FOREIGN_KEY_CHECKS = 0');
+
         $this->addSql('ALTER TABLE Campaign CHANGE charity_id charity_id INT UNSIGNED NOT NULL');
         $this->addSql('ALTER TABLE CampaignFunding CHANGE fund_id fund_id INT UNSIGNED NOT NULL');
         $this->addSql('ALTER TABLE Donation CHANGE campaign_id campaign_id INT UNSIGNED NOT NULL');
+
+        $this->addSql('SET FOREIGN_KEY_CHECKS = 1');
     }
 
     public function down(Schema $schema): void
     {
+        $this->addSql('SET FOREIGN_KEY_CHECKS = 0');
+
         $this->addSql('ALTER TABLE Campaign CHANGE charity_id charity_id INT UNSIGNED DEFAULT NULL');
         $this->addSql('ALTER TABLE CampaignFunding CHANGE fund_id fund_id INT UNSIGNED DEFAULT NULL');
         $this->addSql('ALTER TABLE Donation CHANGE campaign_id campaign_id INT UNSIGNED DEFAULT NULL');
+
+        $this->addSql('SET FOREIGN_KEY_CHECKS = 1');
     }
 }

--- a/src/Migrations/Version20250506174024.php
+++ b/src/Migrations/Version20250506174024.php
@@ -16,11 +16,22 @@ final class Version20250506174024 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        // SET FOREIGN_KEY_CHECKS required to allow changing type of a foreign key, even when making
+        // it narrower. I believe this only affects this connection, and we don't rely purely on these checks for
+        // integrity in any case.
+        $this->addSql('SET FOREIGN_KEY_CHECKS = 0');
+
         $this->addSql('ALTER TABLE FundingWithdrawal CHANGE donation_id donation_id INT UNSIGNED NOT NULL');
+
+        $this->addSql('SET FOREIGN_KEY_CHECKS = 1');
     }
 
     public function down(Schema $schema): void
     {
+        $this->addSql('SET FOREIGN_KEY_CHECKS = 0');
+
         $this->addSql('ALTER TABLE FundingWithdrawal CHANGE donation_id donation_id INT UNSIGNED DEFAULT NULL');
+
+        $this->addSql('SET FOREIGN_KEY_CHECKS = 1');
     }
 }


### PR DESCRIPTION
These migrations have not yet run in staging, because changing these columns with foreign key constraints is not allowed.