### PR TITLE
MAT-421 – matching recovery

### DIFF
--- a/app/dependencies.php
+++ b/app/dependencies.php
@@ -538,15 +538,6 @@ return function (ContainerBuilder $containerBuilder) {
 
         EventDispatcherInterface::class => fn() => new EventDispatcher(),
 
-        Matching\Allocator::class => static function (ContainerInterface $c): Matching\Allocator {
-            return new Matching\Allocator(
-                $c->get(Matching\Adapter::class),
-                $c->get(CampaignFundingRepository::class),
-                $c->get(EntityManagerInterface::class),
-                $c->get(LoggerInterface::class),
-            );
-        },
-
         Auth\SalesforceAuthMiddleware::class =>
             function (ContainerInterface $c) {
                /**

--- a/app/repositories.php
+++ b/app/repositories.php
@@ -59,7 +59,6 @@ return static function (ContainerBuilder $containerBuilder) {
 
             $repo->setClient($c->get(Client\Donation::class));
             $repo->setLogger($c->get(LoggerInterface::class));
-            $repo->setMatchingAdapter($c->get(Matching\Adapter::class));
 
             return $repo;
         },

--- a/integrationTests/DonationMatchingTest.php
+++ b/integrationTests/DonationMatchingTest.php
@@ -55,9 +55,6 @@ class DonationMatchingTest extends IntegrationTest
         // arrange
         $this->matchingAdapater = $this->makeAdapterThatThrowsAfterSubtractingFunds($this->matchingAdapater);
         $this->setInContainer(Adapter::class, $this->matchingAdapater);
-        $donationRepository = $this->getService(\MatchBot\Domain\DonationRepository::class);
-        Assertion::isInstanceOf($donationRepository, DoctrineDonationRepository::class);
-        $donationRepository->setMatchingAdapter($this->matchingAdapater);
 
         $campaignInfo = $this->addFundedCampaignAndCharityToDB(
             campaignSfId: $this->randomString(),

--- a/integrationTests/DonationMatchingTest.php
+++ b/integrationTests/DonationMatchingTest.php
@@ -76,7 +76,7 @@ class DonationMatchingTest extends IntegrationTest
             $this->createDonation(
                 withPremadeCampaign: false,
                 campaignSfID: $campaign->getSalesforceId(),
-                amountInPounds: 10
+                amountInPounds: 10,
             );
         } catch (\Exception $e) {
             $this->assertEquals(

--- a/integrationTests/RedistributeMatchingCommandTest.php
+++ b/integrationTests/RedistributeMatchingCommandTest.php
@@ -7,15 +7,14 @@ use MatchBot\Application\Assertion;
 use MatchBot\Application\Commands\RedistributeMatchFunds;
 use MatchBot\Application\HttpModels\DonationCreate;
 use MatchBot\Application\Matching\Adapter;
+use MatchBot\Application\Matching\Allocator;
 use MatchBot\Application\Matching\MatchFundsRedistributor;
 use MatchBot\Domain\Campaign;
 use MatchBot\Domain\CampaignFunding;
 use MatchBot\Domain\CampaignFundingRepository;
 use MatchBot\Domain\CampaignRepository;
-use MatchBot\Domain\Fund;
 use MatchBot\Domain\Donation;
 use MatchBot\Domain\DonationRepository;
-use MatchBot\Domain\DonationService;
 use MatchBot\Domain\FundingWithdrawal;
 use MatchBot\Domain\FundType;
 use MatchBot\Domain\PaymentMethodType;
@@ -27,7 +26,6 @@ use Psr\Log\LoggerInterface;
 use Random\Randomizer;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\RoutableMessageBus;
@@ -229,6 +227,7 @@ class RedistributeMatchingCommandTest extends IntegrationTest
         $output = new BufferedOutput();
         $command = new RedistributeMatchFunds(
             new MatchFundsRedistributor(
+                allocator: $this->getService(Allocator::class),
                 chatter: $this->createStub(ChatterInterface::class),
                 donationRepository: $this->getService(DonationRepository::class),
                 now: new \DateTimeImmutable('now'),

--- a/integrationTests/StripeCancelsDonationTest.php
+++ b/integrationTests/StripeCancelsDonationTest.php
@@ -11,6 +11,8 @@ class StripeCancelsDonationTest extends IntegrationTest
 {
     public function testStripeCanCancelDonation(): void
     {
+        $this->markTestSkipped('See comment in StripePaymentsUpdate::handlePaymentIntentCancelled()');
+
         /**
          * @psalm-suppress MixedArrayAccess
          * @var array<string,string> $donation
@@ -32,6 +34,9 @@ class StripeCancelsDonationTest extends IntegrationTest
         );
     }
 
+    /**
+     * @psalm-suppress UnusedMethod will be used if we fix test
+     */
     private function sendCancellationWebhookFromStripe(string $transactionId): void
     {
         $paymentIntentId = $transactionId;

--- a/integrationTests/StripeCancelsDonationTest.php
+++ b/integrationTests/StripeCancelsDonationTest.php
@@ -40,9 +40,6 @@ class StripeCancelsDonationTest extends IntegrationTest
         );
     }
 
-    /**
-     * @psalm-suppress UnusedMethod will be used if we fix test
-     */
     private function sendCancellationWebhookFromStripe(string $transactionId): void
     {
         $paymentIntentId = $transactionId;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -247,6 +247,18 @@ parameters:
 			path: tests/Application/Matching/AdapterTest.php
 
 		-
+			message: '#^Call to function assert\(\) with true will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: tests/Application/Matching/AllocatorTest.php
+
+		-
+			message: '#^Loose comparison using \=\= between 4 and 4 will always evaluate to true\.$#'
+			identifier: equal.alwaysTrue
+			count: 1
+			path: tests/Application/Matching/AllocatorTest.php
+
+		-
 			message: '#^Access to an undefined property Prophecy\\Prophecy\\ObjectProphecy\<Stripe\\StripeClient\>\:\:\$balanceTransactions\.$#'
 			identifier: property.notFound
 			count: 5
@@ -263,18 +275,6 @@ parameters:
 			identifier: property.notFound
 			count: 1
 			path: tests/Application/Messenger/Handler/StripePayoutHandlerTest.php
-
-		-
-			message: '#^Call to function assert\(\) with true will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: tests/Domain/DonationRepositoryMatchFundsAllocationTest.php
-
-		-
-			message: '#^Loose comparison using \=\= between 4 and 4 will always evaluate to true\.$#'
-			identifier: equal.alwaysTrue
-			count: 1
-			path: tests/Domain/DonationRepositoryMatchFundsAllocationTest.php
 
 		-
 			message: '#^Property Stripe\\ConfirmationToken\:\:\$payment_method_preview \(Stripe\\StripeObject\|null\) does not accept array\<string, array\<string, string\>\>\.$#'

--- a/phpunit-integration.xml
+++ b/phpunit-integration.xml
@@ -1,5 +1,19 @@
 <?xml version="1.0"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" backupStaticAttributes="false" beStrictAboutTestsThatDoNotTestAnything="true" beStrictAboutChangesToGlobalState="true" beStrictAboutOutputDuringTests="true" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="integrationTests/bootstrap.php">
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+        backupGlobals="false"
+        backupStaticAttributes="false"
+        beStrictAboutTestsThatDoNotTestAnything="true"
+        beStrictAboutChangesToGlobalState="true"
+        beStrictAboutOutputDuringTests="true"
+        colors="true"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+        processIsolation="true"
+        stopOnFailure="false"
+        bootstrap="integrationTests/bootstrap.php">
   <coverage processUncoveredFiles="true">
     <include>
       <directory suffix=".php">./src</directory>

--- a/src/Application/Actions/Donations/Create.php
+++ b/src/Application/Actions/Donations/Create.php
@@ -15,6 +15,7 @@ use MatchBot\Application\Auth\PersonManagementAuthMiddleware;
 use MatchBot\Application\Auth\PersonWithPasswordAuthMiddleware;
 use MatchBot\Application\HttpModels\DonationCreate;
 use MatchBot\Application\HttpModels\DonationCreatedResponse;
+use MatchBot\Application\Matching\DbErrorPreventedMatch;
 use MatchBot\Application\Messenger\DonationUpserted;
 use MatchBot\Client\Stripe;
 use MatchBot\Domain\DomainException\CampaignNotOpen;
@@ -177,7 +178,7 @@ class Create extends Action
                     ),
                 ),
             );
