### PR TITLE
Revert "MAT-390 part 3: Display all payment cards on payment methods page, us…"

### DIFF
--- a/src/Application/Actions/GetPaymentMethods.php
+++ b/src/Application/Actions/GetPaymentMethods.php
@@ -41,22 +41,22 @@ class GetPaymentMethods extends Action
 
         $regularGivingPaymentMethod = null;
 
-        $nonRegularGivingMethods = array_values(array_filter(
+        // exclude payment methods with 'allow_redisplay' set to limited:
+        $displayableMethods = array_values(array_filter(
             $paymentMethodArray,
             static function (array $paymentMethod) use ($donor, &$regularGivingPaymentMethod) {
                 if ($paymentMethod['id'] === $donor->getRegularGivingPaymentMethod()?->stripePaymentMethodId) {
                     $regularGivingPaymentMethod = $paymentMethod;
-                    return false;
+                } else {
+                    return in_array($paymentMethod['allow_redisplay'], ['always', 'unspecified']);
                 }
-
-                return true;
             }
         ));
 
         return $this->respondWithData(
             $response,
             [
-                'data' => $nonRegularGivingMethods,
+                'data' => $displayableMethods,
                 'regularGivingPaymentMethod' => $regularGivingPaymentMethod
             ]
         );

--- a/src/Client/LiveStripeClient.php
+++ b/src/Client/LiveStripeClient.php
@@ -29,6 +29,7 @@ class LiveStripeClient implements Stripe
         'payment_element' => [
             'enabled' => true,
             'features' => [
+                'payment_method_allow_redisplay_filters' => ['always', 'unspecified'],
                 'payment_method_redisplay' => 'enabled',
                 'payment_method_redisplay_limit' => 3, // Keep default 3; 10 is max stripe allows.
                 // default value – need to ensure it stays off to avoid breaking Regular Giving by mistake,
@@ -100,6 +101,7 @@ class LiveStripeClient implements Stripe
         $components = self::SESSION_COMPONENTS;
         $components['payment_element']['features']['payment_method_save_usage'] = 'off_session';
         $components['payment_element']['features']['payment_method_redisplay'] = 'disabled';
+        unset($components['payment_element']['features']['payment_method_allow_redisplay_filters']);
         unset($components['payment_element']['features']['payment_method_redisplay_limit']);
 
         return $this->stripeClient->customerSessions->create([


### PR DESCRIPTION
Reverts thebiggive/matchbot#1351

I think losing the display of 'unspecified' methods is making regtests fail. Will look in more detail tomorrow.