### PR TITLE
MAT-390 part 3: Display all payment cards on payment methods page, us…

### DIFF
--- a/src/Application/Actions/GetPaymentMethods.php
+++ b/src/Application/Actions/GetPaymentMethods.php
@@ -41,22 +41,22 @@ class GetPaymentMethods extends Action
 
         $regularGivingPaymentMethod = null;
 
-        // exclude payment methods with 'allow_redisplay' set to limited:
-        $displayableMethods = array_values(array_filter(
+        $nonRegularGivingMethods = array_values(array_filter(
             $paymentMethodArray,
             static function (array $paymentMethod) use ($donor, &$regularGivingPaymentMethod) {
                 if ($paymentMethod['id'] === $donor->getRegularGivingPaymentMethod()?->stripePaymentMethodId) {
                     $regularGivingPaymentMethod = $paymentMethod;
-                } else {
-                    return in_array($paymentMethod['allow_redisplay'], ['always', 'unspecified']);
+                    return false;
                 }
+
+                return true;
             }
         ));
 
         return $this->respondWithData(
             $response,
             [
-                'data' => $displayableMethods,
+                'data' => $nonRegularGivingMethods,
                 'regularGivingPaymentMethod' => $regularGivingPaymentMethod
             ]
         );

--- a/src/Client/LiveStripeClient.php
+++ b/src/Client/LiveStripeClient.php
@@ -29,7 +29,6 @@ class LiveStripeClient implements Stripe
         'payment_element' => [
             'enabled' => true,
             'features' => [
-                'payment_method_allow_redisplay_filters' => ['always', 'unspecified'],
                 'payment_method_redisplay' => 'enabled',
                 'payment_method_redisplay_limit' => 3, // Keep default 3; 10 is max stripe allows.
                 // default value – need to ensure it stays off to avoid breaking Regular Giving by mistake,
@@ -101,7 +100,6 @@ class LiveStripeClient implements Stripe
         $components = self::SESSION_COMPONENTS;
         $components['payment_element']['features']['payment_method_save_usage'] = 'off_session';
         $components['payment_element']['features']['payment_method_redisplay'] = 'disabled';
-        unset($components['payment_element']['features']['payment_method_allow_redisplay_filters']);
         unset($components['payment_element']['features']['payment_method_redisplay_limit']);
 
         return $this->stripeClient->customerSessions->create([


### PR DESCRIPTION
…e stripe default to show only cards with redisplay="always" on in payment element

Should not be merged until part 2 is completed running in production.

See https://docs.stripe.com/api/customer_sessions/create#create_customer_session-components-payment_element-features-payment_method_allow_redisplay_filters

> components.payment_element.features.payment_method_allow_redisplay_filtersarray of enums

> A list of allow_redisplay values that controls which saved payment methods the Payment
> Element displays by filtering to only show payment methods with an allow_redisplay value
> that is present in this list.
>
> If not specified, defaults to [“always”]. In order to display all saved payment methods,
> specify [“always”, “limited”, “unspecified”].