-        } catch (ORMException | DBALServerException $ex) {
+        } catch (ORMException | DBALServerException | DbErrorPreventedMatch $ex) {
             // '(D)' errors are DB persistence issues, typically ones that still exist after some retries.
             return $this->respond(
                 $response,

--- a/src/Application/Actions/Hooks/StripePaymentsUpdate.php
+++ b/src/Application/Actions/Hooks/StripePaymentsUpdate.php
@@ -355,10 +355,6 @@ class StripePaymentsUpdate extends Stripe
         \assert($paymentIntent instanceof PaymentIntent);
 
         $this->entityManager->beginTransaction();
-        // Locking this fails StripeCancelsDonationTest currently, probably because of
-        // https://github.com/doctrine/orm/issues/9505 combined with the test creating and
-        // then patching the donation in one thread? Doctrine doesn't recognise the donation
-        // to cancel as the same and gets an error trying to set the readonly $amount property.
         $donation = $this->donationRepository->findAndLockOneBy(['transactionId' => $paymentIntent->id]);
 
         if ($donation === null) {

--- a/src/Application/Actions/Status.php
+++ b/src/Application/Actions/Status.php
@@ -11,7 +11,6 @@ use JetBrains\PhpStorm\Pure;
 use MatchBot\Application\Assertion;
 use MatchBot\Domain\Campaign;
 use MatchBot\Domain\CampaignFunding;
-use MatchBot\Domain\Fund;
 use MatchBot\Domain\Charity;
 use MatchBot\Domain\Donation;
 use MatchBot\Domain\FundingWithdrawal;

--- a/src/Application/Commands/HandleOutOfSyncFunds.php
+++ b/src/Application/Commands/HandleOutOfSyncFunds.php
@@ -92,11 +92,13 @@ class HandleOutOfSyncFunds extends LockingCommand
                 continue;
             }
 
-            // Amount allocated from the CampaignFunding
+            // Amount allocated from the CampaignFunding according to Redis which is the source
+            // of truth for these balances.
             $fundingAvailable = $this->matchingAdapter->getAmountAvailable($funding);
             $campaignFundingAllocated = bcsub($funding->getAmount(), $fundingAvailable, 2);
 
-            // Get the sum of all FundingWithdrawals for donations, whether complete or active reservations.
+            // Get the sum of all FundingWithdrawals for donations, whether complete or active reservations,
+            // according to the database.
             $fundingWithdrawalTotal = $this->fundingWithdrawalRepository->getWithdrawalsTotal($funding);
 
             $comparison = bccomp($campaignFundingAllocated, $fundingWithdrawalTotal, 2);

--- a/src/Application/Commands/RetrospectivelyMatch.php
+++ b/src/Application/Commands/RetrospectivelyMatch.php
@@ -7,6 +7,7 @@ namespace MatchBot\Application\Commands;
 use DateTime;
 use Doctrine\ORM\EntityManagerInterface;
 use MatchBot\Application\Assertion;
+use MatchBot\Application\Matching\Allocator;
 use MatchBot\Application\Matching\MatchFundsRedistributor;
 use MatchBot\Application\Messenger\DonationUpserted;
 use MatchBot\Application\Messenger\FundTotalUpdated;
@@ -46,6 +47,7 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 class RetrospectivelyMatch extends LockingCommand
 {
     public function __construct(
+        private Allocator $allocator,
         private DonationRepository $donationRepository,
         private FundRepository $fundRepository,
         private ChatterInterface $chatter,
@@ -92,7 +94,7 @@ class RetrospectivelyMatch extends LockingCommand
         $totalNewMatching = '0.00';
 
         foreach ($toCheckForMatching as $donation) {
-            $amountAllocated = $this->donationRepository->allocateMatchFunds($donation);
+            $amountAllocated = $this->allocator->allocateMatchFunds($donation);
 
             if (bccomp($amountAllocated, '0.00', 2) === 1) {
                 $this->entityManager->flush();

--- a/src/Application/Matching/Allocator.php
+++ b/src/Application/Matching/Allocator.php
@@ -6,6 +6,7 @@ namespace MatchBot\Application\Matching;
 
 use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\ORM\EntityManagerInterface;
+use MatchBot\Application\Assertion;
 use MatchBot\Domain\CampaignFunding;
 use MatchBot\Domain\CampaignFundingRepository;
 use MatchBot\Domain\Donation;
@@ -24,7 +25,9 @@ class Allocator
         private EntityManagerInterface $entityManager,
         private LoggerInterface $logger,
     ) {
-        $this->campaignFundingRepository = $entityManager->getRepository(CampaignFunding::class);
+        $campaignFundingRepo = $entityManager->getRepository(CampaignFunding::class);
+        \assert($campaignFundingRepo instanceof CampaignFundingRepository);
+        $this->campaignFundingRepository = $campaignFundingRepo;
     }
 
     /**
@@ -39,6 +42,8 @@ class Allocator
      */
     public function allocateMatchFunds(Donation $donation): string
     {
+        Assertion::notNull($this->campaignFundingRepository);
+
         // We look up matching withdrawals to allow for the case where retrospective matching was required
         // and the donation is not new, and *some* (or full) matching already occurred. The collection of withdrawals
         // is most often empty (for new donations) so this will frequently be 0.00.

--- a/src/Application/Matching/Allocator.php
+++ b/src/Application/Matching/Allocator.php
@@ -27,7 +27,7 @@ class Allocator
     ) {
         // For now, just type this as a few tests don't set it up. We assert before use in allocateMatchFunds() where
         // it's really needed.
-        /** @var CampaignFundingRepository $campaignFundingRepo */
+        /** @var CampaignFundingRepository $campaignFundingRepo */ // @phpstan-ignore varTag.type
         $campaignFundingRepo = $entityManager->getRepository(CampaignFunding::class);
         $this->campaignFundingRepository = $campaignFundingRepo;
     }

--- a/src/Application/Matching/Allocator.php
+++ b/src/Application/Matching/Allocator.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Application\Matching;
+
+use Doctrine\DBAL\Exception as DBALException;
+use Doctrine\ORM\EntityManagerInterface;
+use MatchBot\Domain\CampaignFunding;
+use MatchBot\Domain\CampaignFundingRepository;
+use MatchBot\Domain\Donation;
+use MatchBot\Domain\FundingWithdrawal;
+use Psr\Log\LoggerInterface;
+
+class Allocator
+{
+    public function __construct(
+        private Adapter $adapter,
+        private CampaignFundingRepository $campaignFundingRepository,
+        private EntityManagerInterface $entityManager,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * Create all funding allocations, with `FundingWithdrawal` links to this donation, and safely update the funds'
+     * available amount figures.
+     *
+     * @param Donation $donation
+     * @psalm-return numeric-string Total amount of matching *newly* allocated. Return value is only used in
+     *                              retrospective matching and redistribution commands - Donation::create does not take
+     *                              return value.
+     * @see CampaignFundingRepository::getAvailableFundings() for lock acquisition detail
+     */
+    public function allocateMatchFunds(Donation $donation): string
+    {
+        // We look up matching withdrawals to allow for the case where retrospective matching was required
+        // and the donation is not new, and *some* (or full) matching already occurred. The collection of withdrawals
+        // is most often empty (for new donations) so this will frequently be 0.00.
+        $amountMatchedAtStart = $donation->getFundingWithdrawalTotal();
+
+        $allocateStartTime = 0; // dummy value, should always be overwritten before usage.
+        try {
+            /** @var list<CampaignFunding> $likelyAvailableFunds */
+            $likelyAvailableFunds = $this->campaignFundingRepository->getAvailableFundings($donation->getCampaign());
+
+            foreach ($likelyAvailableFunds as $funding) {
+                if ($funding->getCurrencyCode() !== $donation->currency()->isoCode()) {
+                    throw new \UnexpectedValueException('Currency mismatch');
+                }
+            }
+
+            $allocateStartTime = microtime(true);
+            $newWithdrawals = $this->allocateFundsAndPrepareDBChanges($donation, $likelyAvailableFunds, $amountMatchedAtStart);
+            $allocateEndTime = microtime(true);
+        } catch (TerminalLockException $exception) {
+            $waitTime = round(microtime(true) - (float)$allocateStartTime, 6);
+            $this->logError(
+                "Match allocate error: ID {$donation->getUuid()} got " . get_class($exception) .
+                " after {$waitTime}s: {$exception->getMessage()}"
+            );
+            throw $exception; // Re-throw exception after logging the details if not recoverable
+        }
+
+        $amountNewlyMatched = '0.0';
+
+        foreach ($newWithdrawals as $newWithdrawal) {
+            $this->entityManager->persist($newWithdrawal);
+            $donation->addFundingWithdrawal($newWithdrawal);
+            $newWithdrawalAmount = $newWithdrawal->getAmount();
+
+            $amountNewlyMatched = bcadd($amountNewlyMatched, $newWithdrawalAmount, 2);
+        }
+
+        try {
+            // Flush `$newWithdrawals` if any and updates to DB copies of CampaignFundings.
+            $this->entityManager->flush();
+        } catch (\Throwable $exception) {
+            $this->adapter->releaseNewlyAllocatedFunds();
+
+            // Ensure nothing later tries to persist the pending Donation or CampaignFunding changes.
+            $this->entityManager->close();
+            throw new DbErrorPreventedMatch(
+                'Failed to flush DB for new withdrawals so donation UUID ' . $donation->getUuid()->toString() .
+                ' did not get matching: ' . $exception->getMessage(),
+            );
+        }
+
+        $this->logInfo('ID ' . $donation->getUuid()->toString() . ' allocated new match funds totalling ' . $amountNewlyMatched);
+        $this->logInfo('Allocation took ' . (string) round($allocateEndTime - $allocateStartTime, 6) . ' seconds');
+
+        return $amountNewlyMatched;
+    }
+
+    /**
+     * This method is safe for general use only inside transations.
+     *
+     * Prefer {@see DonationService::releaseMatchFundsInTransaction()} if you're not updating internals and don't
+     * have a reason otherwise.
+     *
+     * @psalm-internal MatchBot\Domain
+     * @param Donation $donation
+     * @throws TerminalLockException
+     */
+    public function releaseMatchFunds(Donation $donation): void
+    {
+        $startTime = microtime(true);
+        try {
+            $totalAmountReleased = $this->adapter->releaseAllFundsForDonation($donation);
+            $this->entityManager->flush();
+            $endTime = microtime(true);
+
+            try {
+                $this->removeAllFundingWithdrawalsForDonation($donation);
+            } catch (DBALException $exception) {
+                $this->logError('Doctrine could not remove withdrawals after maximum tries');
+            }
+        } catch (TerminalLockException $exception) {
+            $waitTime = round(microtime(true) - $startTime, 6);
+            $this->logError(
+                'Match release error: ID ' . $donation->getUuid()->toString() . ' got ' . get_class($exception) .
+                " after {$waitTime}s: {$exception->getMessage()}"
+            );
+            throw $exception; // Re-throw exception after logging the details if not recoverable
+        }
+
+        $this->logInfo("Taking from ID {$donation->getUuid()} released match funds totalling {$totalAmountReleased}");
+        $this->logInfo('Deallocation took ' . (string) round($endTime - $startTime, 6) . ' seconds');
+    }
+
+    /**
+     * Attempt an allocation of funds. When all is well this:
+     *
+     * * updates the Redis authoritative store of fund balances,
+     * * updates the CampaignFunding balances from those copies to match (in entity manager but not flushed yet); and
+     * * updates the FundingWithdrawal records in the entity manager (also not flushed yet).
+     *
+     * @param Donation $donation
+     * @param CampaignFunding[] $fundings   Fundings likely to have funds available. To be re-queried with a
+     *                                      pessimistic write lock before allocation.
+     *
+     * @param numeric-string $amountMatchedAtStart Amount of match funds already allocated to the donation when we
+     *                                              started.
+     * @return FundingWithdrawal[]
+     */
+    private function allocateFundsAndPrepareDBChanges(Donation $donation, array $fundings, string $amountMatchedAtStart): array
+    {
+        $amountLeftToMatch = bcsub($donation->getAmount(), $amountMatchedAtStart, 2);
+        $currentFundingIndex = 0;
+        /** @var FundingWithdrawal[] $newWithdrawals Track these to persist to DB after the main allocation */
+        $newWithdrawals = [];
+
+        // Loop as long as there are still campaign funds not allocated and we have allocated less than the donation
+        // amount
+        while ($currentFundingIndex < count($fundings) && bccomp($amountLeftToMatch, '0.00', 2) === 1) {
+            $funding = $fundings[$currentFundingIndex];
+            $startAmountAvailable = $fundings[$currentFundingIndex]->getAmountAvailable();
+
+            if (bccomp($funding->getAmountAvailable(), $amountLeftToMatch, 2) === -1) {
+                $amountToAllocateNow = $startAmountAvailable;
+            } else {
+                $amountToAllocateNow = $amountLeftToMatch;
+            }
+
+            $newTotal = '[new total not defined]';
+            try {
+                $newTotal = $this->adapter->subtractAmount($funding, $amountToAllocateNow);
+                $amountAllocated = $amountToAllocateNow; // If no exception thrown
+            } catch (LessThanRequestedAllocatedException $exception) {
+                $amountAllocated = $exception->getAmountAllocated();
+                $this->logInfo(
+                    "Amount available from funding ID {$funding->getId()} changed: - got $amountAllocated " .
+                    "of requested $amountToAllocateNow"
+                );
+            }
+
+            $amountLeftToMatch = bcsub($amountLeftToMatch, $amountAllocated, 2);
+
+            if (bccomp($amountAllocated, '0.00', 2) === 1) {
+                $withdrawal = new FundingWithdrawal($funding);
+                $withdrawal->setDonation($donation);
+                $withdrawal->setAmount($amountAllocated);
+                $newWithdrawals[] = $withdrawal;
+                $this->logInfo("Successfully withdrew $amountAllocated from funding ID {$funding->getId()} for UUID {$donation->getUuid()}");
+                $this->logInfo("New fund total for {$funding->getId()}: $newTotal");
+            }
+
+            $currentFundingIndex++;
+        }
+
+        return $newWithdrawals;
+    }
+
+    /**
+     * Normally called just as part of releaseMatchFunds which also releases the funds in Redis. But
+     * used separately in case of a crash when we would need to release the funds in Redis whether or not
+     * we have any FundingWithdrawals in MySQL.
+     */
+    private function removeAllFundingWithdrawalsForDonation(Donation $donation): void
+    {
+        $this->entityManager->wrapInTransaction(function () use ($donation) {
+            foreach ($donation->getFundingWithdrawals() as $fundingWithdrawal) {
+                $this->entityManager->remove($fundingWithdrawal);
+            }
+        });
+    }
+
+    private function logError(string $message): void
+    {
+        $this->logger->error($message);
+    }
+
+    private function logInfo(string $message): void
+    {
+        $this->logger->info($message);
+    }
+}

--- a/src/Application/Matching/Allocator.php
+++ b/src/Application/Matching/Allocator.php
@@ -25,8 +25,10 @@ class Allocator
         private EntityManagerInterface $entityManager,
         private LoggerInterface $logger,
     ) {
+        // For now, just type this as a few tests don't set it up. We assert before use in allocateMatchFunds() where
+        // it's really needed.
+        /** @var CampaignFundingRepository $campaignFundingRepo */
         $campaignFundingRepo = $entityManager->getRepository(CampaignFunding::class);
-        \assert($campaignFundingRepo instanceof CampaignFundingRepository);
         $this->campaignFundingRepository = $campaignFundingRepo;
     }
 

--- a/src/Application/Matching/Allocator.php
+++ b/src/Application/Matching/Allocator.php
@@ -14,12 +14,17 @@ use Psr\Log\LoggerInterface;
 
 class Allocator
 {
+    /**
+     * Seems we must do this dynamically to avoid circular dependency. Remains null for some tests for now.
+     */
+    private ?CampaignFundingRepository $campaignFundingRepository = null;
+
     public function __construct(
         private Adapter $adapter,
-        private CampaignFundingRepository $campaignFundingRepository,
         private EntityManagerInterface $entityManager,
         private LoggerInterface $logger,
     ) {
+        $this->campaignFundingRepository = $entityManager->getRepository(CampaignFunding::class);
     }
 
     /**

--- a/src/Application/Matching/DbErrorPreventedMatch.php
+++ b/src/Application/Matching/DbErrorPreventedMatch.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Application\Matching;
+
+class DbErrorPreventedMatch extends \Exception
+{}

--- a/src/Application/Matching/DbErrorPreventedMatch.php
+++ b/src/Application/Matching/DbErrorPreventedMatch.php
@@ -5,4 +5,5 @@ declare(strict_types=1);
 namespace MatchBot\Application\Matching;
 
 class DbErrorPreventedMatch extends \Exception
-{}
+{
+}

--- a/src/Application/Matching/MatchFundsRedistributor.php
+++ b/src/Application/Matching/MatchFundsRedistributor.php
@@ -8,7 +8,6 @@ use MatchBot\Application\Messenger\DonationUpserted;
 use MatchBot\Domain\CampaignFundingRepository;
 use MatchBot\Domain\DonationRepository;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\RoutableMessageBus;
 use Symfony\Component\Notifier\Bridge\Slack\Block\SlackHeaderBlock;
 use Symfony\Component\Notifier\Bridge\Slack\Block\SlackSectionBlock;
@@ -19,6 +18,7 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 class MatchFundsRedistributor
 {
     public function __construct(
+        private Allocator $allocator,
         private ChatterInterface $chatter,
         private DonationRepository $donationRepository,
         private \DateTimeImmutable $now,
@@ -89,8 +89,8 @@ class MatchFundsRedistributor
             // take action.
 
             /** @psalm-suppress InternalMethod */
-            $this->donationRepository->releaseMatchFunds($donation);
-            $amountMatchedAfterRedistribution = $this->donationRepository->allocateMatchFunds($donation);
+            $this->allocator->releaseMatchFunds($donation);
+            $amountMatchedAfterRedistribution = $this->allocator->allocateMatchFunds($donation);
 
             // If the new allocation is less, log an error but still count the donation and continue with the loop.
             // We don't expect to actually see this happen as we now intend to run the script only for closed campaigns.

--- a/src/Application/Messenger/Handler/GiftAidResultHandler.php
+++ b/src/Application/Messenger/Handler/GiftAidResultHandler.php
@@ -28,8 +28,10 @@ class GiftAidResultHandler
             $donationMessage->id,
         ));
 
+        $this->entityManager->beginTransaction();
+
         /** @var Donation $donation */
-        $donation = $this->donationRepository->findOneByUUID(Uuid::fromString($donationMessage->id));
+        $donation = $this->donationRepository->findAndLockOneByUUID(Uuid::fromString($donationMessage->id));
 
         if ($donationMessage->response_success === false) {
             $donation->setTbgGiftAidRequestFailedAt(new \DateTime());
@@ -51,5 +53,6 @@ class GiftAidResultHandler
 
         $this->entityManager->persist($donation);
         $this->entityManager->flush();
+        $this->entityManager->commit();
     }
 }

--- a/src/Application/Messenger/Handler/GiftAidResultHandler.php
+++ b/src/Application/Messenger/Handler/GiftAidResultHandler.php
@@ -28,31 +28,30 @@ class GiftAidResultHandler
             $donationMessage->id,
         ));
 
-        $this->entityManager->beginTransaction();
+        $this->entityManager->wrapInTransaction(function () use ($donationMessage) {
+            /** @var Donation $donation */
+            $donation = $this->donationRepository->findAndLockOneByUUID(Uuid::fromString($donationMessage->id));
 
-        /** @var Donation $donation */
-        $donation = $this->donationRepository->findAndLockOneByUUID(Uuid::fromString($donationMessage->id));
+            if ($donationMessage->response_success === false) {
+                $donation->setTbgGiftAidRequestFailedAt(new \DateTime());
+            }
 
-        if ($donationMessage->response_success === false) {
-            $donation->setTbgGiftAidRequestFailedAt(new \DateTime());
-        }
+            if ($donationMessage->response_success === true) {
+                $donation->setTbgGiftAidRequestConfirmedCompleteAt(new \DateTime());
+            }
 
-        if ($donationMessage->response_success === true) {
-            $donation->setTbgGiftAidRequestConfirmedCompleteAt(new \DateTime());
-        }
+            if ($donationMessage->submission_correlation_id !== null && $donationMessage->submission_correlation_id !== '') {
+                $donation->setTbgGiftAidRequestCorrelationId($donationMessage->submission_correlation_id);
+            }
 
-        if ($donationMessage->submission_correlation_id !== null && $donationMessage->submission_correlation_id !== '') {
-            $donation->setTbgGiftAidRequestCorrelationId($donationMessage->submission_correlation_id);
-        }
+            if ($donationMessage->response_detail !== null && $donationMessage->response_detail !== '') {
+                $donation->setTbgGiftAidResponseDetail($donationMessage->response_detail);
+            }
 
-        if ($donationMessage->response_detail !== null && $donationMessage->response_detail !== '') {
-            $donation->setTbgGiftAidResponseDetail($donationMessage->response_detail);
-        }
+            $donation->setSalesforcePushStatus(SalesforceWriteProxy::PUSH_STATUS_PENDING_UPDATE);
 
-        $donation->setSalesforcePushStatus(SalesforceWriteProxy::PUSH_STATUS_PENDING_UPDATE);
-
-        $this->entityManager->persist($donation);
-        $this->entityManager->flush();
-        $this->entityManager->commit();
+            $this->entityManager->persist($donation);
+            $this->entityManager->flush();
+        });
     }
 }

--- a/src/Domain/DonationRepository.php
+++ b/src/Domain/DonationRepository.php
@@ -200,4 +200,6 @@ interface DonationRepository
     public function findOneBy(array $criteria);
 
     public function findOneByUUID(UuidInterface $donationUUID): ?Donation;
+
+//    public function reverseMatchingAllocations(Donation $donation, array $newWithdrawals, array $likelyAvailableFundings): void;
 }

--- a/src/Domain/DonationRepository.php
+++ b/src/Domain/DonationRepository.php
@@ -200,6 +200,4 @@ interface DonationRepository
     public function findOneBy(array $criteria);
 
     public function findOneByUUID(UuidInterface $donationUUID): ?Donation;
-
-//    public function reverseMatchingAllocations(Donation $donation, array $newWithdrawals, array $likelyAvailableFundings): void;
 }

--- a/src/Domain/DonationService.php
+++ b/src/Domain/DonationService.php
@@ -956,18 +956,4 @@ class DonationService
 
         return $donation;
     }
-
-    private function confirmEmHasNoRelaventChanges(): void
-    {
-        $unitOfWork = $this->entityManager->getUnitOfWork();
-        $unitOfWork->computeChangeSets();
-
-        Assertion::false($unitOfWork->hasPendingInsertions());
-        $identityMap = $unitOfWork->getIdentityMap();
-
-        // may have to clear em between redistrubte  match and retro match funds loop iterations.
-
-        Assertion::keyNotExists($identityMap, FundingWithdrawal::class, 'Entity Manager must not have managed FWs before funding allocation');
-        Assertion::keyNotExists($identityMap, CampaignFunding::class, 'Entity Manager must not have managed FWs before funding allocation');
-    }
 }

--- a/src/Domain/DonationService.php
+++ b/src/Domain/DonationService.php
@@ -217,8 +217,7 @@ class DonationService
      */
     private function runWithPossibleRetry(
         \Closure $retryable,
-        string $actionName,
-        ?\Closure $onErrorTidy = null
+        string $actionName
     ): void {
         $retryCount = 0;
         while ($retryCount < self::MAX_RETRY_COUNT) {
@@ -232,12 +231,6 @@ class DonationService
                 }
                 return;
             } catch (RetryableException $exception) {
-                if ($onErrorTidy) {
-                    $this->logger->info(sprintf('%s retryable error will tidy up', $actionName));
-                    $onErrorTidy();
-                    $this->logger->info(sprintf('%s retryable error did tidy up', $actionName));
-                }
-
                 $retryCount++;
                 $this->logger->info(
                     sprintf(
@@ -262,15 +255,6 @@ class DonationService
 
                     throw $exception;
                 }
-            } catch (\Throwable $exception) {
-                if ($onErrorTidy) {
-                    $this->logger->info(sprintf('%s non-retryable error will tidy up', $actionName));
-                    $onErrorTidy();
-                    $this->logger->info(sprintf('%s non-retryable error did tidy up', $actionName));
-                }
-
-                // No retries for exceptions we aren't confident of recovering from
-                throw $exception;
             }
         }
     }

--- a/src/Domain/DonationService.php
+++ b/src/Domain/DonationService.php
@@ -383,29 +383,42 @@ class DonationService
         // Handling txn ourselves because Doctrine closes EM on errors. We want to only remove the new Donation from
         // tracking instead so that a retry can work.
         $this->entityManager->beginTransaction();
+        echo __FILE__ . ':' . __LINE__ . " Started transaction\n";
 
         // Must persist before Stripe work to have ID available. Outer fn throws if all attempts fail.
         // @todo-MAT-388: remove runWithPossibleRetry if we determine its not useful and unwrap body of function below
         $this->runWithPossibleRetry(function () use ($donation) {
+            echo __FILE__ . ':' . __LINE__ . " Persisting donation\n";
             $this->entityManager->persist($donation);
             try {
+                echo __FILE__ . ':' . __LINE__ . " Flushing donation\n";
                 $this->entityManager->flush();
+                echo __FILE__ . ':' . __LINE__ . " Did flush donation\n";
             } catch (\Throwable $exception) {
+                echo __FILE__ . ':' . __LINE__ . " Will rollback: {$exception->getMessage()}\n";
                 $this->entityManager->rollback();
+                echo __FILE__ . ':' . __LINE__ . " Will detach donation\n";
                 $this->entityManager->detach($donation);
+                echo __FILE__ . ':' . __LINE__ . " Detached donation\n";
                 throw $exception;
             }
         }, 'Donation Create persist before stripe work');
 
         if ($campaign->isMatched() && $attemptMatching) {
             try {
+                echo __FILE__ . ':' . __LINE__ . " Attempting funding allocation\n";
                 $this->attemptFundingAllocation($donation);
-            } catch (RetryableException) { // here
+            } catch (RetryableException) {
+                echo __FILE__ . ':' . __LINE__ . " Attempting funding allocation second time\n";
                 $this->attemptFundingAllocation($donation);
             }
         }
 
+        echo __FILE__ . ':' . __LINE__ . " Will commit\n";
+
         $this->entityManager->commit();
+
+        echo __FILE__ . ':' . __LINE__ . " Did commit\n";
 
         // Regular Giving enrolls donations with `DonationStatus::PreAuthorized`, which get Payment Intents later instead.
         if ($donation->getPsp() === 'stripe' && $donation->getDonationStatus() === DonationStatus::Pending) {

--- a/src/Migrations/Version20250515172831.php
+++ b/src/Migrations/Version20250515172831.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Patch a donation to get Regression fund balances in sync.
+ */
+final class Version20250515172831 extends AbstractMigration
+{
+    private $donationId = 248739;
+
+    public function getDescription(): string
+    {
+        return 'Patch a donation to £3 so balances are in sync, only in Regression';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if (getenv('APP_ENV') !== 'regression') {
+            return;
+        }
+
+        $donationId = $this->donationId;
+        $this->addSql("UPDATE Donation SET amount = 3 WHERE id = $donationId LIMIT 1");
+        $this->addSql("UPDATE FundingWithdrawal SET amount = 3 WHERE donation_id = $donationId LIMIT 1");
+    }
+
+    public function down(Schema $schema): void
+    {
+        if (getenv('APP_ENV') !== 'regression') {
+            return;
+        }
+
+        $donationId = $this->donationId;
+        $this->addSql("UPDATE Donation SET amount = 1 WHERE id = $donationId LIMIT 1");
+        $this->addSql("UPDATE FundingWithdrawal SET amount = 1 WHERE donation_id = $donationId LIMIT 1");
+    }
+}

--- a/src/Migrations/Version20250515172831.php
+++ b/src/Migrations/Version20250515172831.php
@@ -12,7 +12,7 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20250515172831 extends AbstractMigration
 {
-    private $donationId = 248739;
+    private int $donationId = 248739;
 
     public function getDescription(): string
     {

--- a/tests/Application/Actions/Donations/ConfirmTest.php
+++ b/tests/Application/Actions/Donations/ConfirmTest.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace MatchBot\Tests\Application\Actions\Donations;
 
-use Assert\AssertionFailedException;
 use Doctrine\ORM\EntityManagerInterface;
 use MatchBot\Application\Actions\Donations\Confirm;
-use MatchBot\Application\Environment;
 use MatchBot\Application\HttpModels\DonationCreate;
 use MatchBot\Application\Matching\Adapter;
+use MatchBot\Application\Matching\Allocator;
 use MatchBot\Client\Stripe;
 use MatchBot\Domain\CampaignRepository;
 use MatchBot\Domain\Donation;
@@ -78,6 +77,7 @@ class ConfirmTest extends TestCase
             bus: $messageBusStub,
             clock: new MockClock('2025-01-01'),
             donationService: new DonationService(
+                allocator: $this->createStub(Allocator::class),
                 donationRepository: $this->getDonationRepository(),
                 campaignRepository: $this->createStub(CampaignRepository::class),
                 logger: new NullLogger(),

--- a/tests/Application/Actions/Donations/CreateTest.php
+++ b/tests/Application/Actions/Donations/CreateTest.php
@@ -6,7 +6,7 @@ namespace MatchBot\Tests\Application\Actions\Donations;
 
 use Doctrine\Common\Cache\CacheProvider;
 use Doctrine\DBAL\Exception\ServerException as DBALServerException;
-use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\ORM\UnitOfWork;
 use Los\RateLimit\Exception\MissingRequirement;
 use MatchBot\Application\Actions\ActionPayload;
 use MatchBot\Application\Matching\Allocator;
@@ -134,8 +134,14 @@ class CreateTest extends TestCase
         $config = $configurationProphecy->reveal();
         $configurationProphecy->getResultCacheImpl()->willReturn($this->createStub(CacheProvider::class));
 
+        $emptyUow = $this->prophesize(UnitOfWork::class);
+        $emptyUow->computeChangeSets()->willReturn(null); // void
+        $emptyUow->hasPendingInsertions()->willReturn(false);
+        $emptyUow->getIdentityMap()->willReturn([]);
+
         $this->entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
         $this->entityManagerProphecy->getConfiguration()->willReturn($config);
+        $this->entityManagerProphecy->getUnitOfWork()->willReturn($emptyUow->reveal());
         $this->diContainer()->set(EntityManagerInterface::class, $this->entityManagerProphecy->reveal());
 
         $this->diContainer()->set(CampaignRepository::class, $this->campaignRepositoryProphecy->reveal());

--- a/tests/Application/Actions/Donations/CreateTest.php
+++ b/tests/Application/Actions/Donations/CreateTest.php
@@ -243,6 +243,13 @@ class CreateTest extends TestCase
         $this->entityManagerProphecy->isOpen()->willReturn(true);
         $this->entityManagerProphecy->persist(Argument::type(Donation::class))->shouldBeCalledOnce();
         $this->entityManagerProphecy->flush()->shouldBeCalledOnce();
+        /**
+         * @psalm-suppress MixedFunctionCall
+         */
+        $this->entityManagerProphecy->wrapInTransaction(Argument::type(\Closure::class))
+            ->will(function (array $args): mixed {
+                return $args[0]();
+            });
 
         $this->stripeProphecy->createPaymentIntent(Argument::any())->shouldNotBeCalled();
 
@@ -905,6 +912,13 @@ class CreateTest extends TestCase
         }
 
         $this->entityManagerProphecy->isOpen()->willReturn(true);
+        /**
+         * @psalm-suppress MixedFunctionCall
+         */
+        $this->entityManagerProphecy->wrapInTransaction(Argument::type(\Closure::class))
+            ->will(function (array $args): mixed {
+                return $args[0]();
+            });
 
         if ($donationPersisted) {
             if (!$skipEmExpectations) {

--- a/tests/Application/Actions/Donations/CreateTest.php
+++ b/tests/Application/Actions/Donations/CreateTest.php
@@ -243,13 +243,8 @@ class CreateTest extends TestCase
         $this->entityManagerProphecy->isOpen()->willReturn(true);
         $this->entityManagerProphecy->persist(Argument::type(Donation::class))->shouldBeCalledOnce();
         $this->entityManagerProphecy->flush()->shouldBeCalledOnce();
-        /**
-         * @psalm-suppress MixedFunctionCall
-         */
-        $this->entityManagerProphecy->wrapInTransaction(Argument::type(\Closure::class))
-            ->will(function (array $args): mixed {
-                return $args[0]();
-            });
+        $this->entityManagerProphecy->beginTransaction()->willReturn(null);
+        $this->entityManagerProphecy->commit()->willReturn(null);
 
         $this->stripeProphecy->createPaymentIntent(Argument::any())->shouldNotBeCalled();
 
@@ -912,13 +907,8 @@ class CreateTest extends TestCase
         }
 
         $this->entityManagerProphecy->isOpen()->willReturn(true);
-        /**
-         * @psalm-suppress MixedFunctionCall
-         */
-        $this->entityManagerProphecy->wrapInTransaction(Argument::type(\Closure::class))
-            ->will(function (array $args): mixed {
-                return $args[0]();
-            });
+        $this->entityManagerProphecy->beginTransaction()->willReturn(null);
+        $this->entityManagerProphecy->commit()->willReturn(null);
 
         if ($donationPersisted) {
             if (!$skipEmExpectations) {

--- a/tests/Application/Actions/Donations/CreateTest.php
+++ b/tests/Application/Actions/Donations/CreateTest.php
@@ -806,7 +806,10 @@ class CreateTest extends TestCase
         $this->assertEquals('123CampaignId12345', $payloadArray['donation']['projectId']);
     }
 
-    public function testErrorWhenAllDbPersistCallsFail(): void
+    /**
+     * Persist itself failing with a non-retryable exception should mean we give up immediately.
+     */
+    public function testErrorWhenDbPersistCallFails(): void
     {
         $donation = $this->getTestDonation(true, true, true);
 
@@ -821,7 +824,7 @@ class CreateTest extends TestCase
         $this->entityManagerProphecy->isOpen()->willReturn(true);
         $this->entityManagerProphecy->persist(Argument::type(Donation::class))
             ->willThrow($this->prophesize(DBALServerException::class)->reveal())
-            ->shouldBeCalledTimes(3); // DonationService::MAX_RETRY_COUNT
+            ->shouldBeCalledOnce(); // DonationService::MAX_RETRY_COUNT
         $this->entityManagerProphecy->flush()->shouldNotBeCalled();
 
         $this->diContainer()->set(ClockInterface::class, new MockClock($this->now));

--- a/tests/Application/Actions/Donations/GetTest.php
+++ b/tests/Application/Actions/Donations/GetTest.php
@@ -6,6 +6,7 @@ namespace MatchBot\Tests\Application\Actions\Donations;
 
 use DI\Container;
 use MatchBot\Application\Auth\DonationToken;
+use MatchBot\Application\Matching\Allocator;
 use MatchBot\Domain\CampaignRepository;
 use MatchBot\Domain\DonationRepository;
 use MatchBot\Domain\DonorAccountRepository;
@@ -33,6 +34,7 @@ class GetTest extends TestCase
         assert($container instanceof Container);
         $this->donationRepository = new InMemoryDonationRepository();
 
+        $container->set(Allocator::class, $this->createStub(Allocator::class));
         $container->set(DonationRepository::class, $this->donationRepository);
         $container->set(CampaignRepository::class, $this->createStub(CampaignRepository::class));
         $container->set(DonorAccountRepository::class, $this->createStub(DonorAccountRepository::class));

--- a/tests/Application/Actions/Donations/UpdateHandlesLockExceptionTest.php
+++ b/tests/Application/Actions/Donations/UpdateHandlesLockExceptionTest.php
@@ -9,10 +9,9 @@ use Doctrine\DBAL\Exception\LockWaitTimeoutException;
 use Doctrine\ORM\EntityManagerInterface;
 use GuzzleHttp\Psr7\ServerRequest;
 use MatchBot\Application\Actions\Donations\Update;
-use MatchBot\Application\Environment;
 use MatchBot\Application\Matching\Adapter;
+use MatchBot\Application\Matching\Allocator;
 use MatchBot\Client\Stripe;
-use MatchBot\Domain\Campaign;
 use MatchBot\Domain\CampaignRepository;
 use MatchBot\Domain\Donation;
 use MatchBot\Domain\DonationNotifier;
@@ -22,7 +21,6 @@ use MatchBot\Domain\DonationStatus;
 use MatchBot\Domain\DonorAccountRepository;
 use MatchBot\Domain\DonorName;
 use MatchBot\Domain\FundRepository;
-use MatchBot\Domain\Salesforce18Id;
 use MatchBot\Tests\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -45,6 +43,10 @@ class UpdateHandlesLockExceptionTest extends TestCase
     use ProphecyTrait;
 
     private int $alreadyThrewTimes = 0;
+
+    /** @var ObjectProphecy<Allocator> */
+    private ObjectProphecy $allocatorProphecy;
+
     /** @var ObjectProphecy<DonationRepository>  */
     private ObjectProphecy $donationRepositoryProphecy;
 
@@ -57,6 +59,7 @@ class UpdateHandlesLockExceptionTest extends TestCase
     #[\Override]
     public function setUp(): void
     {
+        $this->allocatorProphecy = $this->prophesize(Allocator::class);
         $this->donationRepositoryProphecy = $this->prophesize(DonationRepository::class);
         $this->entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
         $this->messageBusProphecy = $this->prophesize(RoutableMessageBus::class);
@@ -94,7 +97,7 @@ class UpdateHandlesLockExceptionTest extends TestCase
 
         $this->setExpectationsForPersistAfterRetry($donationId, $donation, DonationStatus::Cancelled);
 
-        $this->donationRepositoryProphecy->releaseMatchFunds($donation)->shouldBeCalled();
+        $this->allocatorProphecy->releaseMatchFunds($donation)->shouldBeCalled();
 
         $updateAction = $this->makeUpdateAction();
 
@@ -212,6 +215,7 @@ class UpdateHandlesLockExceptionTest extends TestCase
             new NullLogger(),
             new MockClock(),
             new DonationService(
+                allocator: $this->allocatorProphecy->reveal(),
                 donationRepository: $donationRepository,
                 campaignRepository: $this->createStub(CampaignRepository::class),
                 fundRepository: $this->createStub(FundRepository::class),

--- a/tests/Application/Actions/Hooks/StripePaymentsUpdateTest.php
+++ b/tests/Application/Actions/Hooks/StripePaymentsUpdateTest.php
@@ -11,6 +11,8 @@ use MatchBot\Application\Email\EmailMessage;
 use MatchBot\Application\Notifier\StripeChatterInterface;
 use MatchBot\Application\Settings;
 use MatchBot\Client\Mailer;
+use MatchBot\Domain\CampaignFunding;
+use MatchBot\Domain\CampaignFundingRepository;
 use MatchBot\Domain\CampaignRepository;
 use MatchBot\Domain\Donation;
 use MatchBot\Domain\DonationRepository;
@@ -531,6 +533,7 @@ class StripePaymentsUpdateTest extends StripeTest
         $time = (string) time();
 
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
+        $entityManagerProphecy->getRepository(CampaignFunding::class)->willReturn($this->createStub(CampaignFundingRepository::class));
         $entityManagerProphecy->beginTransaction()->shouldBeCalledOnce();
         $entityManagerProphecy->persist(Argument::type(Donation::class))->shouldBeCalledOnce();
         $entityManagerProphecy->flush()->shouldBeCalledTimes(2);
@@ -611,7 +614,6 @@ class StripePaymentsUpdateTest extends StripeTest
         $this->assertEquals(DonationStatus::Collected, $donation->getDonationStatus());
         $this->assertEquals('1.00', $donation->getTipAmount());
         $this->assertEquals(204, $response->getStatusCode());
-        $this->assertEquals('0', $this->donationRepository->totalMatchFundsReleased());
     }
 
     private function getValidWebhookSecret(Container $container): string

--- a/tests/Application/Actions/Hooks/StripePaymentsUpdateTest.php
+++ b/tests/Application/Actions/Hooks/StripePaymentsUpdateTest.php
@@ -290,10 +290,6 @@ class StripePaymentsUpdateTest extends StripeTest
             ->findAndLockOneBy(['transactionId' => 'pi_externalId_123'])
             ->shouldNotBeCalled();
 
-        $donationRepoProphecy
-            ->releaseMatchFunds($donation)
-            ->shouldNotBeCalled();
-
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
 
         $container->set(EntityManagerInterface::class, $entityManagerProphecy->reveal());

--- a/tests/Application/Actions/RegularGivingMandate/CancelAsAdminTest.php
+++ b/tests/Application/Actions/RegularGivingMandate/CancelAsAdminTest.php
@@ -6,6 +6,7 @@ namespace MatchBot\Tests\Application\Actions\RegularGivingMandate;
 
 use DI\Container;
 use MatchBot\Application\Actions\ActionPayload;
+use MatchBot\Application\Matching\Allocator;
 use MatchBot\Domain\CampaignRepository;
 use MatchBot\Domain\DayOfMonth;
 use MatchBot\Domain\DonationRepository;
@@ -141,6 +142,7 @@ class CancelAsAdminTest extends TestCase
         $container = $app->getContainer();
         \assert($container instanceof Container);
 
+        $container->set(Allocator::class, $this->createStub(Allocator::class));
         $container->set(CampaignRepository::class, $this->createStub(CampaignRepository::class));
         $container->set(DonationRepository::class, $this->getMockDonationRepository($mandate));
         $container->set(RegularGivingMandateRepository::class, $this->getMockMandateRepository($mandate));

--- a/tests/Application/DonationTestDataTrait.php
+++ b/tests/Application/DonationTestDataTrait.php
@@ -5,7 +5,6 @@ namespace MatchBot\Tests\Application;
 use DateTime;
 use MatchBot\Application\HttpModels\DonationCreate;
 use MatchBot\Domain\Campaign;
-use MatchBot\Domain\Charity;
 use MatchBot\Domain\Donation;
 use MatchBot\Domain\DonationStatus;
 use MatchBot\Domain\DonorName;
@@ -17,7 +16,6 @@ use MatchBot\Domain\SalesforceWriteProxy;
 use MatchBot\Tests\TestCase;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
-use Stripe\Charge;
 
 trait DonationTestDataTrait
 {

--- a/tests/Application/Matching/AllocatorTest.php
+++ b/tests/Application/Matching/AllocatorTest.php
@@ -1,35 +1,30 @@
 <?php
 
-namespace MatchBot\Tests\Domain;
+namespace MatchBot\Tests\Application\Matching;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Mapping\ClassMetadata;
 use MatchBot\Application\HttpModels\DonationCreate;
 use MatchBot\Application\Matching\Adapter;
+use MatchBot\Application\Matching\Allocator;
 use MatchBot\Domain\Campaign;
 use MatchBot\Domain\CampaignFunding;
 use MatchBot\Domain\CampaignFundingRepository;
-use MatchBot\Domain\DoctrineDonationRepository;
 use MatchBot\Domain\Donation;
-use MatchBot\Domain\DonationRepository;
+use MatchBot\Domain\Fund;
 use MatchBot\Domain\FundingWithdrawal;
 use MatchBot\Domain\FundType;
 use MatchBot\Domain\PaymentMethodType;
-use MatchBot\Domain\Fund;
 use MatchBot\Domain\PersonId;
-use MatchBot\Tests\Application\Matching\ArrayMatchingStorage;
-use MatchBot\Tests\TestCase;
+use MatchBot\Tests\Application\DonationTestDataTrait;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Log\NullLogger;
-use Symfony\Component\Messenger\RoutableMessageBus;
 
-/**
- * Focused test class just for the part match fund allocation part of DonationRepository.
- */
-class DonationRepositoryMatchFundsAllocationTest extends TestCase
+class AllocatorTest extends TestCase
 {
+    use DonationTestDataTrait;
     use ProphecyTrait;
 
     /** @var ObjectProphecy<CampaignFundingRepository>  */
@@ -40,7 +35,7 @@ class DonationRepositoryMatchFundsAllocationTest extends TestCase
     /** @var ObjectProphecy<EntityManagerInterface> */
     private ObjectProphecy $emProphecy;
 
-    private DonationRepository $sut;
+    private Allocator $sut;
 
     #[\Override]
     public function setUp(): void
@@ -63,14 +58,14 @@ class DonationRepositoryMatchFundsAllocationTest extends TestCase
             new NullLogger(),
         );
 
-        $this->sut = new DoctrineDonationRepository(
+        $this->sut = new Allocator(
+            $matchingAdapter,
+            $this->campaignFundingsRepositoryProphecy->reveal(),
             $this->emProphecy->reveal(),
-            new ClassMetadata(Donation::class),
+            new NullLogger()
         );
-        $this->sut->setMatchingAdapter($matchingAdapter);
-        $this->sut->setLogger(new NullLogger());
 
-        $this->campaign = TestCase::someCampaign();
+        $this->campaign = \MatchBot\Tests\TestCase::someCampaign();
     }
 
     public function testItAllocatesZeroWhenNoMatchFundsAvailable(): void
@@ -157,7 +152,7 @@ class DonationRepositoryMatchFundsAllocationTest extends TestCase
      */
     public function allocationFromTwoFundingsCases(): array
     {
-    // phpcs:disable
+        // phpcs:disable
         return [
             // f0 available, f1 available, donation amount, amount matched, withdrawal0, withdrawal1,
             ['6.00', '1000000', '10', '10.00', '6.00', '4.00'],
@@ -309,5 +304,25 @@ class DonationRepositoryMatchFundsAllocationTest extends TestCase
 
         // act
         $this->sut->allocateMatchFunds($donation);
+    }
+
+    public function testReleaseMatchFundsSuccess(): void
+    {
+        $matchingAdapterProphecy = $this->prophesize(Adapter::class);
+        $matchingAdapterProphecy->releaseAllFundsForDonation(Argument::cetera())
+            ->willReturn('0.00')
+            ->shouldBeCalledOnce();
+
+        $this->emProphecy->wrapInTransaction(Argument::type(\Closure::class))->will(/**
+         * @param array<\Closure> $args
+         * @return mixed
+         */            fn(array $args) => $args[0]()
+        );
+        $this->emProphecy->flush()->shouldBeCalledOnce();
+
+        $donation = $this->getTestDonation();
+
+        /** @psalm-suppress InternalMethod */
+        $this->sut->releaseMatchFunds($donation);
     }
 }

--- a/tests/Application/Matching/AllocatorTest.php
+++ b/tests/Application/Matching/AllocatorTest.php
@@ -60,9 +60,8 @@ class AllocatorTest extends TestCase
 
         $this->sut = new Allocator(
             $matchingAdapter,
-            $this->campaignFundingsRepositoryProphecy->reveal(),
             $this->emProphecy->reveal(),
-            new NullLogger()
+            new NullLogger(),
         );
 
         $this->campaign = \MatchBot\Tests\TestCase::someCampaign();
@@ -322,7 +321,13 @@ class AllocatorTest extends TestCase
 
         $donation = $this->getTestDonation();
 
+        $sut = new Allocator(
+            $matchingAdapterProphecy->reveal(),
+            $this->emProphecy->reveal(),
+            new NullLogger(),
+        );
+
         /** @psalm-suppress InternalMethod */
-        $this->sut->releaseMatchFunds($donation);
+        $sut->releaseMatchFunds($donation);
     }
 }

--- a/tests/Application/Messenger/Handler/GiftAidResultHandlerTest.php
+++ b/tests/Application/Messenger/Handler/GiftAidResultHandlerTest.php
@@ -146,10 +146,18 @@ class GiftAidResultHandlerTest extends TestCase
     private function getEntityManagerExpectingPersist(): EntityManagerInterface
     {
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
-        $entityManagerProphecy->beginTransaction()->shouldBeCalledOnce();
+
+        /**
+         * @psalm-suppress MixedFunctionCall
+         */
+        $entityManagerProphecy->wrapInTransaction(Argument::type(\Closure::class))
+            ->will(function (array $args): mixed {
+                return $args[0]();
+            })
+            ->shouldBeCalledOnce();
+
         $entityManagerProphecy->persist(Argument::type(Donation::class))->shouldBeCalledOnce();
         $entityManagerProphecy->flush()->shouldBeCalledOnce();
-        $entityManagerProphecy->commit()->shouldBeCalledOnce();
 
         return $entityManagerProphecy->reveal();
     }

--- a/tests/Domain/DonationRepositoryTest.php
+++ b/tests/Domain/DonationRepositoryTest.php
@@ -14,6 +14,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\QueryBuilder;
 use MatchBot\Application\HttpModels\DonationCreate;
 use MatchBot\Application\Matching\Adapter;
+use MatchBot\Application\Matching\Allocator;
 use MatchBot\Application\Messenger\DonationUpserted;
 use MatchBot\Client;
 use MatchBot\Domain\Campaign;
@@ -241,30 +242,6 @@ class DonationRepositoryTest extends TestCase
         $this->assertEquals(5_90, $donation->getAmountForCharityFractional());
     }
 
-    public function testReleaseMatchFundsSuccess(): void
-    {
-        $matchingAdapterProphecy = $this->prophesize(Adapter::class);
-        $matchingAdapterProphecy->releaseAllFundsForDonation(Argument::cetera())
-            ->willReturn('0.00')
-            ->shouldBeCalledOnce();
-
-        $this->entityManagerProphecy->wrapInTransaction(Argument::type(\Closure::class))->will(/**
-         * @param array<\Closure> $args
-         * @return mixed
-         */            fn(array $args) => $args[0]()
-        );
-        $this->entityManagerProphecy->flush()->shouldBeCalledOnce();
-
-        $repo = $this->getRepo(
-            matchingAdapterProphecy: $matchingAdapterProphecy,
-        );
-
-        $donation = $this->getTestDonation();
-
-        /** @psalm-suppress InternalMethod */
-        $repo->releaseMatchFunds($donation);
-    }
-
     public function testAbandonOldCancelled(): void
     {
         $this->getAppInstance();
@@ -408,12 +385,8 @@ class DonationRepositoryTest extends TestCase
 
     /**
      * @param ObjectProphecy<Client\Donation> $donationClientProphecy
-     * @param ObjectProphecy<Adapter> $matchingAdapterProphecy
      */
-    private function getRepo(
-        ?ObjectProphecy $donationClientProphecy = null,
-        ?ObjectProphecy $matchingAdapterProphecy = null,
-    ): DonationRepository {
+    private function getRepo(?ObjectProphecy $donationClientProphecy = null): DonationRepository {
         if (!$donationClientProphecy) {
             $donationClientProphecy = $this->prophesize(Client\Donation::class);
         }
@@ -426,10 +399,6 @@ class DonationRepositoryTest extends TestCase
         );
         $repo->setClient($donationClientProphecy->reveal());
         $repo->setLogger(new NullLogger());
-
-        if ($matchingAdapterProphecy) {
-            $repo->setMatchingAdapter($matchingAdapterProphecy->reveal());
-        }
 
         return $repo;
     }

--- a/tests/Domain/DonationRepositoryTest.php
+++ b/tests/Domain/DonationRepositoryTest.php
@@ -386,7 +386,8 @@ class DonationRepositoryTest extends TestCase
     /**
      * @param ObjectProphecy<Client\Donation> $donationClientProphecy
      */
-    private function getRepo(?ObjectProphecy $donationClientProphecy = null): DonationRepository {
+    private function getRepo(?ObjectProphecy $donationClientProphecy = null): DonationRepository
+    {
         if (!$donationClientProphecy) {
             $donationClientProphecy = $this->prophesize(Client\Donation::class);
         }

--- a/tests/Domain/DonationServiceTest.php
+++ b/tests/Domain/DonationServiceTest.php
@@ -121,6 +121,8 @@ class DonationServiceTest extends TestCase
 
     public function testInitialPersistRunsOutOfRetries(): void
     {
+        $this->markTestSkipped('retry not being done at same level now - consider moving to test for retry higher in stack');
+
         $logger = $this->prophesize(LoggerInterface::class);
         $logger->info(
             'Donation Create persist before stripe work error: ' .

--- a/tests/Domain/DonationServiceTest.php
+++ b/tests/Domain/DonationServiceTest.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Driver\PDO\Exception as PDOException;
 use Doctrine\DBAL\Exception\LockWaitTimeoutException;
 use MatchBot\Application\HttpModels\DonationCreate;
 use MatchBot\Application\Matching\Adapter;
+use MatchBot\Application\Matching\Allocator;
 use MatchBot\Application\Notifier\StripeChatterInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use MatchBot\Client\Stripe;
@@ -217,6 +218,7 @@ class DonationServiceTest extends TestCase
         $fundRepoProphecy ??= $this->prophesize(FundRepository::class);
 
         return new DonationService(
+            allocator: $this->createStub(Allocator::class),
             donationRepository: $this->donationRepoProphecy->reveal(),
             campaignRepository: $campaignRepoProphecy->reveal(),
             logger: $logger,

--- a/tests/Domain/DonationServiceTest.php
+++ b/tests/Domain/DonationServiceTest.php
@@ -213,6 +213,14 @@ class DonationServiceTest extends TestCase
             $this->entityManagerProphecy->flush()->willReturn(null);
         }
 
+        /**
+         * @psalm-suppress MixedFunctionCall
+         */
+        $this->entityManagerProphecy->wrapInTransaction(Argument::type(\Closure::class))
+            ->will(function (array $args): mixed {
+                return $args[0]();
+            });
+
         $logger = $logger ?? new NullLogger();
 
 

--- a/tests/Domain/DonationServiceTest.php
+++ b/tests/Domain/DonationServiceTest.php
@@ -123,33 +123,33 @@ class DonationServiceTest extends TestCase
     {
         $this->markTestSkipped('retry not being done at same level now - consider moving to test for retry higher in stack');
 
-        $logger = $this->prophesize(LoggerInterface::class);
-        $logger->info(
-            'Donation Create persist before stripe work error: ' .
-            'An exception occurred in the driver: EXCEPTION_MESSAGE. Retrying 1 of 3.'
-        )->shouldBeCalledOnce();
-        $logger->info(Argument::type('string'))->shouldBeCalled();
-        $logger->error(
-            'Donation Create persist before stripe work error: ' .
-            'An exception occurred in the driver: EXCEPTION_MESSAGE. Giving up after 3 retries.'
-        )
-            ->shouldBeCalledOnce();
-
-        $campaignRepoProphecy = $this->prophesize(CampaignRepository::class);
-
-        $this->sut = $this->getDonationService(withAlwaysCrashingEntityManager: true, logger: $logger->reveal(), campaignRepoProphecy: $campaignRepoProphecy);
-
-        $donationCreate = $this->getDonationCreate();
-        $donation = $this->getDonation();
-        $campaignRepoProphecy->findOneBy(['salesforceId' => self::CAMPAIGN_ID])
-            ->willReturn($donation->getCampaign());
-
-        $this->stripeProphecy->createPaymentIntent(Argument::any())
-            ->willReturn($this->prophesize(\Stripe\PaymentIntent::class)->reveal());
-
-        $this->expectException(LockWaitTimeoutException::class);
-
-        $this->sut->createDonation($donationCreate, self::CUSTOMER_ID, PersonId::nil());
+//        $logger = $this->prophesize(LoggerInterface::class);
+//        $logger->info(
+//            'Donation Create persist before stripe work error: ' .
+//            'An exception occurred in the driver: EXCEPTION_MESSAGE. Retrying 1 of 3.'
+//        )->shouldBeCalledOnce();
+//        $logger->info(Argument::type('string'))->shouldBeCalled();
+//        $logger->error(
+//            'Donation Create persist before stripe work error: ' .
+//            'An exception occurred in the driver: EXCEPTION_MESSAGE. Giving up after 3 retries.'
+//        )
+//            ->shouldBeCalledOnce();
+//
+//        $campaignRepoProphecy = $this->prophesize(CampaignRepository::class);
+//
+//        $this->sut = $this->getDonationService(withAlwaysCrashingEntityManager: true, logger: $logger->reveal(), campaignRepoProphecy: $campaignRepoProphecy);
+//
+//        $donationCreate = $this->getDonationCreate();
+//        $donation = $this->getDonation();
+//        $campaignRepoProphecy->findOneBy(['salesforceId' => self::CAMPAIGN_ID])
+//            ->willReturn($donation->getCampaign());
+//
+//        $this->stripeProphecy->createPaymentIntent(Argument::any())
+//            ->willReturn($this->prophesize(\Stripe\PaymentIntent::class)->reveal());
+//
+//        $this->expectException(LockWaitTimeoutException::class);
+//
+//        $this->sut->createDonation($donationCreate, self::CUSTOMER_ID, PersonId::nil());
     }
 
     public function testRefusesToConfirmPreAuthedDonationForNonActiveMandate(): void

--- a/tests/Domain/DonationServiceTest.php
+++ b/tests/Domain/DonationServiceTest.php
@@ -213,13 +213,8 @@ class DonationServiceTest extends TestCase
             $this->entityManagerProphecy->flush()->willReturn(null);
         }
 
-        /**
-         * @psalm-suppress MixedFunctionCall
-         */
-        $this->entityManagerProphecy->wrapInTransaction(Argument::type(\Closure::class))
-            ->will(function (array $args): mixed {
-                return $args[0]();
-            });
+        $this->entityManagerProphecy->beginTransaction()->willReturn(null);
+        $this->entityManagerProphecy->commit()->willReturn(null);
 
         $logger = $logger ?? new NullLogger();
 

--- a/tests/Domain/InMemoryDonationRepository.php
+++ b/tests/Domain/InMemoryDonationRepository.php
@@ -18,11 +18,6 @@ class InMemoryDonationRepository implements DonationRepository
     /** @var array<int, Donation> */
     private $donations = [];
 
-    /**
-     * @var numeric-string
-     */
-    private string $matchFundsReleased = '0';
-
     #[\Override] public function findAndLockOneByUUID(UuidInterface $donationId): ?Donation
     {
         foreach ($this->donations as $donation) {

--- a/tests/Domain/InMemoryDonationRepository.php
+++ b/tests/Domain/InMemoryDonationRepository.php
@@ -230,4 +230,10 @@ class InMemoryDonationRepository implements DonationRepository
     {
         return $this->findOneBy(['uuid' => $donationUUID]);
     }
+//
+//    #[\Override]
+//    public function reverseMatchingAllocations(Donation $donation, array $newWithdrawals, array $likelyAvailableFundings): void
+//    {
+//        throw new \Exception("Method not implemented in test double");
+//    }
 }

--- a/tests/Domain/InMemoryDonationRepository.php
+++ b/tests/Domain/InMemoryDonationRepository.php
@@ -230,10 +230,4 @@ class InMemoryDonationRepository implements DonationRepository
     {
         return $this->findOneBy(['uuid' => $donationUUID]);
     }
-//
-//    #[\Override]
-//    public function reverseMatchingAllocations(Donation $donation, array $newWithdrawals, array $likelyAvailableFundings): void
-//    {
-//        throw new \Exception("Method not implemented in test double");
-//    }
 }

--- a/tests/Domain/InMemoryDonationRepository.php
+++ b/tests/Domain/InMemoryDonationRepository.php
@@ -89,14 +89,6 @@ class InMemoryDonationRepository implements DonationRepository
         return $this->findOneBy($criteria);
     }
 
-    /**
-     * @return numeric-string
-     */
-    public function totalMatchFundsReleased(): string
-    {
-        return $this->matchFundsReleased;
-    }
-
     #[\Override] public function findWithExpiredMatching(\DateTimeImmutable $now): array
     {
         throw new \Exception("Method not implemented in test double");

--- a/tests/Domain/InMemoryDonationRepository.php
+++ b/tests/Domain/InMemoryDonationRepository.php
@@ -97,16 +97,6 @@ class InMemoryDonationRepository implements DonationRepository
         return $this->matchFundsReleased;
     }
 
-    #[\Override] public function releaseMatchFunds(Donation $donation): void
-    {
-        $this->matchFundsReleased = bcadd($this->matchFundsReleased, $donation->getAmount());
-    }
-
-    #[\Override] public function allocateMatchFunds(Donation $donation): string
-    {
-        throw new \Exception("Method not implemented in test double");
-    }
-
     #[\Override] public function findWithExpiredMatching(\DateTimeImmutable $now): array
     {
         throw new \Exception("Method not implemented in test double");
@@ -153,11 +143,6 @@ class InMemoryDonationRepository implements DonationRepository
     }
 
     #[\Override] public function abandonOldCancelled(): int
-    {
-        throw new \Exception("Method not implemented in test double");
-    }
-
-    #[\Override] public function removeAllFundingWithdrawalsForDonation(Donation $donation): void
     {
         throw new \Exception("Method not implemented in test double");
     }


### PR DESCRIPTION
Edit: now pretty much ready, with test reinstated and temporary stuff removed.

* Recovery from allocation DB errors now reverses fund allocation the right number of times
* Retries of donation create are higher up the stack
* Donation Create only tries up to 2 times, not 3
* Retries don't happen for Regular Giving

Nice for after this PR: test the new retry approach and delete the newly skipped test.

---

WIP, quite a bit still to tidy of course.

* Stripe cancelling with lock test issue is one first faced on https://github.com/thebiggive/matchbot/pull/893 – skipping that test temporarily
* psalm errors are side effects of skipping that test
* I'll check tomorrow if I still think the existing Redis reversal plus clearing the EM is equivalent to the new method I started drafting