### PR TITLE
More stanning for php

### DIFF
--- a/.psalm/containers.php.stub
+++ b/.psalm/containers.php.stub
@@ -14,20 +14,24 @@ namespace Psr\Container {
          * @template T of object
          * @psalm-param string|class-string<T> $name
          * @psalm-return ($name is class-string ? T : mixed)
+         *
+         * @phpstan-return ($name is class-string<T> ? T : object)
          */
-        public function get(string $name): object;
+        public function get(string $name): mixed;
     }
 }
 
 namespace DI {
     use Psr\Container\ContainerInterface;
     use \DI\FactoryInterface;
-    use Invoker\InvokerInterface;
 
-    class Container implements ContainerInterface, FactoryInterface, InvokerInterface
+    class Container implements ContainerInterface
+    // real class also implements FactoryInterface, InvokerInterface
+    // but those are not used in our code so not represented in stub. For PHPStan if we want to include those interfaces
+    // in stub we have to copy them into the stub.
     {
         /**
-         * @template T of object
+         * @template T
          * @psalm-param string|class-string<T> $name
          * @psalm-param ($name is class-string ? T : mixed) $value
          */
@@ -40,7 +44,9 @@ namespace DI {
          * @template T of object
          * @psalm-param string|class-string<T> $name
          * @psalm-return ($name is class-string ? T : mixed)
+         *
+         * @phpstan-return ($name is class-string<T> ? T : object)
          */
-        public function get(string $name): object;
+        public function get(string $name): mixed;
     }
 }

--- a/app/dependencies.php
+++ b/app/dependencies.php
@@ -540,10 +540,6 @@ return function (ContainerBuilder $containerBuilder) {
 
         Auth\SalesforceAuthMiddleware::class =>
             function (ContainerInterface $c) {
-               /**
-                * @psalm-suppress MixedArrayAccess
-                * @psalm-suppress MixedArgument
-                */
                 return new Auth\SalesforceAuthMiddleware(
                     sfApiKey: $c->get(Settings::class)->salesforce['apiKey'],
                     logger: $c->get(LoggerInterface::class)

--- a/app/dependencies.php
+++ b/app/dependencies.php
@@ -572,7 +572,7 @@ return function (ContainerBuilder $containerBuilder) {
              * Injecting `StripeChatterInterface` directly doesn't work because `Chatter` itself
              * is final and does not implement our custom interface.
              */
-                $chatter = $c->get(StripeChatterInterface::class);
+                $chatter = $c->get(StripeChatterInterface::class); // @phpstan-ignore varTag.type
 
                 $rateLimiterFactory = $c->get('donation-creation-rate-limiter-factory');
                 \assert($rateLimiterFactory instanceof RateLimiterFactory);

--- a/integrationTests/CreateRegularGivingMandateTest.php
+++ b/integrationTests/CreateRegularGivingMandateTest.php
@@ -187,7 +187,7 @@ class CreateRegularGivingMandateTest extends IntegrationTest
         return $id;
     }
 
-    public function assertDonationDetailsInDB(mixed $mandateId): void
+    public function assertDonationDetailsInDB(int $mandateId): void
     {
         $donationDatabaseRows = $this->db()->executeQuery(
             "SELECT * from Donation where Donation.mandate_id = ? ORDER BY mandateSequenceNumber asc",

--- a/integrationTests/DonationMatchingTest.php
+++ b/integrationTests/DonationMatchingTest.php
@@ -124,7 +124,6 @@ class DonationMatchingTest extends IntegrationTest
         };
     }
 
-    /** @psalm-suppress MixedArgument */
     #[\Override]
     public function tearDown(): void
     {

--- a/integrationTests/DonationMatchingTest.php
+++ b/integrationTests/DonationMatchingTest.php
@@ -76,7 +76,7 @@ class DonationMatchingTest extends IntegrationTest
                 amountInPounds: 10,
             );
         } catch (\Exception $e) {
-            $this->assertEquals(
+            $this->assertSame(
                 'Throwing after subtracting funds to test how our system handles the crash',
                 $e->getMessage(),
             );

--- a/integrationTests/DonationPersistenceTest.php
+++ b/integrationTests/DonationPersistenceTest.php
@@ -34,6 +34,9 @@ class DonationPersistenceTest extends IntegrationTest
 
     /**
      * Asserts that two DB rows are similar, ignoring things out of our contril like IDs and dates.
+     *
+     * @param array<string, mixed> $expected
+     * @param array<string, mixed> $actual
      */
     private function assertRowsSimilar(array $expected, array $actual, string $message = ''): void
     {

--- a/integrationTests/IntegrationTest.php
+++ b/integrationTests/IntegrationTest.php
@@ -69,6 +69,8 @@ abstract class IntegrationTest extends TestCase
         };
 
         $container = require __DIR__ . '/../bootstrap.php';
+
+        /** @psalm-suppress RedundantConditionGivenDocblockType - probably not redundant for PHPStorm */
         \assert($container instanceof Container);
         IntegrationTest::setContainer($container);
         $container->set(RateLimitMiddleware::class, $noOpMiddleware);
@@ -293,8 +295,6 @@ abstract class IntegrationTest extends TestCase
      * @param string $campaignSfId
      * @return array{charityId: int, campaignId: int, fundId: int, campaignFundingId: int}
      * @throws \Doctrine\DBAL\Exception
-     * @psalm-suppress MoreSpecificReturnType
-     * @psalm-suppress LessSpecificReturnStatement
      */
     public function addFundedCampaignAndCharityToDB(
         string $campaignSfId,
@@ -319,8 +319,6 @@ abstract class IntegrationTest extends TestCase
     /**
      * @param FundType $fundType
      * @return array{fundId: int, campaignFundingId: int}
-     * @psalm-suppress MoreSpecificReturnType
-     * @psalm-suppress LessSpecificReturnStatement
      */
     public function addFunding(
         int $campaignId,

--- a/integrationTests/IntegrationTest.php
+++ b/integrationTests/IntegrationTest.php
@@ -188,7 +188,7 @@ abstract class IntegrationTest extends TestCase
     /**
      * @param class-string $name
      */
-    protected function setInContainer(string $name, mixed $value): void
+    protected function setInContainer(string $name, object $value): void
     {
         $container = $this->getContainer();
 

--- a/integrationTests/IntegrationTest.php
+++ b/integrationTests/IntegrationTest.php
@@ -69,6 +69,7 @@ abstract class IntegrationTest extends TestCase
         };
 
         $container = require __DIR__ . '/../bootstrap.php';
+        \assert($container instanceof Container);
         IntegrationTest::setContainer($container);
         $container->set(RateLimitMiddleware::class, $noOpMiddleware);
         $container->set(\Psr\Log\LoggerInterface::class, new \Psr\Log\NullLogger());

--- a/integrationTests/PullCharityUpdatedBasedOnSfHookTest.php
+++ b/integrationTests/PullCharityUpdatedBasedOnSfHookTest.php
@@ -81,12 +81,15 @@ class PullCharityUpdatedBasedOnSfHookTest extends IntegrationTest
         // assert
         $em->clear();
 
-        $charity = $this->getService(CharityRepository::class)->findOneBySfIDOrThrow(Salesforce18Id::of($sfId));
+        $charity = $this->getService(CharityRepository::class)->findOneBySfIDOrThrow(Salesforce18Id::ofCharity($sfId));
         $this->assertSame('New Charity Name', $charity->getName());
         $this->assertFalse($campaign->isReady());
         $this->assertSame('Preview', $campaign->getStatus());
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     private function simulatedCampaignFromSFAPI(string $sfId, string $newCharityName, string $stripeAccountId): array
     {
         return [

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 includes:
 	- phpstan-baseline.neon
+	- phar://phpstan.phar/conf/bleedingEdge.neon
 parameters:
 	# Phpstan levels go the opposite way to Psalm - 1 is the laxest, 10 is the strictest.
 	level: 6

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,6 +11,7 @@ parameters:
 	treatPhpDocTypesAsCertain: false
 	checkUninitializedProperties: true
 	rememberPossiblyImpureFunctionValues: false
+	checkExplicitMixed: true
 	strictRules:
 		disallowedLooseComparison: false
 		booleansInConditions: false
@@ -45,6 +46,11 @@ parameters:
 		-
 			identifier: property.uninitialized
 			# properties in tests are initialised in setup instead of __construct.
+			paths:
+				- tests/*
+				- integrationTests/*
+		-
+			identifier: offsetAccess.nonOffsetAccessible
 			paths:
 				- tests/*
 				- integrationTests/*

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,7 +2,7 @@ includes:
 	- phpstan-baseline.neon
 parameters:
 	# Phpstan levels go the opposite way to Psalm - 1 is the laxest, 10 is the strictest.
-	level: 5
+	level: 6
 	paths:
 		- src
 		- tests

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -48,3 +48,5 @@ parameters:
 			paths:
 				- tests/*
 				- integrationTests/*
+	stubFiles:
+		- .psalm/containers.php.stub

--- a/psalm.xml
+++ b/psalm.xml
@@ -7,6 +7,7 @@
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
     findUnusedBaselineEntry="false"
     findUnusedCode="true"
+    findUnusedPsalmSuppress="true"
 >
     <stubs>
         <file name=".psalm/containers.php.stub" preloadClasses="true"/>

--- a/src/Application/Actions/Action.php
+++ b/src/Application/Actions/Action.php
@@ -30,7 +30,7 @@ abstract class Action
     /**
      * @param Request  $request
      * @param Response $response
-     * @param array    $args
+     * @param array<string, string|null> $args
      * @return Response
      * @throws HttpNotFoundException
      * @throws HttpBadRequestException
@@ -45,6 +45,8 @@ abstract class Action
     }
 
     /**
+     * @param array<string, string|null> $args
+     *
      * @return Response
      * @throws DomainRecordNotFoundException
      * @throws HttpBadRequestException
@@ -66,6 +68,9 @@ abstract class Action
         );
     }
 
+    /**
+     * @param array<mixed> $args
+     */
     protected function argToUuid(array $args, string $argName): UuidInterface
     {
         Assertion::keyExists($args, $argName);
@@ -80,6 +85,7 @@ abstract class Action
 
     /**
      * @param  string $name
+     * @param array<mixed> $args
      * @return mixed
      * @throws HttpBadRequestException
      */
@@ -98,7 +104,7 @@ abstract class Action
      * @param bool          $reduceSeverity Whether to log this error only at INFO level. Used to
      *                                      avoid noise from known issues.
      * @param ActionError::* $errorType Identifier for the type of error to be used by FE.
-     * @param array $errorData JSON-serializable detailed error data for use in FE.
+     * @param array<string, mixed> $errorData JSON-serializable detailed error data for use in FE.
      * @return Response with 400 HTTP response code.
      */
     protected function validationError(
@@ -120,7 +126,7 @@ abstract class Action
     }
 
     /**
-     * @param  array|object|null $data
+     * @param  array<mixed>|object|null $data
      * @return Response
      */
     protected function respondWithData(Response $response, $data = null, int $statusCode = 200): Response

--- a/src/Application/Actions/ActionError.php
+++ b/src/Application/Actions/ActionError.php
@@ -21,6 +21,9 @@ class ActionError implements JsonSerializable
     public const string VERIFICATION_ERROR = 'VERIFICATION_ERROR';
     public const string INSUFFICIENT_MATCH_FUNDS = 'INSUFFICIENT_MATCH_FUNDS';
 
+    /**
+     * @param array<string, mixed> $data
+     */
     #[Pure]
     public function __construct(
         private string $type,
@@ -68,13 +71,9 @@ class ActionError implements JsonSerializable
     }
 
     /**
-     * @return array
+     * @return array{type: string, description: string, ...}
      */
     #[\Override]
-    #[ArrayShape([
-        'type' => 'string',
-        'description' => 'string'
-    ])]
     public function jsonSerialize(): array
     {
         return [

--- a/src/Application/Actions/ActionPayload.php
+++ b/src/Application/Actions/ActionPayload.php
@@ -9,6 +9,9 @@ use JsonSerializable;
 
 class ActionPayload implements JsonSerializable
 {
+    /**
+     * @param array<mixed>|object|null $data
+     */
     #[Pure]
     public function __construct(
         private int $statusCode = 200,
@@ -27,7 +30,7 @@ class ActionPayload implements JsonSerializable
     }
 
     /**
-     * @return array|null|object
+     * @return array<array-key,mixed>|null|object
      */
     #[Pure]
     public function getData(): object | array | null
@@ -45,7 +48,7 @@ class ActionPayload implements JsonSerializable
     }
 
     /**
-     * @return object | array | null
+     * @return object | array<mixed> | null
      */
     #[\Override]
     public function jsonSerialize(): object | array | null

--- a/src/Application/Actions/Donations/Update.php
+++ b/src/Application/Actions/Donations/Update.php
@@ -63,6 +63,7 @@ class Update extends Action
     }
 
     /**
+     * @param array<string, mixed> $args
      * @return Response
      * @throws DomainRecordNotFoundException on missing donation
      * @throws ApiErrorException if Stripe Payment Intent confirm() fails, other than because of a
@@ -252,6 +253,9 @@ class Update extends Action
 
     /**
      * Assumes it will be called only after starting a transaction pre-donation-select.
+     *
+     * @param array{donationId: string, ...} $args
+     *
      * @throws InvalidRequestException
      * @throws ApiErrorException if confirm() fails other than because of a missing payment method.
      * @throws \UnexpectedValueException

--- a/src/Application/Actions/Donations/Update.php
+++ b/src/Application/Actions/Donations/Update.php
@@ -426,10 +426,6 @@ class Update extends Action
                     $nextActionType = null;
                     if ($confirmedIntent->status === PaymentIntent::STATUS_REQUIRES_ACTION) {
                         $nextAction = $confirmedIntent->next_action;
-
-                        /** @psalm-suppress UndefinedMagicPropertyFetch - type is not documented on StripeObject but
-                         * appears to work in this context
-                         */
                         $nextActionType = (string) $nextAction?->type;
                     }
 

--- a/src/Application/Actions/Hooks/StripePaymentsUpdate.php
+++ b/src/Application/Actions/Hooks/StripePaymentsUpdate.php
@@ -107,7 +107,6 @@ class StripePaymentsUpdate extends Stripe
     private function handleChargeSucceeded(Event $event, Response $response): Response
     {
         /**
-         * @psalm-suppress UndefinedMagicPropertyFetch
          * @var Charge $charge
          */
         $charge = $event->data->object;
@@ -180,7 +179,6 @@ class StripePaymentsUpdate extends Stripe
     private function handleChargeDisputeClosed(Event $event, Response $response): Response
     {
         /**
-         * @psalm-suppress UndefinedMagicPropertyFetch
          * @var Dispute $dispute
          */
         $dispute = $event->data->object;
@@ -258,7 +256,6 @@ class StripePaymentsUpdate extends Stripe
     private function handleChargeRefunded(Event $event, Response $response): Response
     {
         /**
-         * @psalm-suppress UndefinedMagicPropertyFetch
          * @var Charge $charge
          */
         $charge = $event->data->object;
@@ -348,8 +345,6 @@ class StripePaymentsUpdate extends Stripe
         /**
          * https://docs.stripe.com/api/events/types?event_types-invoice.payment_succeeded=#event_types-payment_intent.canceled
          * says "data.object is a payment intent" so:
-         *
-         * @psalm-suppress UndefinedMagicPropertyFetch $paymentIntent
          */
         $paymentIntent = $event->data->object;
         \assert($paymentIntent instanceof PaymentIntent);

--- a/src/Application/Actions/Hooks/StripePaymentsUpdate.php
+++ b/src/Application/Actions/Hooks/StripePaymentsUpdate.php
@@ -456,7 +456,7 @@ class StripePaymentsUpdate extends Stripe
     {
         Assertion::eq('customer_cash_balance_transaction.created', $event->type);
 
-        /** @var array $eventAsArray
+        /** @var array<string, mixed> $eventAsArray
          * @psalm-suppress MixedMethodCall
          * (not sure why Psalm can't tell that this is an array since Upgrade to stripe Library v.17)
          */

--- a/src/Application/Actions/Hooks/StripePaymentsUpdate.php
+++ b/src/Application/Actions/Hooks/StripePaymentsUpdate.php
@@ -59,7 +59,7 @@ class StripePaymentsUpdate extends Stripe
          * Injecting `StripeChatterInterface` directly doesn't work because `Chatter` itself
          * is final and does not implement our custom interface.
          */
-        $chatter = $container->get(StripeChatterInterface::class);
+        $chatter = $container->get(StripeChatterInterface::class); // @phpstan-ignore varTag.type
         $this->chatter = $chatter;
 
         parent::__construct($container, $logger);

--- a/src/Application/Actions/Hooks/StripePayoutUpdate.php
+++ b/src/Application/Actions/Hooks/StripePayoutUpdate.php
@@ -40,7 +40,7 @@ class StripePayoutUpdate extends Stripe
          * Injecting `StripeChatterInterface` directly doesn't work because `Chatter` itself
          * is final and does not implement our custom interface.
          */
-        $chatter = $container->get(StripeChatterInterface::class);
+        $chatter = $container->get(StripeChatterInterface::class); // @phpstan-ignore varTag.type
         $this->chatter = $chatter;
 
         parent::__construct($container, $logger);

--- a/src/Application/Actions/Hooks/StripePayoutUpdate.php
+++ b/src/Application/Actions/Hooks/StripePayoutUpdate.php
@@ -81,8 +81,6 @@ class StripePayoutUpdate extends Stripe
             case Event::PAYOUT_FAILED:
                 /**
                  * @var string $id
-                 * @psalm-suppress UndefinedMagicPropertyFetch
-                 * @psalm-suppress MixedPropertyFetch
                  */
                 $id = $event->data->object->id;
                 $failureMessage = sprintf(
@@ -111,7 +109,6 @@ class StripePayoutUpdate extends Stripe
     private function handlePayoutPaid(Request $request, Event $event, Response $response): Response
     {
         /**
-         * @psalm-suppress UndefinedMagicPropertyFetch
          * @var \Stripe\StripeObject&object{id: string, automatic: bool} $object
          */
         $object = $event->data->object;

--- a/src/Application/Actions/RegularGivingMandate/Get.php
+++ b/src/Application/Actions/RegularGivingMandate/Get.php
@@ -42,12 +42,17 @@ class Get extends Action
         Assertion::keyExists($args, "mandateId");
         $mandateId = $args["mandateId"];
         Assertion::string($mandateId);
+
+        /** @psalm-suppress RiskyTruthyFalsyComparison -- suppressing issue in old code instead of editing */
         if (empty($args['mandateId'])) {
             throw new DomainRecordNotFoundException('Missing mandate ID ' . $mandateId);
         }
 
         $authenticatedUser = $this->securityService->requireAuthenticatedDonorAccountWithPassword($request);
 
+        /** @psalm-suppress RedundantCast - psalm is probably right and this is redundant but I don't want to
+         * change now without testing
+         */
         $uuid = Uuid::fromString((string) $args['mandateId']);
         $mandate = $this->regularGivingMandateRepository->findOneByUuid($uuid);
 

--- a/src/Application/Auth/DonationToken.php
+++ b/src/Application/Auth/DonationToken.php
@@ -25,7 +25,7 @@ class DonationToken
     public static function create(string $donationId): string
     {
         /**
-         * @var array $claims
+         * @var array<mixed> $claims
          * @link https://tools.ietf.org/html/rfc7519 has info on the standard keys like `exp`
          */
         $claims = [

--- a/src/Application/Commands/CancelStaleDonationFundTips.php
+++ b/src/Application/Commands/CancelStaleDonationFundTips.php
@@ -33,9 +33,6 @@ use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
 )]
 class CancelStaleDonationFundTips extends LockingCommand
 {
-    /**
-     * @psalm-suppress PossiblyUnusedMethod - called by framework
-     */
     public function __construct(
         private DonationRepository $donationRepository,
         private DonationService $donationService,

--- a/src/Application/Commands/HandleOutOfSyncFunds.php
+++ b/src/Application/Commands/HandleOutOfSyncFunds.php
@@ -76,7 +76,7 @@ class HandleOutOfSyncFunds extends LockingCommand
         $excludedFundingIds = [];
         $excludeJson = getenv('KNOWN_OVERMATCHED_FUNDING_IDS');
         if (is_string($excludeJson) && $excludeJson !== '') {
-            /** @var array $excludedFundingIds */
+            /** @var list<int> $excludedFundingIds */
             $excludedFundingIds = json_decode($excludeJson, true, 512, \JSON_THROW_ON_ERROR);
         }
 

--- a/src/Application/Commands/PullIndividualCampaignFromSF.php
+++ b/src/Application/Commands/PullIndividualCampaignFromSF.php
@@ -24,9 +24,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 )]
 class PullIndividualCampaignFromSF extends LockingCommand
 {
-    /**
-     * @psalm-suppress PossiblyUnusedMethod
-     */
     public function __construct(
         private Environment $environment,
         private CampaignRepository $campaignRepository,

--- a/src/Application/Commands/PullIndividualCampaignFromSF.php
+++ b/src/Application/Commands/PullIndividualCampaignFromSF.php
@@ -49,6 +49,7 @@ class PullIndividualCampaignFromSF extends LockingCommand
     {
         Assertion::notEq($this->environment, Environment::Production);
 
+        // @phpstan-ignore cast.string
         $campaignId = Salesforce18Id::ofCampaign((string) $input->getArgument('CampaignSFID'));
 
         $campaign = $this->campaignRepository->findOneBySalesforceId($campaignId);

--- a/src/Application/Commands/PullMetaCampaignFromSF.php
+++ b/src/Application/Commands/PullMetaCampaignFromSF.php
@@ -32,9 +32,6 @@ use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
 )]
 class PullMetaCampaignFromSF extends LockingCommand
 {
-    /**
-     * @psalm-suppress PossiblyUnusedMethod
-     */
     public function __construct(
         private CampaignRepository $campaignRepository,
         private FundRepository $fundRepository

--- a/src/Application/Commands/RetrospectivelyMatch.php
+++ b/src/Application/Commands/RetrospectivelyMatch.php
@@ -81,7 +81,7 @@ class RetrospectivelyMatch extends LockingCommand
                 ->findNotFullyMatchedToCampaignsWhichClosedSince($oneHourBeforeExecStarted);
         } else {
             // Allow + round non-whole day count.
-            $daysBack = round((float) $input->getArgument('days-back'));
+            $daysBack = round((float) $input->getArgument('days-back')); // @phpstan-ignore cast.double
             $output->writeln("Looking at past $daysBack days' donations");
             $sinceDate = (new DateTime('now'))->sub(new \DateInterval("P{$daysBack}D"));
             $toCheckForMatching = $this->donationRepository

--- a/src/Application/Commands/SendStatistics.php
+++ b/src/Application/Commands/SendStatistics.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MatchBot\Application\Commands;
 
 use Aws\CloudWatch\CloudWatchClient;
+use Doctrine\Common\Collections\Expr\Value;
 use GuzzleHttp\Exception\RequestException;
 use MatchBot\Application\Environment;
 use MatchBot\Domain\DonationRepository;
@@ -78,6 +79,8 @@ class SendStatistics extends LockingCommand
     /**
      * Value in default 'Unit' mode accepts doubles, so we leave this with the default for both float
      * & int values.
+     *
+     * @return array{MetricName: string, Value: float | int | null, Timestamp: \DateTimeImmutable}
      */
     private function makeMetric(string $name, float | int | null $value, \DateTimeImmutable $timestamp): array
     {

--- a/src/Application/Commands/SetupTestMandate.php
+++ b/src/Application/Commands/SetupTestMandate.php
@@ -54,7 +54,6 @@ class SetupTestMandate extends LockingCommand
 {
     private \DateTimeImmutable $now;
 
-    /** @psalm-suppress PossiblyUnusedMethod */
     public function __construct(
         private Environment $environment,
         private EntityManagerInterface $em,

--- a/src/Application/Commands/TakeRegularGivingDonations.php
+++ b/src/Application/Commands/TakeRegularGivingDonations.php
@@ -45,7 +45,6 @@ class TakeRegularGivingDonations extends LockingCommand
 
     private bool $reportableEventHappened = false;
 
-    /** @psalm-suppress PossiblyUnusedMethod - called by PHP-DI */
     public function __construct(
         private Container $container,
         private RegularGivingMandateRepository $mandateRepository,

--- a/src/Application/Email/EmailMessage.php
+++ b/src/Application/Email/EmailMessage.php
@@ -7,7 +7,7 @@ use MatchBot\Domain\EmailAddress;
 /**
  * A message to be sent by email, via our Mailer service
  *
- * @psalm-type emailParams array<string,string|null|int|float|bool|array>
+ * @psalm-type emailParams array<string,string|null|int|float|bool|array<array-key, mixed>>
  */
 readonly class EmailMessage
 {

--- a/src/Application/Fees/Calculator.php
+++ b/src/Application/Fees/Calculator.php
@@ -99,7 +99,6 @@ class Calculator
         self::assertIsGBPOrInUnitTest($currencyCode);
 
         // Currency code has been compulsory for some time.
-        /** @psalm-suppress ImpureMethodCall */
         Assertion::keyExists(self::FEES_FIXED, $currencyCode);
         $feeAmountFixed = self::FEES_FIXED[$currencyCode];
 

--- a/src/Application/Handlers/ShutdownHandler.php
+++ b/src/Application/Handlers/ShutdownHandler.php
@@ -19,6 +19,7 @@ class ShutdownHandler
     ) {
     }
 
+    /** @return void */
     public function __invoke()
     {
         $error = error_get_last();

--- a/src/Application/HttpModels/Donation.php
+++ b/src/Application/HttpModels/Donation.php
@@ -21,8 +21,8 @@ readonly class Donation
     /**
      * @psalm-suppress PossiblyUnusedMethod - this constructor is called by the Symfony Serializer
      *
-     * @psalm-suppress PossiblyUnusedParam - some params here are included to document that FE sends them, even though
-     * we don't do anything with them currently in matchbot.
+     * some params were once included here included to document that FE sends them, even though
+     * we don't do anything with them currently in matchbot. Check git history for details.
      */
     public function __construct(
         public float $donationAmount,

--- a/src/Application/HttpModels/DonationCreatedResponse.php
+++ b/src/Application/HttpModels/DonationCreatedResponse.php
@@ -10,6 +10,9 @@ namespace MatchBot\Application\HttpModels;
  */
 readonly class DonationCreatedResponse
 {
+    /**
+     * @param array<string,mixed> $donation
+     */
     public function __construct(
         public array $donation,
         public string $jwt,

--- a/src/Application/Messenger/CharityUpdated.php
+++ b/src/Application/Messenger/CharityUpdated.php
@@ -13,6 +13,9 @@ use Symfony\Component\Messenger\Bridge\AmazonSqs\MessageGroupAwareInterface;
  */
 readonly class CharityUpdated implements MessageDeduplicationAwareInterface, MessageGroupAwareInterface
 {
+    /**
+     * @param Salesforce18Id<Charity> $charityAccountId
+     */
     public function __construct(public Salesforce18Id $charityAccountId, private ?string $requestTraceId)
     {
     }

--- a/src/Application/Messenger/DonationUpserted.php
+++ b/src/Application/Messenger/DonationUpserted.php
@@ -2,6 +2,7 @@
 
 namespace MatchBot\Application\Messenger;
 
+use Assert\AssertionFailedException;
 use MatchBot\Application\Assertion;
 use MatchBot\Domain\Donation;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\MessageGroupAwareInterface;
@@ -15,6 +16,9 @@ class DonationUpserted implements MessageGroupAwareInterface
 {
     public const string SNAPSHOT_TAKEN_AT = 'snapshot_taken_at';
 
+    /**
+     * @param array<mixed>|null $jsonSnapshot
+     */
     protected function __construct(
         public string $uuid,
         public array|null $jsonSnapshot

--- a/src/Application/Messenger/FundTotalUpdated.php
+++ b/src/Application/Messenger/FundTotalUpdated.php
@@ -8,6 +8,9 @@ use Symfony\Component\Messenger\Bridge\AmazonSqs\MessageGroupAwareInterface;
 
 readonly class FundTotalUpdated implements MessageGroupAwareInterface
 {
+    /**
+     * @param array<string, mixed> $jsonSnapshot
+     */
     protected function __construct(public string $salesforceId, public array $jsonSnapshot)
     {
     }

--- a/src/Application/Messenger/Handler/DonationUpsertedHandler.php
+++ b/src/Application/Messenger/Handler/DonationUpsertedHandler.php
@@ -28,6 +28,7 @@ readonly class DonationUpsertedHandler
 
         $jsonSnapshot = $message->jsonSnapshot;
 
+        // @phpstan-ignore cast.string
         $messageDate = (string)($jsonSnapshot[DonationUpserted::SNAPSHOT_TAKEN_AT] ?? 'unknown date');
 
         $this->logger->info("DUH invoked for UUID: $donationUUID, handling message from $messageDate");

--- a/src/Application/Messenger/Handler/MandateUpsertedHandler.php
+++ b/src/Application/Messenger/Handler/MandateUpsertedHandler.php
@@ -27,9 +27,6 @@ use Symfony\Component\Messenger\Stamp\DelayStamp;
 #[AsMessageHandler]
 readonly class MandateUpsertedHandler
 {
-    /**
-     * @psalm-suppress PossiblyUnusedMethod
-     */
     public function __construct(
         private LoggerInterface $logger,
         private MandateClient $client,

--- a/src/Application/Messenger/Handler/MandateUpsertedHandler.php
+++ b/src/Application/Messenger/Handler/MandateUpsertedHandler.php
@@ -11,6 +11,7 @@ use MatchBot\Client\BadResponseException;
 use MatchBot\Client\Mandate as MandateClient;
 use MatchBot\Client\NotFoundException;
 use MatchBot\Domain\DonationRepository;
+use MatchBot\Domain\RegularGivingMandate;
 use MatchBot\Domain\Salesforce18Id;
 use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\Uuid;
@@ -92,6 +93,8 @@ readonly class MandateUpsertedHandler
     /**
      * Consider DRYing up duplication with DoctrineDonationRepository::setSalesforceFields before
      * making a third copy
+     *
+     * @param Salesforce18Id<RegularGivingMandate> $salesforceId
      */
     private function setSalesforceFields(string $uuid, ?Salesforce18Id $salesforceId): void
     {

--- a/src/Application/Messenger/Handler/PersonHandler.php
+++ b/src/Application/Messenger/Handler/PersonHandler.php
@@ -17,7 +17,6 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 #[AsMessageHandler]
 readonly class PersonHandler
 {
-    /** @psalm-suppress PossiblyUnusedMethod Used by Messenger mapping & tests. */
     public function __construct(
         // apparently at the time this is constructed in tests the container isn't ready to give
         // us a donorAccountRepository, so taking a ref to the container instead and getting the

--- a/src/Application/Messenger/MandateUpserted.php
+++ b/src/Application/Messenger/MandateUpserted.php
@@ -10,6 +10,9 @@ use Symfony\Component\Messenger\Bridge\AmazonSqs\MessageGroupAwareInterface;
 
 class MandateUpserted implements MessageGroupAwareInterface
 {
+    /**
+     * @param array<string, mixed> $jsonSnapshot
+     */
     protected function __construct(public string $uuid, public array $jsonSnapshot)
     {
         Assertion::uuid($this->uuid);

--- a/src/Application/RealTimeMatchingStorage.php
+++ b/src/Application/RealTimeMatchingStorage.php
@@ -2,8 +2,13 @@
 
 namespace MatchBot\Application;
 
+use MatchBot\Application\Matching\Adapter;
+
 interface RealTimeMatchingStorage
 {
+    /**
+     * @param Adapter::REDIS_OPTIONS_FOR_LIMITED_DURATION_STORAGE $options
+     */
     public function set(string $key, string|int $value, array $options): bool|self;
 
     /**
@@ -26,7 +31,7 @@ interface RealTimeMatchingStorage
     public function del(string $key): void;
 
     /**
-     * @return array|false|self
+     * @return array<mixed>|false|self
      */
     public function exec();
 }

--- a/src/Application/RedisMatchingStorage.php
+++ b/src/Application/RedisMatchingStorage.php
@@ -59,6 +59,9 @@ class RedisMatchingStorage implements RealTimeMatchingStorage
         $this->redis->del($key);
     }
 
+    /**
+     * @return array<mixed>|false|self
+     */
     #[\Override]
     public function exec(): self|array|false
     {

--- a/src/Application/Settings.php
+++ b/src/Application/Settings.php
@@ -37,7 +37,7 @@ class Settings
     public array $logger;
 
     /**
-     * @var array
+     * @var array<string, mixed>
      */
     public array $los_rate_limit;
 
@@ -55,6 +55,9 @@ class Settings
     /** @var array{apiKey: non-empty-string, accountWebhookSecret: string, connectAppWebhookSecret: string} */
     public array $stripe;
 
+    /**
+     * @param array<string, string> $env
+     */
     private function __construct(array $env)
     {
         $doctrineConnectionOptions = [];
@@ -115,7 +118,6 @@ class Settings
             'level' => $appEnv === 'local' ? Logger::DEBUG : Logger::INFO,
         ];
 
-        /** @var string|null $maxCreatesPerIpPer5M */
         $maxCreatesPerIpPer5M = $env['MAX_CREATES_PER_IP_PER_5M'] ?? null;
         if (is_string($maxCreatesPerIpPer5M)) {
             $this->los_rate_limit = [
@@ -173,7 +175,7 @@ class Settings
         ];
     }
 
-    /** @param array $env
+    /** @param array<string, string> $env
      * @return non-empty-string
      */
     private function getNonEmptyStringEnv(array $env, string $varName, bool $throwIfMissing = true): string
@@ -186,6 +188,9 @@ class Settings
         return $value;
     }
 
+    /**
+     * @param array<string, string> $env
+     */
     private function getStringEnv(array $env, string $varName, bool $throwIfMissing = true): string
     {
         $value = $env[$varName] ?? null;
@@ -202,6 +207,9 @@ class Settings
         return $value;
     }
 
+    /**
+     * @param array<string, string> $env
+     */
     public static function fromEnvVars(array $env): self
     {
         return new self($env);

--- a/src/Application/Settings.php
+++ b/src/Application/Settings.php
@@ -33,7 +33,7 @@ class Settings
     /** @var array{baseUri: string} */
     public array $identity;
 
-    /** @var array{name: 'matchbot', path: "php://stdout", level: int} */
+    /** @var array{name: 'matchbot', path: "php://stdout", level: Logger::DEBUG|Logger::INFO} */
     public array $logger;
 
     /**

--- a/src/Client/Campaign.php
+++ b/src/Client/Campaign.php
@@ -88,7 +88,6 @@ class Campaign extends Common
      *
      * @psalm-suppress MoreSpecificReturnType
      * @psalm-suppress LessSpecificReturnStatement
-     * @psalm-suppress MixedReturnTypeCoercion
      * @return list<array>
      */
     public function findCampaignsForMetaCampaign(string $metaCampaignSlug, int $limit = 100): array

--- a/src/Client/Common.php
+++ b/src/Client/Common.php
@@ -10,6 +10,7 @@ use GuzzleHttp\Exception\RequestException;
 use MatchBot\Application\Messenger\DonationUpserted;
 use MatchBot\Application\Settings;
 use MatchBot\Domain\Salesforce18Id;
+use MatchBot\Domain\SalesforceProxy;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 
@@ -75,10 +76,13 @@ abstract class Common
     }
 
     /**
+     * @param array<mixed> $jsonSnapshot
+     * @return Salesforce18Id<SalesforceProxy>
+     *@throws NotFoundException
+     * @throws GuzzleException
+     *
      * @throws BadRequestException
      * @throws BadResponseException
-     * @throws NotFoundException
-     * @throws GuzzleException
      */
     protected function postUpdateToSalesforce(string $uri, array $jsonSnapshot, string $uuid, string $entityType): Salesforce18Id
     {
@@ -87,6 +91,7 @@ abstract class Common
             throw new BadRequestException('Client push is off');
         }
 
+        // @phpstan-ignore cast.string
         $messageDate = (string)($jsonSnapshot[DonationUpserted::SNAPSHOT_TAKEN_AT] ?? 'unknown date');
 
         try {

--- a/src/Client/Common.php
+++ b/src/Client/Common.php
@@ -34,9 +34,6 @@ abstract class Common
      *
      * Suppress psalm issues in this function as Psalm seems to prefer to read the type of the param
      * rather than the type of the property, and its awkward to type the array based param.
-     *
-     * @psalm-suppress MixedAssignment
-     * @psalm-suppress MixedArrayAccess
      */
     public function __construct(
         Settings $settings,

--- a/src/Client/Donation.php
+++ b/src/Client/Donation.php
@@ -16,10 +16,15 @@ use MatchBot\Domain\Salesforce18Id;
 class Donation extends Common
 {
     /**
-     * @throws BadRequestException
-     * @throws BadResponseException
+     * @return Salesforce18Id<\MatchBot\Domain\Donation>|null
+     *@throws BadResponseException
      * @throws NotFoundException on missing campaign in a sandbox
      * @throws GuzzleException
+     *
+     * @psalm-suppress LessSpecificReturnStatement
+     * @psalm-suppress MoreSpecificReturnType
+     *
+     * @throws BadRequestException
      */
     public function createOrUpdate(DonationUpserted $message): ?Salesforce18Id
     {

--- a/src/Client/HashTrait.php
+++ b/src/Client/HashTrait.php
@@ -6,6 +6,9 @@ namespace MatchBot\Client;
 
 trait HashTrait
 {
+    /**
+     * @return array<string, string>
+     */
     private function getVerifyHeaders(string $json): array
     {
         return ['X-Webhook-Verify-Hash' => $this->hash($json)];

--- a/src/Client/Mailer.php
+++ b/src/Client/Mailer.php
@@ -16,6 +16,7 @@ class Mailer extends Common
      * @deprecated for public use - use {@see self::send()} instead.
      *
      * @psalm-param array{templateKey: string, recipientEmailAddress: string, params: array, ...} $requestBody
+     * @phpstan-param array<string, mixed> $requestBody
      */
     public function sendEmail(array $requestBody): void
     {

--- a/src/Client/Mandate.php
+++ b/src/Client/Mandate.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Exception\RequestException;
 use MatchBot\Application\Messenger\DonationUpserted;
 use MatchBot\Application\Messenger\MandateUpserted;
 use MatchBot\Domain\DonationRepository;
+use MatchBot\Domain\RegularGivingMandate;
 use MatchBot\Domain\Salesforce18Id;
 
 /**
@@ -23,6 +24,11 @@ class Mandate extends Common
      * @throws BadResponseException
      * @throws NotFoundException on missing campaign in a sandbox
      * @throws GuzzleException
+     *
+     * @psalm-suppress LessSpecificReturnStatement
+     * @psalm-suppress MoreSpecificReturnType
+     *
+     * @return Salesforce18Id<RegularGivingMandate>
      */
     public function createOrUpdate(MandateUpserted $message): Salesforce18Id
     {

--- a/src/Domain/Campaign.php
+++ b/src/Domain/Campaign.php
@@ -49,7 +49,6 @@ class Campaign extends SalesforceReadProxy
      * Consider converting to enum or value object before using in any logic.
      *
      * Default null because campaigns not recently updated in matchbot have not pulled this field from SF.
-     * @psalm-suppress UnusedProperty
      */
     #[ORM\Column(length: 64, nullable: true, options: ['default' => null])]
     private ?string $status = null;

--- a/src/Domain/CampaignRepository.php
+++ b/src/Domain/CampaignRepository.php
@@ -65,7 +65,10 @@ class CampaignRepository extends SalesforceReadProxyRepository
         return $campaigns;
     }
 
-    /** @return list<Campaign> */
+    /**
+     * @param Salesforce18Id<Charity> $charitySfId
+     * @return list<Campaign>
+     */
     public function findUpdatableForCharity(Salesforce18Id $charitySfId): array
     {
         $query = $this->getEntityManager()->createQuery(

--- a/src/Domain/Charity.php
+++ b/src/Domain/Charity.php
@@ -110,7 +110,6 @@ class Charity extends SalesforceReadProxy
     protected bool $tbgClaimingGiftAid = false;
 
     /**
-     * @psalm-suppress UnusedProperty - used in a database query in DonationRepository::findReadyToClaimGiftAid
      * @var bool    Whether the charity's Gift Aid may NOW be claimed by the Big Give according to HMRC.
      */
     #[ORM\Column(type: 'boolean')]

--- a/src/Domain/CharityRepository.php
+++ b/src/Domain/CharityRepository.php
@@ -17,6 +17,7 @@ use MatchBot\Domain\DomainException\DomainRecordNotFoundException;
 class CharityRepository extends EntityRepository
 {
     /**
+     * @param Salesforce18Id<Charity> $sfId
      * @throws DomainRecordNotFoundException
      */
     public function findOneBySfIDOrThrow(Salesforce18Id $sfId): Charity

--- a/src/Domain/DoctrineDonationRepository.php
+++ b/src/Domain/DoctrineDonationRepository.php
@@ -409,6 +409,9 @@ class DoctrineDonationRepository extends SalesforceProxyRepository implements Do
         return count($proxiesToCreate) + count($proxiesToUpdate);
     }
 
+    /**
+     * @param Salesforce18Id<Donation>|null $salesforceId
+     */
     private function setSalesforceFieldsWithRetry(
         DonationUpserted $changeMessage,
         ?Salesforce18Id $salesforceId
@@ -461,6 +464,8 @@ class DoctrineDonationRepository extends SalesforceProxyRepository implements Do
      *  Consider DRYing up duplication with MandateUpsertedHandler::setSalesforceFields before
      *  making a third copy
      * /
+     *
+     * @param Salesforce18Id<Donation>|null $salesforceId
      *
      * @throws DBALException\LockWaitTimeoutException if some other transaction is holding a lock
      */

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -240,15 +240,10 @@ class Donation extends SalesforceWriteProxy
      * (taken at mandate creation time), 2nd, 3rd etc.
      *
      * Null only iff this is a one-off, non regular-giving donation.
-     *
-     * @psalm-suppress PossiblyUnusedProperty - used in DQL
      */
     #[ORM\Column(nullable: true)]
     protected ?int $mandateSequenceNumber = null;
 
-    /**
-     * @psalm-suppress PossiblyUnusedProperty - used in DQL
-     */
     #[ORM\ManyToOne(targetEntity: RegularGivingMandate::class)]
     private ?RegularGivingMandate $mandate = null;
 
@@ -313,7 +308,6 @@ class Donation extends SalesforceWriteProxy
     protected ?bool $tbgShouldProcessGiftAid = null;
 
     /**
-     * @psalm-suppress PossiblyUnusedProperty - used in DB queries
      * @var ?DateTimeImmutable When a queued message that should lead to a Gift Aid claim was sent.
      */
     #[ORM\Column(nullable: true)]
@@ -367,8 +361,6 @@ class Donation extends SalesforceWriteProxy
     /**
      * We only have permission to collect a preAuthorized donation on or after the given date. Intended to be used
      * with regular giving.
-     *
-     * @psalm-suppress UnusedProperty (will use soon)
      *
      * @see DonationStatus::PreAuthorized
      */
@@ -1662,9 +1654,6 @@ class Donation extends SalesforceWriteProxy
         return DonationSequenceNumber::of($this->mandateSequenceNumber);
     }
 
-    /**
-     * @psalm-suppress PossiblyUnusedMethod
-     */
     public function getMandate(): ?RegularGivingMandate
     {
         return $this->mandate;
@@ -1724,10 +1713,7 @@ class Donation extends SalesforceWriteProxy
         $mandate = $this->getMandate();
         $sequenceNumber = $this->getMandateSequenceNumber();
         if ($mandate !== null && $sequenceNumber !== null) {
-            /** @psalm-suppress MixedArrayAssignment */
             $payload['metadata']['mandateId'] = $mandate->getId(); // @phpstan-ignore offsetAccess.nonOffsetAccessible
-
-            /** @psalm-suppress MixedArrayAssignment */
             $payload['metadata']['mandateSequenceNumber'] = $sequenceNumber->number; // @phpstan-ignore offsetAccess.nonOffsetAccessible
         }
 
@@ -1904,9 +1890,6 @@ class Donation extends SalesforceWriteProxy
         $this->tipGiftAid = false;
     }
 
-    /**
-     * @psalm-suppress PossiblyUnusedMethod - expected to be useful for sending donor thanks emails.
-     */
     public function getDonorId(): ?PersonId
     {
         return $this->donorUUID ? PersonId::ofUUID($this->donorUUID) : null;

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -57,7 +57,7 @@ class Donation extends SalesforceWriteProxy
 
     public const string MAT_400_ENABLE_TIMESTAMP = '2025-03-18T14:30:00+00:00';
 
-    private array $possiblePSPs = ['stripe'];
+    private const array POSSIBLE_PSPS = ['stripe'];
 
     /**
      * The donation ID for PSPs and public APIs. Not the same as the internal auto-increment $id used
@@ -552,8 +552,8 @@ class Donation extends SalesforceWriteProxy
     }
 
     /**
-     * @return array|null A representation of the donation suitable for sending to Salesforce, or null if this donation
-     * cannot be represented in SF in its current state.
+     * @return array<string|mixed>|null A representation of the donation suitable for sending to Salesforce,
+     * or null if this donation cannot be represented in SF in its current state.
      */
     public function toSFApiModel(): null|array
     {
@@ -586,6 +586,9 @@ class Donation extends SalesforceWriteProxy
         return $data;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function toFrontEndApiModel(): array
     {
         $totalPaidByDonor = $this->getTotalPaidByDonor();
@@ -972,7 +975,7 @@ class Donation extends SalesforceWriteProxy
      */
     private function setPsp(string $psp): void
     {
-        if (!in_array($psp, $this->possiblePSPs, true)) {
+        if (!in_array($psp, self::POSSIBLE_PSPS, true)) {
             throw new \UnexpectedValueException("Unexpected PSP '$psp'");
         }
 
@@ -1239,6 +1242,8 @@ class Donation extends SalesforceWriteProxy
      * preparing to make a bank transfer. In the latter case we rely on
      * `payment_method_options` to allow the PI to be created even though there aren't
      * yet sufficient funds.
+     *
+     * @return array<string, mixed>
      */
     public function getStripeMethodProperties(): array
     {
@@ -1296,6 +1301,8 @@ class Donation extends SalesforceWriteProxy
      *
      * @link https://stripe.com/docs/payments/connected-accounts
      * @link https://stripe.com/docs/connect/destination-charges#settlement-merchant
+     *
+     * @return array<string, string|null>
      */
     public function getStripeOnBehalfOfProperties(): array
     {
@@ -1718,10 +1725,10 @@ class Donation extends SalesforceWriteProxy
         $sequenceNumber = $this->getMandateSequenceNumber();
         if ($mandate !== null && $sequenceNumber !== null) {
             /** @psalm-suppress MixedArrayAssignment */
-            $payload['metadata']['mandateId'] = $mandate->getId();
+            $payload['metadata']['mandateId'] = $mandate->getId(); // @phpstan-ignore offsetAccess.nonOffsetAccessible
 
             /** @psalm-suppress MixedArrayAssignment */
-            $payload['metadata']['mandateSequenceNumber'] = $sequenceNumber->number;
+            $payload['metadata']['mandateSequenceNumber'] = $sequenceNumber->number; // @phpstan-ignore offsetAccess.nonOffsetAccessible
         }
 
         /** @psalm-suppress InvalidReturnStatement - see note in docblock */

--- a/src/Domain/DonationNotifier.php
+++ b/src/Domain/DonationNotifier.php
@@ -9,9 +9,6 @@ use MatchBot\Client\Mailer;
 
 class DonationNotifier
 {
-    /**
-     * @psalm-suppress PossiblyUnusedMethod - used by DI container
-     */
     public function __construct(
         private Mailer $mailer,
         private EmailVerificationTokenRepository $emailVerificationTokenRepository,

--- a/src/Domain/DonationRepository.php
+++ b/src/Domain/DonationRepository.php
@@ -82,6 +82,8 @@ interface DonationRepository
      * Locks row in DB to prevent concurrent updates. See jira MAT-260
      * Requires an open transaction to be managed by the caller.
      * @throws LockWaitTimeoutException
+     * @param array<string, string|null> $criteria
+     * @param array<string, string>|null $orderBy
      */
     public function findAndLockOneBy(array $criteria, ?array $orderBy = null): ?Donation;
 
@@ -139,6 +141,7 @@ interface DonationRepository
     public function findStaleDonationFundsTips(\DateTimeImmutable $atDateTime, \DateInterval $cancelationDelay): array;
 
     /**
+     * @param Salesforce18Id<Campaign> $campaignId
      * @return list<UuidInterface>
      */
     public function findPendingByDonorCampaignAndMethod(string $donorStripeId, Salesforce18Id $campaignId, PaymentMethodType $paymentMethodType,): array;
@@ -154,11 +157,13 @@ interface DonationRepository
     public function find($id);
 
     /**
+     * @param array{uuid: UuidInterface[]} $criteria
      * @return list<Donation>
      */
     public function findBy(array $criteria);
 
     /**
+     * @phpstan-param array<string, mixed> $criteria
      * @return ?Donation
      */
     public function findOneBy(array $criteria);

--- a/src/Domain/DonationRepository.php
+++ b/src/Domain/DonationRepository.php
@@ -95,8 +95,6 @@ interface DonationRepository
      *
      * @return int  Number of objects pushed
      *
-     * @psalm-suppress PossiblyUnusedReturnValue Psalm bug? Value is used in
-     * \MatchBot\Application\Commands\PushDonations::doExecute
      *
      */
     public function pushSalesforcePending(\DateTimeImmutable $now, MessageBusInterface $bus): int;

--- a/src/Domain/DonationService.php
+++ b/src/Domain/DonationService.php
@@ -447,7 +447,6 @@ class DonationService
 
         $paymentIntentId = $donation->getTransactionId();
         if ($paymentIntentId !== null) {
-            /** @psalm-suppress InvalidArgument  */
             $this->stripe->updatePaymentIntent($paymentIntentId, $updatedIntentData);
         }
     }

--- a/src/Domain/DonationService.php
+++ b/src/Domain/DonationService.php
@@ -679,6 +679,9 @@ class DonationService
         });
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function donationAsApiModel(UuidInterface $donationUUID): array
     {
         $donation = $this->donationRepository->findOneByUUID($donationUUID);
@@ -690,6 +693,9 @@ class DonationService
         return $donation->toFrontEndApiModel();
     }
 
+    /**
+     * @return list<array<string, mixed>>
+     */
     public function findAllCompleteForCustomerAsAPIModels(StripeCustomerId $stripeCustomerId): array
     {
         $donations = $this->donationRepository->findAllCompleteForCustomer($stripeCustomerId);
@@ -762,7 +768,7 @@ class DonationService
 
         /**
          * @psalm-suppress MixedMethodCall
-         * @var array|Card|null $card
+         * @var array<string, mixed>|Card|null $card
          */
         $card = $charge->payment_method_details?->toArray()['card'] ?? null;
         if (is_array($card)) {

--- a/src/Domain/DonorAccount.php
+++ b/src/Domain/DonorAccount.php
@@ -185,6 +185,9 @@ class DonorAccount extends Model
             ->verifyNow();
     }
 
+    /**
+     * @return array<string, null|string>
+     */
     public function toFrontEndApiModel(): array
     {
         return [
@@ -207,6 +210,9 @@ class DonorAccount extends Model
         return Country::fromAlpha2OrNull($this->billingCountryCode);
     }
 
+    /**
+     * @return array<string, string|null>
+     */
     public function toSfApiModel(): array
     {
         return [

--- a/src/Domain/DonorName.php
+++ b/src/Domain/DonorName.php
@@ -68,9 +68,6 @@ class DonorName
         return ($hasFirstName && $hasLastName) ? DonorName::of($firstName, $lastName) : null;
     }
 
-    /**
-     * @psalm-suppress PossiblyUnusedMethod - likely to be used soon when we send emails.
-     */
     public function fullName(): string
     {
         return "{$this->first} {$this->last}";

--- a/src/Domain/Fund.php
+++ b/src/Domain/Fund.php
@@ -54,6 +54,9 @@ class Fund extends SalesforceReadProxy
     #[ORM\Column()]
     private int $allocationOrder;
 
+    /**
+     * @param Salesforce18Id<self>|null $salesforceId
+     */
     public function __construct(string $currencyCode, string $name, ?Salesforce18Id $salesforceId, FundType $fundType)
     {
         $this->createdAt = new \DateTime();

--- a/src/Domain/FundRepository.php
+++ b/src/Domain/FundRepository.php
@@ -184,6 +184,7 @@ class FundRepository extends SalesforceReadProxyRepository
         return $fund;
     }
 
+    /** @param array<string, mixed> $fundData */
     protected function getNewFund(array $fundData): Fund
     {
         $currencyCode = $fundData['currencyCode'] ?? 'GBP';
@@ -194,7 +195,7 @@ class FundRepository extends SalesforceReadProxyRepository
         Assertion::string($name);
         Assertion::string($type);
         Assertion::string($id);
-        $fund = new Fund(currencyCode: $currencyCode, name: $name, salesforceId: Salesforce18Id::of($id), fundType: FundType::from($type));
+        $fund = new Fund(currencyCode: $currencyCode, name: $name, salesforceId: Salesforce18Id::ofFund($id), fundType: FundType::from($type));
 
         return $fund;
     }

--- a/src/Domain/Money.php
+++ b/src/Domain/Money.php
@@ -63,7 +63,6 @@ readonly class Money implements \JsonSerializable, \Stringable
      */
     public function format(): string
     {
-        /** @psalm-suppress ImpureMethodCall - not sure exactly why symbol is considered impure */
         return $this->currency->symbol() .
             number_format(
                 num: $this->amountInPence / 100,
@@ -73,9 +72,6 @@ readonly class Money implements \JsonSerializable, \Stringable
             );
     }
 
-    /**
-     * @psalm-suppress PossiblyUnusedMethod - used indirectly
-     */
     #[\Override]
     public function jsonSerialize(): mixed
     {
@@ -122,7 +118,6 @@ readonly class Money implements \JsonSerializable, \Stringable
     {
         $amountInPence = bcmul($amount, '100', 2);
 
-        /** @psalm-suppress ImpureMethodCall */
         Assertion::integerish((float) $amountInPence);
 
         return new self((int) $amountInPence, Currency::GBP);
@@ -135,7 +130,6 @@ readonly class Money implements \JsonSerializable, \Stringable
     {
         $amountInPence = bcmul($amount, '100', 2);
 
-        /** @psalm-suppress ImpureMethodCall */
         Assertion::integerish((float) $amountInPence);
 
         return new self((int) $amountInPence, $currency);

--- a/src/Domain/RegularGivingMandate.php
+++ b/src/Domain/RegularGivingMandate.php
@@ -278,8 +278,6 @@ class RegularGivingMandate extends SalesforceWriteProxy
      * Records that all donations we plan to take for this donation before the given time have been created
      * and saved as pre-authorized donations. This means that no more donations need to be created based on this
      * mandate before that date.
-     *
-     * @psalm-suppress PossiblyUnusedMethod - to be used soon.
      */
     public function setDonationsCreatedUpTo(?\DateTimeImmutable $donationsCreatedUpTo): void
     {

--- a/src/Domain/RegularGivingMandate.php
+++ b/src/Domain/RegularGivingMandate.php
@@ -186,6 +186,9 @@ class RegularGivingMandate extends SalesforceWriteProxy
         $this->activeFrom = $activationDate;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function toFrontEndApiModel(Charity $charity, \DateTimeImmutable $now): array
     {
         Assertion::same($charity->getSalesforceId(), $this->charityId);
@@ -227,6 +230,9 @@ class RegularGivingMandate extends SalesforceWriteProxy
     }
 
 
+    /**
+     * @return array<string, mixed>
+     */
     public function toSFApiModel(DonorAccount $donor): array
     {
         Assertion::eq($donor->id(), $this->donorId);

--- a/src/Domain/RegularGivingMandateRepository.php
+++ b/src/Domain/RegularGivingMandateRepository.php
@@ -139,8 +139,10 @@ class RegularGivingMandateRepository
      * @param \Doctrine\ORM\Query $query . Query must be for mandates and charities jonied together.
      * @return list<array{0: RegularGivingMandate, 1: Charity}>
      */
-    private function getMandatesWithCharities(\Doctrine\ORM\Query $query)
+    private function getMandatesWithCharities(\Doctrine\ORM\Query $query) // @phpstan-ignore missingType.generics
     {
+        // I'm confused about the missingType.generics error - as far as I can see the Query class is not generic.
+
         /** @var list<RegularGivingMandate|Charity> $x */
         $x = $query->getResult();
 

--- a/src/Domain/RegularGivingNotifier.php
+++ b/src/Domain/RegularGivingNotifier.php
@@ -56,6 +56,8 @@ class RegularGivingNotifier
      * This is currently of course just for regular giving, but we may start using matchbot to send
      * ad-hoc donation email reciepts in future, in which case this function should be able to be moved
      * and re-used
+     *
+     * @return array<string, string|null>
      */
     private function donationToConfirmationEmailFields(
         Donation $firstDonation,
@@ -66,8 +68,6 @@ class RegularGivingNotifier
 
         Assertion::notNull($firstDonationCollectedAt, 'First donation collected at should not be null');
 
-        // todo: consider remvoing duplication below with code in
-        // DonationNotifier::emailCommandForCollectedDonation
         return [
             'currencyCode' => $firstDonation->currency()->isoCode(),
             'donationAmount' => $firstDonation->getAmount(),

--- a/src/Domain/RegularGivingService.php
+++ b/src/Domain/RegularGivingService.php
@@ -31,7 +31,6 @@ use UnexpectedValueException;
 
 readonly class RegularGivingService
 {
-    /** @psalm-suppress PossiblyUnusedMethod - will be used by DI */
     public function __construct(
         private \DateTimeImmutable $now,
         private DonationRepository $donationRepository,

--- a/src/Domain/RegularGivingService.php
+++ b/src/Domain/RegularGivingService.php
@@ -296,6 +296,9 @@ readonly class RegularGivingService
         return $donation;
     }
 
+    /**
+     * @return list<array<array-key, mixed>> List of mandates as front end api models
+     */
     public function allMandatesForDisplayToDonor(PersonId $donor): array
     {
         $mandatesWithCharities = $this->regularGivingMandateRepository->allMandatesForDisplayToDonor($donor);

--- a/src/Domain/Salesforce18Id.php
+++ b/src/Domain/Salesforce18Id.php
@@ -75,9 +75,6 @@ class Salesforce18Id implements JsonSerializable
         return $this->value;
     }
 
-    /**
-     * @psalm-suppress PossiblyUnusedMethod - used indirectly
-     */
     #[\Override]
     public function jsonSerialize(): string
     {

--- a/src/Domain/Salesforce18Id.php
+++ b/src/Domain/Salesforce18Id.php
@@ -28,6 +28,7 @@ class Salesforce18Id implements JsonSerializable
 
     /**
      * @throws AssertionFailedException
+     * @return self<SalesforceProxy>
      */
     public static function of(string $value): self
     {
@@ -46,11 +47,27 @@ class Salesforce18Id implements JsonSerializable
     }
 
     /**
+     * @return self<Fund>
+     */
+    public static function ofFund(string $id): self
+    {
+        return new self($id, Fund::class);
+    }
+
+    /**
      * @return self<Campaign>
      */
     public static function ofCampaign(string $id): self
     {
         return new self($id, Campaign::class);
+    }
+
+    /**
+     * @return self<RegularGivingMandate>
+     */
+    public static function ofRegularGivingMandate(string $id)
+    {
+        return new self($id, RegularGivingMandate::class);
     }
 
     public function __toString(): string

--- a/src/Domain/SalesforceProxyRepository.php
+++ b/src/Domain/SalesforceProxyRepository.php
@@ -67,7 +67,6 @@ abstract class SalesforceProxyRepository extends EntityRepository
      */
     protected function getClient(): Client\Common
     {
-        /** @psalm-suppress DocblockTypeContradiction */
         if (!$this->client) {
             throw new \LogicException('Set a Client in DI config for this Repository to sync data');
         }

--- a/src/Domain/TimestampsTrait.php
+++ b/src/Domain/TimestampsTrait.php
@@ -25,9 +25,6 @@ trait TimestampsTrait
     #[ORM\Column(type: 'datetime')]
     protected DateTime $updatedAt;
 
-    /**
-     * @psalm-suppress PossiblyUnusedMethod
-     */
     #[ORM\PrePersist]
     final public function createdNow(): void
     {

--- a/src/Monolog/Handler/SlackHandler.php
+++ b/src/Monolog/Handler/SlackHandler.php
@@ -32,6 +32,7 @@ class SlackHandler implements HandlerInterface
     }
 
     /**
+     * @param array<string, mixed>|\ArrayAccess<string,mixed> $record
      * @psalm-suppress PossiblyUnusedReturnValue - used by Monolog.
      */
     #[\Override]
@@ -41,7 +42,10 @@ class SlackHandler implements HandlerInterface
             return false; // allows another handle to handle this.
         }
 
+        /** @var string $message */
         $message = $record['message'];
+
+        /** @var string $levelName */
         $levelName = $record['level_name'];
 
         $lines = explode(PHP_EOL, $message);

--- a/src/Monolog/Processor/AwsTraceIdProcessor.php
+++ b/src/Monolog/Processor/AwsTraceIdProcessor.php
@@ -8,7 +8,7 @@ use Monolog\Processor\ProcessorInterface;
 
 class AwsTraceIdProcessor implements ProcessorInterface
 {
-    #[\Override]
+    #[\Override] // @phpstan-ignore missingType.generics
     public function __invoke(array|\ArrayAccess $record): array
     {
         $traceId = $_SERVER['HTTP_X_AMZN_TRACE_ID'] ?? null;

--- a/tests/Application/Actions/DeletePaymentMethodTest.php
+++ b/tests/Application/Actions/DeletePaymentMethodTest.php
@@ -15,6 +15,7 @@ use Stripe\Collection;
 use Stripe\Service\CustomerService;
 use Stripe\Service\PaymentMethodService;
 use Stripe\StripeClient;
+use Stripe\StripeObject;
 
 class DeletePaymentMethodTest extends TestCase
 {
@@ -74,6 +75,10 @@ class DeletePaymentMethodTest extends TestCase
         $sut->__invoke($request, new Response(), ['payment_method_id' => 'stripe_payment_method_id_35']);
     }
 
+    /**
+     * @param list<array{id: string}> $paymentMethods
+     * @return Stub&Collection<StripeObject>
+     */
     public function stubCollectionOf(array $paymentMethods): Stub&Collection
     {
         $stubCollection = $this->createStub(Collection::class);
@@ -85,6 +90,9 @@ class DeletePaymentMethodTest extends TestCase
     /**
      * @psalm-suppress UndefinedPropertyAssignment
      * Not sure why Psalm isn't reading the `@property` annotation on the StripeClient class
+     *
+     * @param ObjectProphecy<PaymentMethodService> $stripePaymentMethodServiceProphecy
+     * @param ObjectProphecy<CustomerService> $stripeCustomerServiceProphecy
      */
     public function fakeStripeClient(
         ObjectProphecy $stripePaymentMethodServiceProphecy,

--- a/tests/Application/Actions/Donations/CancelAllTest.php
+++ b/tests/Application/Actions/Donations/CancelAllTest.php
@@ -118,17 +118,17 @@ class CancelAllTest extends TestCase
         $response = $app->handle($request);
 
         // assert
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $json = (string) $response->getBody();
         $this->assertJson($json);
-        /** @var array{donations: list<array{donationAmount: float, status: string}>} $payload */
+        /** @var array{donations: list<array{donationAmount: float|int, status: string}>} $payload */
         $payload = json_decode($json, true, 512, \JSON_THROW_ON_ERROR);
         $this->assertArrayHasKey('donations', $payload);
         $this->assertCount(2, $payload['donations']);
 
         $donationZero = $payload['donations'][0];
-        $this->assertEquals('Cancelled', $donationZero['status']);
-        $this->assertEquals(10.0, $donationZero['donationAmount']);
+        $this->assertSame('Cancelled', $donationZero['status']);
+        $this->assertSame(10, $donationZero['donationAmount']);
     }
 
     public function testNoAuth(): void

--- a/tests/Application/Actions/Donations/ConfirmTest.php
+++ b/tests/Application/Actions/Donations/ConfirmTest.php
@@ -32,6 +32,7 @@ use Ramsey\Uuid\UuidInterface;
 use Slim\Exception\HttpBadRequestException;
 use Slim\Psr7\Response;
 use Stripe\ConfirmationToken;
+use Stripe\Exception\ApiErrorException;
 use Stripe\Exception\CardException;
 use Stripe\Exception\InvalidRequestException;
 use Stripe\Exception\UnknownApiErrorException;
@@ -312,6 +313,11 @@ class ConfirmTest extends TestCase
         );
     }
 
+    /**
+     * @param array<mixed> $cardDetails
+     * @param array<mixed> $updatedIntentData
+     * @param array<mixed> $expectedMetadataUpdate
+     */
     private function fakeStripeClient(
         array $cardDetails,
         string $paymentMethodId,

--- a/tests/Application/Actions/Donations/CreateTest.php
+++ b/tests/Application/Actions/Donations/CreateTest.php
@@ -33,6 +33,7 @@ use MatchBot\Tests\TestData\Identity;
 use Override;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Ramsey\Uuid\Uuid;
 use Slim\App;
@@ -48,6 +49,8 @@ class CreateTest extends TestCase
 {
     public const string PSPCUSTOMERID = 'cus_aaaaaaaaaaaa11';
     public const string DONATION_UUID = '1822c3b6-b405-11ef-9766-63f04fc63fc3';
+
+    /** @var array<string, mixed> */
     private static array $somePaymentIntentArgs;
     /**
      * @var PaymentIntent Mock result, most properites we don't use omitted.
@@ -804,7 +807,7 @@ class CreateTest extends TestCase
         $this->assertJson($payload);
         $this->assertEquals(201, $response->getStatusCode());
 
-        /** @var array<string, string|numeric|boolean|array> $payloadArray */
+        /** @var array<string, string|numeric|boolean|array<array-key, mixed>> $payloadArray */
         $payloadArray = json_decode($payload, true);
 
         $this->assertIsString($payloadArray['jwt']);
@@ -859,7 +862,7 @@ class CreateTest extends TestCase
         $this->assertJson($payload);
         $this->assertEquals(500, $response->getStatusCode());
 
-        /** @var array $payloadArray */
+        /** @var array<string, mixed> $payloadArray */
         $payloadArray = json_decode($payload, true);
 
         $this->assertEquals(['error' => [
@@ -874,6 +877,7 @@ class CreateTest extends TestCase
      *
      * @param bool $skipEmExpectations  Whether to bypass monitoring calls on the entity manager,
      *                                  e.g. because the test will replace it with a more specific one.
+     * @return App<ContainerInterface|null>
      */
     private function getAppWithCommonPersistenceDeps(
         bool $donationPersisted,
@@ -929,7 +933,7 @@ class CreateTest extends TestCase
         $this->diContainer()->set(DonationRepository::class, $donationRepoProphecy->reveal());
         $this->diContainer()->set(RoutableMessageBus::class, $this->messageBusProphecy->reveal());
 
-        return $app;
+        return $app; // @phpstan-ignore return.type
     }
 
     private function encode(Donation $donation): string

--- a/tests/Application/Actions/Donations/CreateTest.php
+++ b/tests/Application/Actions/Donations/CreateTest.php
@@ -194,8 +194,8 @@ class CreateTest extends TestCase
         ]]);
         $expectedSerialised = json_encode($expectedPayload, JSON_PRETTY_PRINT);
 
-        $this->assertEquals($expectedSerialised, $payload);
-        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertSame($expectedSerialised, $payload);
+        $this->assertSame(400, $response->getStatusCode());
     }
 
     public function testCampaignClosed(): void
@@ -215,8 +215,8 @@ class CreateTest extends TestCase
         ]]);
         $expectedSerialised = json_encode($expectedPayload, JSON_PRETTY_PRINT);
 
-        $this->assertEquals($expectedSerialised, $payload);
-        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertSame($expectedSerialised, $payload);
+        $this->assertSame(400, $response->getStatusCode());
     }
 
     /**
@@ -264,13 +264,13 @@ class CreateTest extends TestCase
         $payload = (string) $response->getBody();
 
         $this->assertJson($payload);
-        $this->assertEquals(500, $response->getStatusCode());
+        $this->assertSame(500, $response->getStatusCode());
 
         $payloadArray = json_decode($payload, true);
         \assert(is_array($payloadArray));
 
-        $this->assertEquals('SERVER_ERROR', $payloadArray['error']['type']);
-        $this->assertEquals('Could not make Stripe Payment Intent (A)', $payloadArray['error']['description']);
+        $this->assertSame('SERVER_ERROR', $payloadArray['error']['type']);
+        $this->assertSame('Could not make Stripe Payment Intent (A)', $payloadArray['error']['description']);
     }
 
     public function testCurrencyMismatch(): void
@@ -298,8 +298,8 @@ class CreateTest extends TestCase
         ]]);
         $expectedSerialised = json_encode($expectedPayload, JSON_PRETTY_PRINT);
 
-        $this->assertEquals($expectedSerialised, $payload);
-        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertSame($expectedSerialised, $payload);
+        $this->assertSame(400, $response->getStatusCode());
     }
 
     /**
@@ -428,7 +428,7 @@ class CreateTest extends TestCase
         $payload = (string) $response->getBody();
 
         $this->assertJson($payload);
-        $this->assertEquals(201, $response->getStatusCode());
+        $this->assertSame(201, $response->getStatusCode());
 
         $payloadArray = json_decode($payload, true);
 
@@ -436,21 +436,21 @@ class CreateTest extends TestCase
         $this->assertNotEmpty($payloadArray['jwt']);
         $this->assertIsArray($payloadArray['donation']);
         $this->assertFalse($payloadArray['donation']['giftAid']);
-        $this->assertEquals(0.38, $payloadArray['donation']['charityFee']);
-        $this->assertEquals(0, $payloadArray['donation']['charityFeeVat']);
-        $this->assertEquals('GB', $payloadArray['donation']['countryCode']);
-        $this->assertEquals('12', $payloadArray['donation']['donationAmount']);
-        $this->assertEquals(self::DONATION_UUID, $payloadArray['donation']['donationId']);
-        $this->assertEquals('8', $payloadArray['donation']['matchReservedAmount']);
+        $this->assertSame(0.38, $payloadArray['donation']['charityFee']);
+        $this->assertSame(0, $payloadArray['donation']['charityFeeVat']);
+        $this->assertSame('GB', $payloadArray['donation']['countryCode']);
+        $this->assertSame(12, $payloadArray['donation']['donationAmount']);
+        $this->assertSame(self::DONATION_UUID, $payloadArray['donation']['donationId']);
+        $this->assertSame(8, $payloadArray['donation']['matchReservedAmount']);
         $this->assertTrue($payloadArray['donation']['optInCharityEmail']);
         $this->assertFalse($payloadArray['donation']['optInChampionEmail']);
         $this->assertFalse($payloadArray['donation']['optInTbgEmail']);
-        $this->assertEquals('1.11', $payloadArray['donation']['tipAmount']);
-        $this->assertEquals('567CharitySFID', $payloadArray['donation']['charityId']);
-        $this->assertEquals('123CampaignId12345', $payloadArray['donation']['projectId']);
-        $this->assertEquals(DonationStatus::Pending->value, $payloadArray['donation']['status']);
-        $this->assertEquals('stripe', $payloadArray['donation']['psp']);
-        $this->assertEquals('pi_dummyIntent456_id', $payloadArray['donation']['transactionId']);
+        $this->assertSame(1.11, $payloadArray['donation']['tipAmount']);
+        $this->assertSame('567CharitySFID', $payloadArray['donation']['charityId']);
+        $this->assertSame('123CampaignId12345', $payloadArray['donation']['projectId']);
+        $this->assertSame(DonationStatus::Pending->value, $payloadArray['donation']['status']);
+        $this->assertSame('stripe', $payloadArray['donation']['psp']);
+        $this->assertSame('pi_dummyIntent456_id', $payloadArray['donation']['transactionId']);
     }
 
     /**
@@ -524,7 +524,7 @@ class CreateTest extends TestCase
         $payload = (string) $response->getBody();
 
         $this->assertJson($payload);
-        $this->assertEquals(201, $response->getStatusCode());
+        $this->assertSame(201, $response->getStatusCode());
 
         $payloadArray = json_decode($payload, true);
 
@@ -532,21 +532,21 @@ class CreateTest extends TestCase
         $this->assertNotEmpty($payloadArray['jwt']);
         $this->assertIsArray($payloadArray['donation']);
         $this->assertFalse($payloadArray['donation']['giftAid']);
-        $this->assertEquals(0.38, $payloadArray['donation']['charityFee']); // 1.5% + 20p.
-        $this->assertEquals(0, $payloadArray['donation']['charityFeeVat']);
-        $this->assertEquals('GB', $payloadArray['donation']['countryCode']);
-        $this->assertEquals('12', $payloadArray['donation']['donationAmount']);
-        $this->assertEquals(self::DONATION_UUID, $payloadArray['donation']['donationId']);
-        $this->assertEquals('8', $payloadArray['donation']['matchReservedAmount']);
+        $this->assertSame(0.38, $payloadArray['donation']['charityFee']); // 1.5% + 20p.
+        $this->assertSame(0, $payloadArray['donation']['charityFeeVat']);
+        $this->assertSame('GB', $payloadArray['donation']['countryCode']);
+        $this->assertSame(12, $payloadArray['donation']['donationAmount']);
+        $this->assertSame(self::DONATION_UUID, $payloadArray['donation']['donationId']);
+        $this->assertSame(8, $payloadArray['donation']['matchReservedAmount']);
         $this->assertTrue($payloadArray['donation']['optInCharityEmail']);
         $this->assertFalse($payloadArray['donation']['optInChampionEmail']);
         $this->assertFalse($payloadArray['donation']['optInTbgEmail']);
-        $this->assertEquals('1.11', $payloadArray['donation']['tipAmount']);
-        $this->assertEquals('567CharitySFID', $payloadArray['donation']['charityId']);
-        $this->assertEquals('123CampaignId12345', $payloadArray['donation']['projectId']);
-        $this->assertEquals(DonationStatus::Pending->value, $payloadArray['donation']['status']);
-        $this->assertEquals('stripe', $payloadArray['donation']['psp']);
-        $this->assertEquals('pi_dummyIntent_id', $payloadArray['donation']['transactionId']);
+        $this->assertSame(1.11, $payloadArray['donation']['tipAmount']);
+        $this->assertSame('567CharitySFID', $payloadArray['donation']['charityId']);
+        $this->assertSame('123CampaignId12345', $payloadArray['donation']['projectId']);
+        $this->assertSame(DonationStatus::Pending->value, $payloadArray['donation']['status']);
+        $this->assertSame('stripe', $payloadArray['donation']['psp']);
+        $this->assertSame('pi_dummyIntent_id', $payloadArray['donation']['transactionId']);
     }
 
     /**
@@ -623,7 +623,7 @@ class CreateTest extends TestCase
         $payload = (string) $response->getBody();
 
         $this->assertJson($payload);
-        $this->assertEquals(201, $response->getStatusCode());
+        $this->assertSame(201, $response->getStatusCode());
 
         $payloadArray = json_decode($payload, true);
 
@@ -631,21 +631,21 @@ class CreateTest extends TestCase
         $this->assertNotEmpty($payloadArray['jwt']);
         $this->assertIsArray($payloadArray['donation']);
         $this->assertFalse($payloadArray['donation']['giftAid']);
-        $this->assertEquals(0.38, $payloadArray['donation']['charityFee']); // 1.5% + 20p.
-        $this->assertEquals(0, $payloadArray['donation']['charityFeeVat']);
-        $this->assertEquals('GB', $payloadArray['donation']['countryCode']);
-        $this->assertEquals('12', $payloadArray['donation']['donationAmount']);
-        $this->assertEquals(self::DONATION_UUID, $payloadArray['donation']['donationId']);
-        $this->assertEquals('8', $payloadArray['donation']['matchReservedAmount']);
+        $this->assertSame(0.38, $payloadArray['donation']['charityFee']); // 1.5% + 20p.
+        $this->assertSame(0, $payloadArray['donation']['charityFeeVat']);
+        $this->assertSame('GB', $payloadArray['donation']['countryCode']);
+        $this->assertSame(12, $payloadArray['donation']['donationAmount']);
+        $this->assertSame(self::DONATION_UUID, $payloadArray['donation']['donationId']);
+        $this->assertSame(8, $payloadArray['donation']['matchReservedAmount']);
         $this->assertTrue($payloadArray['donation']['optInCharityEmail']);
         $this->assertFalse($payloadArray['donation']['optInChampionEmail']);
         $this->assertFalse($payloadArray['donation']['optInTbgEmail']);
-        $this->assertEquals('1.11', $payloadArray['donation']['tipAmount']);
-        $this->assertEquals('567CharitySFID', $payloadArray['donation']['charityId']);
-        $this->assertEquals('123CampaignId12345', $payloadArray['donation']['projectId']);
-        $this->assertEquals(DonationStatus::Pending->value, $payloadArray['donation']['status']);
-        $this->assertEquals('stripe', $payloadArray['donation']['psp']);
-        $this->assertEquals('pi_dummyIntent_id', $payloadArray['donation']['transactionId']);
+        $this->assertSame(1.11, $payloadArray['donation']['tipAmount']);
+        $this->assertSame('567CharitySFID', $payloadArray['donation']['charityId']);
+        $this->assertSame('123CampaignId12345', $payloadArray['donation']['projectId']);
+        $this->assertSame(DonationStatus::Pending->value, $payloadArray['donation']['status']);
+        $this->assertSame('stripe', $payloadArray['donation']['psp']);
+        $this->assertSame('pi_dummyIntent_id', $payloadArray['donation']['transactionId']);
     }
 
     public function testMatchedCampaignButWrongPersonInRoute(): void
@@ -716,8 +716,8 @@ class CreateTest extends TestCase
         ]]);
         $expectedSerialised = json_encode($expectedPayload, JSON_PRETTY_PRINT);
 
-        $this->assertEquals($expectedSerialised, $payload);
-        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertSame($expectedSerialised, $payload);
+        $this->assertSame(400, $response->getStatusCode());
     }
 
     /**
@@ -751,7 +751,7 @@ class CreateTest extends TestCase
         $payload = (string) $response->getBody();
 
         $this->assertJson($payload);
-        $this->assertEquals(201, $response->getStatusCode());
+        $this->assertSame(201, $response->getStatusCode());
 
         $payloadArray = json_decode($payload, true);
 
@@ -759,18 +759,18 @@ class CreateTest extends TestCase
         $this->assertNotEmpty($payloadArray['jwt']);
         $this->assertIsArray($payloadArray['donation']);
         $this->assertFalse($payloadArray['donation']['giftAid']);
-        $this->assertEquals(0.43, $payloadArray['donation']['charityFee']); // 1.9% + 20p.
-        $this->assertEquals(0, $payloadArray['donation']['charityFeeVat']);
-        $this->assertEquals('GB', $payloadArray['donation']['countryCode']);
-        $this->assertEquals('12', $payloadArray['donation']['donationAmount']);
-        $this->assertEquals(self::DONATION_UUID, $payloadArray['donation']['donationId']);
-        $this->assertEquals('0', $payloadArray['donation']['matchReservedAmount']);
+        $this->assertSame(0.43, $payloadArray['donation']['charityFee']); // 1.9% + 20p.
+        $this->assertSame(0, $payloadArray['donation']['charityFeeVat']);
+        $this->assertSame('GB', $payloadArray['donation']['countryCode']);
+        $this->assertSame(12, $payloadArray['donation']['donationAmount']);
+        $this->assertSame(self::DONATION_UUID, $payloadArray['donation']['donationId']);
+        $this->assertSame(0, $payloadArray['donation']['matchReservedAmount']);
         $this->assertTrue($payloadArray['donation']['optInCharityEmail']);
         $this->assertFalse($payloadArray['donation']['optInChampionEmail']);
         $this->assertFalse($payloadArray['donation']['optInTbgEmail']);
-        $this->assertEquals('1.11', $payloadArray['donation']['tipAmount']);
-        $this->assertEquals('567CharitySFID', $payloadArray['donation']['charityId']);
-        $this->assertEquals('123CampaignId12345', $payloadArray['donation']['projectId']);
+        $this->assertSame(1.11, $payloadArray['donation']['tipAmount']);
+        $this->assertSame('567CharitySFID', $payloadArray['donation']['charityId']);
+        $this->assertSame('123CampaignId12345', $payloadArray['donation']['projectId']);
     }
 
     /**
@@ -805,7 +805,7 @@ class CreateTest extends TestCase
         $payload = (string) $response->getBody();
 
         $this->assertJson($payload);
-        $this->assertEquals(201, $response->getStatusCode());
+        $this->assertSame(201, $response->getStatusCode());
 
         /** @var array<string, string|numeric|boolean|array<array-key, mixed>> $payloadArray */
         $payloadArray = json_decode($payload, true);
@@ -818,15 +818,15 @@ class CreateTest extends TestCase
         $this->assertNull($payloadArray['donation']['optInCharityEmail']);
         $this->assertNull($payloadArray['donation']['optInChampionEmail']);
         $this->assertNull($payloadArray['donation']['optInTbgEmail']);
-        $this->assertEquals(0.43, $payloadArray['donation']['charityFee']); // 1.9% + 20p.
-        $this->assertEquals(0, $payloadArray['donation']['charityFeeVat']);
-        $this->assertEquals('GB', $payloadArray['donation']['countryCode']);
-        $this->assertEquals('12', $payloadArray['donation']['donationAmount']);
-        $this->assertEquals(self::DONATION_UUID, $payloadArray['donation']['donationId']);
-        $this->assertEquals('0', $payloadArray['donation']['matchReservedAmount']);
-        $this->assertEquals('1.11', $payloadArray['donation']['tipAmount']);
-        $this->assertEquals('567CharitySFID', $payloadArray['donation']['charityId']);
-        $this->assertEquals('123CampaignId12345', $payloadArray['donation']['projectId']);
+        $this->assertSame(0.43, $payloadArray['donation']['charityFee']); // 1.9% + 20p.
+        $this->assertSame(0, $payloadArray['donation']['charityFeeVat']);
+        $this->assertSame('GB', $payloadArray['donation']['countryCode']);
+        $this->assertSame(12, $payloadArray['donation']['donationAmount']);
+        $this->assertSame(self::DONATION_UUID, $payloadArray['donation']['donationId']);
+        $this->assertSame(0, $payloadArray['donation']['matchReservedAmount']);
+        $this->assertSame(1.11, $payloadArray['donation']['tipAmount']);
+        $this->assertSame('567CharitySFID', $payloadArray['donation']['charityId']);
+        $this->assertSame('123CampaignId12345', $payloadArray['donation']['projectId']);
     }
 
     /**
@@ -860,12 +860,12 @@ class CreateTest extends TestCase
         $payload = (string) $response->getBody();
 
         $this->assertJson($payload);
-        $this->assertEquals(500, $response->getStatusCode());
+        $this->assertSame(500, $response->getStatusCode());
 
         /** @var array<string, mixed> $payloadArray */
         $payloadArray = json_decode($payload, true);
 
-        $this->assertEquals(['error' => [
+        $this->assertSame(['error' => [
             'type' => 'SERVER_ERROR',
             'description' => 'Could not make Stripe Payment Intent (D)',
         ]], $payloadArray);

--- a/tests/Application/Actions/Donations/CreateTest.php
+++ b/tests/Application/Actions/Donations/CreateTest.php
@@ -776,8 +776,6 @@ class CreateTest extends TestCase
     /**
      * Use unmatched campaign in previous test but also omit all donor-supplied
      * detail except donation and tip amount, to test new 2-step Create setup.
-     *
-     * @psalm-suppress MixedArrayAccess
      */
     public function testSuccessWithMinimalData(): void
     {

--- a/tests/Application/Actions/Donations/GetTest.php
+++ b/tests/Application/Actions/Donations/GetTest.php
@@ -116,18 +116,18 @@ class GetTest extends TestCase
         $payload = (string) $response->getBody();
 
         $this->assertJson($payload);
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
 
         /** @var array<string, string|numeric|boolean> $payloadArray */
         $payloadArray = json_decode($payload, true);
         $this->assertNotEmpty($payloadArray['createdTime']);
-        $this->assertEquals('N1 1AA', $payloadArray['billingPostalAddress']);
+        $this->assertSame('N1 1AA', $payloadArray['billingPostalAddress']);
         $this->assertTrue($payloadArray['giftAid']);
         $this->assertTrue($payloadArray['optInCharityEmail']);
         $this->assertFalse($payloadArray['optInTbgEmail']);
-        $this->assertEquals(0, $payloadArray['matchedAmount']);
-        $this->assertEquals(1.00, $payloadArray['tipAmount']);
-        $this->assertEquals(2.05, $payloadArray['charityFee']); // 1.5% + 20p.
-        $this->assertEquals(0, $payloadArray['charityFeeVat']);
+        $this->assertSame(0, $payloadArray['matchedAmount']);
+        $this->assertSame(1, $payloadArray['tipAmount']);
+        $this->assertSame(2.05, $payloadArray['charityFee']); // 1.5% + 20p.
+        $this->assertSame(0, $payloadArray['charityFeeVat']);
     }
 }

--- a/tests/Application/Actions/Donations/PublicJWTAuthTrait.php
+++ b/tests/Application/Actions/Donations/PublicJWTAuthTrait.php
@@ -16,6 +16,7 @@ use Slim\Routing\Route;
  */
 trait PublicJWTAuthTrait
 {
+    /** @return Route<null> */
     private function getRouteWithDonationId(string $method, string $donationId): Route
     {
         $route = new Route(

--- a/tests/Application/Actions/Donations/UpdateHandlesLockExceptionTest.php
+++ b/tests/Application/Actions/Donations/UpdateHandlesLockExceptionTest.php
@@ -181,7 +181,7 @@ class UpdateHandlesLockExceptionTest extends TestCase
                 throw new LockWaitTimeoutException($testCase->createStub(DriverException::class), null);
             }
 
-            TestCase::assertEquals($newStatus, $donation->getDonationStatus());
+            TestCase::assertSame($newStatus, $donation->getDonationStatus());
             return null;
         });
 

--- a/tests/Application/Actions/Donations/UpdateTest.php
+++ b/tests/Application/Actions/Donations/UpdateTest.php
@@ -16,6 +16,7 @@ use MatchBot\Domain\EmailAddress;
 use MatchBot\Domain\FundRepository;
 use MatchBot\Tests\Domain\InMemoryDonationRepository;
 use Override;
+use Psr\Container\ContainerInterface;
 use Slim\Routing\Route;
 use MatchBot\Application\Actions\ActionPayload;
 use MatchBot\Application\Auth\DonationToken;
@@ -1537,9 +1538,9 @@ class UpdateTest extends TestCase
 
     /**
      * @return array{
-     *     app: App,
+     *     app: App<ContainerInterface|null>,
      * request: ServerRequestInterface,
-     * route: Route,
+     * route: Route<null>,
      * entityManagerProphecy: ObjectProphecy<EntityManagerInterface>,
      * stripeProphecy: ObjectProphecy<Stripe>
      * }
@@ -1606,7 +1607,7 @@ class UpdateTest extends TestCase
             ->withHeader('x-tbg-auth', DonationToken::create(self::DONATION_UUID));
         $route = $this->getRouteWithDonationId('put', self::DONATION_UUID);
 
-        return [
+        return [ // @phpstan-ignore return.type
             'app' => $app,
             'request' => $request,
             'route' => $route,
@@ -1669,6 +1670,9 @@ class UpdateTest extends TestCase
         return $entityManagerProphecy;
     }
 
+    /**
+     * @return array<mixed>
+     */
     private function decodePaylode(string $payload): array
     {
         $decoded = json_decode($payload, true, \JSON_THROW_ON_ERROR);

--- a/tests/Application/Actions/Donations/UpdateTest.php
+++ b/tests/Application/Actions/Donations/UpdateTest.php
@@ -169,8 +169,8 @@ class UpdateTest extends TestCase
         ]]);
         $expectedSerialised = json_encode($expectedPayload, JSON_PRETTY_PRINT);
 
-        $this->assertEquals($expectedSerialised, $payload);
-        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertSame($expectedSerialised, $payload);
+        $this->assertSame(400, $response->getStatusCode());
     }
 
     public function testMissingStatus(): void
@@ -204,8 +204,8 @@ class UpdateTest extends TestCase
         ]]);
         $expectedSerialised = json_encode($expectedPayload, JSON_PRETTY_PRINT);
 
-        $this->assertEquals($expectedSerialised, $payload);
-        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertSame($expectedSerialised, $payload);
+        $this->assertSame(400, $response->getStatusCode());
     }
 
     public function testCancelRequestAfterDonationFinalised(): void
@@ -249,8 +249,8 @@ class UpdateTest extends TestCase
         ]]);
         $expectedSerialised = json_encode($expectedPayload, JSON_PRETTY_PRINT);
 
-        $this->assertEquals($expectedSerialised, $payload);
-        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertSame($expectedSerialised, $payload);
+        $this->assertSame(400, $response->getStatusCode());
     }
 
     public function testCancelSuccessWithNoStatusChangesIgnored(): void
@@ -285,19 +285,19 @@ class UpdateTest extends TestCase
         $payload = (string) $response->getBody();
 
         $this->assertJson($payload);
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
 
         $payloadArray = $this->decodePaylode($payload);
-        $this->assertEquals(DonationStatus::Cancelled->value, $payloadArray['status']);
-        $this->assertEquals('N1 1AA', $payloadArray['billingPostalAddress']);
+        $this->assertSame(DonationStatus::Cancelled->value, $payloadArray['status']);
+        $this->assertSame('N1 1AA', $payloadArray['billingPostalAddress']);
         $this->assertTrue($payloadArray['giftAid']);
         $this->assertTrue($payloadArray['optInCharityEmail']);
         $this->assertFalse($payloadArray['optInTbgEmail']);
-        $this->assertEquals(123.45, $payloadArray['donationAmount']); // Attempt to patch this is ignored
-        $this->assertEquals(0, $payloadArray['matchedAmount']);
-        $this->assertEquals(1.00, $payloadArray['tipAmount']);
-        $this->assertEquals(2.05, $payloadArray['charityFee']); // 1.5% + 20p.
-        $this->assertEquals(0, $payloadArray['charityFeeVat']);
+        $this->assertSame(123.45, $payloadArray['donationAmount']); // Attempt to patch this is ignored
+        $this->assertSame(0, $payloadArray['matchedAmount']);
+        $this->assertSame(1, $payloadArray['tipAmount']);
+        $this->assertSame(2.05, $payloadArray['charityFee']); // 1.5% + 20p.
+        $this->assertSame(0, $payloadArray['charityFeeVat']);
     }
 
     public function testCancelSuccessWithChange(): void
@@ -337,19 +337,19 @@ class UpdateTest extends TestCase
         $payload = (string) $response->getBody();
 
         $this->assertJson($payload);
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
 
         $payloadArray = $this->decodePaylode($payload);
-        $this->assertEquals(DonationStatus::Cancelled->value, $payloadArray['status']);
-        $this->assertEquals('N1 1AA', $payloadArray['billingPostalAddress']);
+        $this->assertSame(DonationStatus::Cancelled->value, $payloadArray['status']);
+        $this->assertSame('N1 1AA', $payloadArray['billingPostalAddress']);
         $this->assertTrue($payloadArray['giftAid']);
         $this->assertTrue($payloadArray['optInCharityEmail']);
         $this->assertFalse($payloadArray['optInTbgEmail']);
-        $this->assertEquals(123.45, $payloadArray['donationAmount']); // Attempt to patch this is ignored
-        $this->assertEquals(0, $payloadArray['matchedAmount']);
-        $this->assertEquals(1.00, $payloadArray['tipAmount']);
-        $this->assertEquals(2.05, $payloadArray['charityFee']); // 1.5% + 20p.
-        $this->assertEquals(0, $payloadArray['charityFeeVat']);
+        $this->assertSame(123.45, $payloadArray['donationAmount']); // Attempt to patch this is ignored
+        $this->assertSame(0, $payloadArray['matchedAmount']);
+        $this->assertSame(1, $payloadArray['tipAmount']);
+        $this->assertSame(2.05, $payloadArray['charityFee']); // 1.5% + 20p.
+        $this->assertSame(0, $payloadArray['charityFeeVat']);
     }
 
     /**
@@ -398,7 +398,7 @@ class UpdateTest extends TestCase
         $payload = (string) $response->getBody();
 
         $this->assertJson($payload);
-        $this->assertEquals(500, $response->getStatusCode());
+        $this->assertSame(500, $response->getStatusCode());
     }
 
     /**
@@ -446,10 +446,10 @@ class UpdateTest extends TestCase
         $payload = (string) $response->getBody();
 
         $this->assertJson($payload);
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
 
         $payloadArray = $this->decodePaylode($payload);
-        $this->assertEquals(DonationStatus::Cancelled->value, $payloadArray['status']);
+        $this->assertSame(DonationStatus::Cancelled->value, $payloadArray['status']);
     }
 
     public function testCancelSuccessWithChangeFromPendingAnonymousDonation(): void
@@ -483,16 +483,16 @@ class UpdateTest extends TestCase
         $payload = (string) $response->getBody();
 
         $this->assertJson($payload);
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
 
         $payloadArray = $this->decodePaylode($payload);
-        $this->assertEquals(DonationStatus::Cancelled->value, $payloadArray['status']);
+        $this->assertSame(DonationStatus::Cancelled->value, $payloadArray['status']);
         $this->assertFalse($payloadArray['giftAid']);
-        $this->assertEquals(124.56, $payloadArray['donationAmount']); // Attempt to patch this is ignored
-        $this->assertEquals(0, $payloadArray['matchedAmount']);
-        $this->assertEquals(2.00, $payloadArray['tipAmount']);
-        $this->assertEquals(2.57, $payloadArray['charityFee']); // 1.9% + 20p.
-        $this->assertEquals(0, $payloadArray['charityFeeVat']);
+        $this->assertSame(124.56, $payloadArray['donationAmount']); // Attempt to patch this is ignored
+        $this->assertSame(0, $payloadArray['matchedAmount']);
+        $this->assertSame(2, $payloadArray['tipAmount']);
+        $this->assertSame(2.57, $payloadArray['charityFee']); // 1.9% + 20p.
+        $this->assertSame(0, $payloadArray['charityFeeVat']);
     }
 
     public function testAddDataAttemptWithDifferentAmount(): void
@@ -527,8 +527,8 @@ class UpdateTest extends TestCase
         ]]);
         $expectedSerialised = json_encode($expectedPayload, JSON_PRETTY_PRINT);
 
-        $this->assertEquals($expectedSerialised, $payload);
-        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertSame($expectedSerialised, $payload);
+        $this->assertSame(400, $response->getStatusCode());
     }
 
     public function testAddDataAttemptWithRequiredBooleanFieldMissing(): void
@@ -565,8 +565,8 @@ class UpdateTest extends TestCase
         ]]);
         $expectedSerialised = json_encode($expectedPayload, JSON_PRETTY_PRINT);
 
-        $this->assertEquals($expectedSerialised, $payload);
-        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertSame($expectedSerialised, $payload);
+        $this->assertSame(400, $response->getStatusCode());
     }
 
     /**
@@ -608,8 +608,8 @@ class UpdateTest extends TestCase
         ]]);
         $expectedSerialised = json_encode($expectedPayload, JSON_PRETTY_PRINT);
 
-        $this->assertEquals($expectedSerialised, $payload);
-        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertSame($expectedSerialised, $payload);
+        $this->assertSame(400, $response->getStatusCode());
     }
 
     public function testAddDataAttemptWithGiftAidMissingDonatingInGBP(): void
@@ -646,8 +646,8 @@ class UpdateTest extends TestCase
         ]]);
         $expectedSerialised = json_encode($expectedPayload, JSON_PRETTY_PRINT);
 
-        $this->assertEquals($expectedSerialised, $payload);
-        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertSame($expectedSerialised, $payload);
+        $this->assertSame(400, $response->getStatusCode());
     }
 
     public function testAddDataAttemptWithTipAboveMaximumAllowed(): void
@@ -688,8 +688,8 @@ class UpdateTest extends TestCase
         ]]);
         $expectedSerialised = json_encode($expectedPayload, JSON_PRETTY_PRINT);
 
-        $this->assertEquals($expectedSerialised, $payload);
-        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertSame($expectedSerialised, $payload);
+        $this->assertSame(400, $response->getStatusCode());
     }
 
     public function testAddDataHitsUnexpectedStripeException(): void
@@ -754,10 +754,10 @@ class UpdateTest extends TestCase
         $payload = (string) $response->getBody();
 
         $this->assertJson($payload);
-        $this->assertEquals(500, $response->getStatusCode());
+        $this->assertSame(500, $response->getStatusCode());
 
         $payloadArray = $this->decodePaylode($payload);
-        $this->assertEquals([
+        $this->assertSame([
             'error' => [
                 'type' => 'SERVER_ERROR',
                 'description' => 'Could not update Stripe Payment Intent [B]',
@@ -836,10 +836,10 @@ class UpdateTest extends TestCase
         $payload = (string) $response->getBody();
 
         $this->assertJson($payload);
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
 
         $payloadArray = $this->decodePaylode($payload);
-        $this->assertEquals(3.08, $payloadArray['charityFee']);
+        $this->assertSame(3.08, $payloadArray['charityFee']);
     }
 
     public function testAddDataHitsAlreadyCapturedStripeExceptionWithFeeChange(): void
@@ -915,10 +915,10 @@ class UpdateTest extends TestCase
         $payload = (string) $response->getBody();
 
         $this->assertJson($payload);
-        $this->assertEquals(500, $response->getStatusCode());
+        $this->assertSame(500, $response->getStatusCode());
 
         $payloadArray = $this->decodePaylode($payload);
-        $this->assertEquals([
+        $this->assertSame([
             'error' => [
                 'type' => 'SERVER_ERROR',
                 'description' => 'Could not update Stripe Payment Intent [A]',
@@ -997,10 +997,10 @@ class UpdateTest extends TestCase
 
         // If retry worked, all good from the API client's perspective.
         $this->assertJson($payload);
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
 
         $payloadArray = $this->decodePaylode($payload);
-        $this->assertEquals(3.08, $payloadArray['charityFee']);
+        $this->assertSame(3.08, $payloadArray['charityFee']);
     }
 
     /**
@@ -1074,10 +1074,10 @@ class UpdateTest extends TestCase
         $payload = (string) $response->getBody();
 
         $this->assertJson($payload);
-        $this->assertEquals(500, $response->getStatusCode());
+        $this->assertSame(500, $response->getStatusCode());
 
         $payloadArray = $this->decodePaylode($payload);
-        $this->assertEquals([
+        $this->assertSame([
             'error' => [
                 'type' => 'SERVER_ERROR',
                 'description' => 'Could not update Stripe Payment Intent [C]',
@@ -1159,10 +1159,10 @@ class UpdateTest extends TestCase
         // intermittently from Stripe + don't really need the update, we should
         // succeed from a donor perspective.
         $this->assertJson($payload);
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
 
         $payloadArray = $this->decodePaylode($payload);
-        $this->assertEquals(3.08, $payloadArray['charityFee']);
+        $this->assertSame(3.08, $payloadArray['charityFee']);
     }
 
     public function testAddDataSuccessWithAllValues(): void
@@ -1223,32 +1223,32 @@ class UpdateTest extends TestCase
         $responseBody = (string) $response->getBody();
 
         $this->assertJson($responseBody);
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
 
         $payload = json_decode($responseBody, true);
         \assert(is_array($payload));
 
         // These two values are unchanged but still returned.
-        $this->assertEquals(123.45, $payload['donationAmount']);
-        $this->assertEquals(DonationStatus::Pending->value, $payload['status']);
+        $this->assertSame(123.45, $payload['donationAmount']);
+        $this->assertSame(DonationStatus::Pending->value, $payload['status']);
 
         // Remaining properties should be updated.
-        $this->assertEquals('US', $payload['countryCode']);
-        $this->assertEquals('USD', $payload['currencyCode']);
+        $this->assertSame('US', $payload['countryCode']);
+        $this->assertSame('USD', $payload['currencyCode']);
         // 1.9% + 20p. cardCountry from Stripe payment method ≠ donor country.
-        $this->assertEquals(3.08, $payload['charityFee']);
-        $this->assertEquals(0, $payload['charityFeeVat']);
-        $this->assertEquals('3.21', $payload['tipAmount']);
+        $this->assertSame(3.08, $payload['charityFee']);
+        $this->assertSame(0, $payload['charityFeeVat']);
+        $this->assertSame(3.21, $payload['tipAmount']);
         $this->assertTrue($payload['giftAid']);
         $this->assertFalse($payload['tipGiftAid']);
-        $this->assertEquals('99 Updated St', $payload['homeAddress']);
-        $this->assertEquals('X1 1XY', $payload['homePostcode']);
-        $this->assertEquals('Saul', $payload['firstName']);
-        $this->assertEquals('Williams', $payload['lastName']);
-        $this->assertEquals('saul@example.com', $payload['emailAddress']);
+        $this->assertSame('99 Updated St', $payload['homeAddress']);
+        $this->assertSame('X1 1XY', $payload['homePostcode']);
+        $this->assertSame('Saul', $payload['firstName']);
+        $this->assertSame('Williams', $payload['lastName']);
+        $this->assertSame('saul@example.com', $payload['emailAddress']);
         $this->assertTrue($payload['optInTbgEmail']);
         $this->assertFalse($payload['optInCharityEmail']);
-        $this->assertEquals('Y1 1YX', $payload['billingPostalAddress']);
+        $this->assertSame('Y1 1YX', $payload['billingPostalAddress']);
     }
 
     public function testAddDataSuccessWithCashBalanceAutoconfirm(): void
@@ -1273,14 +1273,14 @@ class UpdateTest extends TestCase
         $payload = (string) $response->getBody();
 
         $this->assertJson($payload);
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
 
         $payloadArray = $this->decodePaylode($payload);
 
         // These values are unchanged but still returned. Confirming alone doesn't change the
         // response payload.
-        $this->assertEquals(123.45, $payloadArray['donationAmount']);
-        $this->assertEquals(DonationStatus::Pending->value, $payloadArray['status']);
+        $this->assertSame(123.45, $payloadArray['donationAmount']);
+        $this->assertSame(DonationStatus::Pending->value, $payloadArray['status']);
     }
 
     public function testAddDataFailsWithCashBalanceAutoconfirmForDonorWithInsufficentFunds(): void
@@ -1326,16 +1326,16 @@ class UpdateTest extends TestCase
 
         $this->assertJson($payload);
 
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
 
         /**
          * @psalm-var array{donationAmount:float, status:string} $payloadArray
          */
         $payloadArray = $this->decodePaylode($payload);
 
-        $this->assertEquals(123.45, $payloadArray['donationAmount']);
+        $this->assertSame(123.45, $payloadArray['donationAmount']);
         // Bank transfer is still required -> status remains pending.
-        $this->assertEquals(DonationStatus::Pending->value, $payloadArray['status']);
+        $this->assertSame(DonationStatus::Pending->value, $payloadArray['status']);
 
         // Stripe PI must be left pending ready for the bank transfer.
         $stripeProphecy->cancelPaymentIntent('pi_externalId_123')->shouldNotBeCalled();
@@ -1412,7 +1412,7 @@ class UpdateTest extends TestCase
         $payload = (string) $response->getBody();
 
         $this->assertJson($payload);
-        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertSame(400, $response->getStatusCode());
 
         $expectedPayload = new ActionPayload(400, ['error' => [
             'type' => 'BAD_REQUEST',
@@ -1420,7 +1420,7 @@ class UpdateTest extends TestCase
         ]]);
         $expectedSerialised = json_encode($expectedPayload, JSON_PRETTY_PRINT);
 
-        $this->assertEquals($expectedSerialised, $payload);
+        $this->assertSame($expectedSerialised, $payload);
     }
 
     public function testCannotAutoConfirmCardPayment(): void
@@ -1466,7 +1466,7 @@ class UpdateTest extends TestCase
         $payload = (string) $response->getBody();
 
         $this->assertJson($payload);
-        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertSame(400, $response->getStatusCode());
 
         $expectedPayload = new ActionPayload(400, ['error' => [
             'type' => 'BAD_REQUEST',
@@ -1474,7 +1474,7 @@ class UpdateTest extends TestCase
         ]]);
         $expectedSerialised = json_encode($expectedPayload, JSON_PRETTY_PRINT);
 
-        $this->assertEquals($expectedSerialised, $payload);
+        $this->assertSame($expectedSerialised, $payload);
     }
 
     public function testAddDataAutoconfirmHitsUnknownInvalidRequestException(): void

--- a/tests/Application/Actions/GetPaymentMethodsTest.php
+++ b/tests/Application/Actions/GetPaymentMethodsTest.php
@@ -72,7 +72,7 @@ class GetPaymentMethodsTest extends TestCase
         $payload = (string) $response->getBody();
 
         $this->assertJson($payload);
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
 
         /** @var array{
          *     data: list<array{card: array{last4: string}}>,
@@ -82,6 +82,6 @@ class GetPaymentMethodsTest extends TestCase
         $payloadArray = json_decode($payload, true);
         $this->assertCount(1, $payloadArray['data']);
 
-        $this->assertEquals('4242', $payloadArray['data'][0]['card']['last4']);
+        $this->assertSame('4242', $payloadArray['data'][0]['card']['last4']);
     }
 }

--- a/tests/Application/Actions/Hooks/StripePaymentsUpdateTest.php
+++ b/tests/Application/Actions/Hooks/StripePaymentsUpdateTest.php
@@ -79,7 +79,7 @@ class StripePaymentsUpdateTest extends StripeTest
 
         $response = $app->handle($request);
 
-        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertSame(204, $response->getStatusCode());
     }
 
     public function testSuccessWithUnrecognisedTransactionId(): void
@@ -101,7 +101,7 @@ class StripePaymentsUpdateTest extends StripeTest
 
         $response = $app->handle($request);
 
-        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertSame(204, $response->getStatusCode());
     }
 
     public function testMissingSignature(): void
@@ -128,8 +128,8 @@ class StripePaymentsUpdateTest extends StripeTest
 
         $payload = (string) $response->getBody();
 
-        $this->assertEquals($expectedSerialised, $payload);
-        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertSame($expectedSerialised, $payload);
+        $this->assertSame(400, $response->getStatusCode());
     }
 
     public function testSuccessfulPayment(): void
@@ -182,11 +182,11 @@ class StripePaymentsUpdateTest extends StripeTest
 
         $response = $app->handle($request);
 
-        $this->assertEquals('ch_externalId_123', $donation->getChargeId());
-        $this->assertEquals('tr_id_t987', $donation->getTransferId());
-        $this->assertEquals(DonationStatus::Collected, $donation->getDonationStatus());
-        $this->assertEquals('0.37', $donation->getOriginalPspFee());
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame('ch_externalId_123', $donation->getChargeId());
+        $this->assertSame('tr_id_t987', $donation->getTransferId());
+        $this->assertSame(DonationStatus::Collected, $donation->getDonationStatus());
+        $this->assertSame('0.37', $donation->getOriginalPspFee());
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     public function testOriginalStripeFeeInSEK(): void
@@ -233,11 +233,11 @@ class StripePaymentsUpdateTest extends StripeTest
 
         $response = $app->handle($request);
 
-        $this->assertEquals('ch_externalId_123', $donation->getChargeId());
-        $this->assertEquals('tr_id_t988', $donation->getTransferId());
-        $this->assertEquals(DonationStatus::Collected, $donation->getDonationStatus());
-        $this->assertEquals('18.72', $donation->getOriginalPspFee());
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame('ch_externalId_123', $donation->getChargeId());
+        $this->assertSame('tr_id_t988', $donation->getTransferId());
+        $this->assertSame(DonationStatus::Collected, $donation->getDonationStatus());
+        $this->assertSame('18.72', $donation->getOriginalPspFee());
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     public function testDisputeLostBehavesLikeRefund(): void
@@ -268,10 +268,10 @@ class StripePaymentsUpdateTest extends StripeTest
 
         $response = $app->handle($request);
 
-        $this->assertEquals('ch_externalId_123', $donation->getChargeId());
-        $this->assertEquals(DonationStatus::Refunded, $donation->getDonationStatus());
-        $this->assertEquals('1.00', $donation->getTipAmount());
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame('ch_externalId_123', $donation->getChargeId());
+        $this->assertSame(DonationStatus::Refunded, $donation->getDonationStatus());
+        $this->assertSame('1.00', $donation->getTipAmount());
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     public function testDisputeWonMakesNoSubstantiveChanges(): void
@@ -305,10 +305,10 @@ class StripePaymentsUpdateTest extends StripeTest
 
         // No change to any donation data. Return 204 for no change. Will log
         // info to help in case of any confusion.
-        $this->assertEquals('ch_externalId_123', $donation->getChargeId());
-        $this->assertEquals(DonationStatus::Collected, $donation->getDonationStatus());
-        $this->assertEquals('1.00', $donation->getTipAmount());
-        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertSame('ch_externalId_123', $donation->getChargeId());
+        $this->assertSame(DonationStatus::Collected, $donation->getDonationStatus());
+        $this->assertSame('1.00', $donation->getTipAmount());
+        $this->assertSame(204, $response->getStatusCode());
     }
 
     public function testDisputeLostWithUnrecognisedTransactionId(): void
@@ -330,7 +330,7 @@ class StripePaymentsUpdateTest extends StripeTest
 
         $response = $app->handle($request);
 
-        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertSame(204, $response->getStatusCode());
     }
 
     public function testDisputeLostWithAmountUnexpectedlyHighIsStillProcessedButAlertsSlack(): void
@@ -380,10 +380,10 @@ class StripePaymentsUpdateTest extends StripeTest
         $response = $app->handle($request);
 
         // assert
-        $this->assertEquals('ch_externalId_123', $donation->getChargeId());
-        $this->assertEquals(DonationStatus::Refunded, $donation->getDonationStatus());
-        $this->assertEquals('1.00', $donation->getTipAmount());
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame('ch_externalId_123', $donation->getChargeId());
+        $this->assertSame(DonationStatus::Refunded, $donation->getDonationStatus());
+        $this->assertSame('1.00', $donation->getTipAmount());
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     public function testDisputeLostWithAmountTooLowIsSkipped(): void
@@ -410,10 +410,10 @@ class StripePaymentsUpdateTest extends StripeTest
 
         // No change to any donation data. Return 204 for no change. Will also log
         // an error so we can investigate.
-        $this->assertEquals('ch_externalId_123', $donation->getChargeId());
-        $this->assertEquals(DonationStatus::Collected, $donation->getDonationStatus());
-        $this->assertEquals('1.00', $donation->getTipAmount());
-        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertSame('ch_externalId_123', $donation->getChargeId());
+        $this->assertSame(DonationStatus::Collected, $donation->getDonationStatus());
+        $this->assertSame('1.00', $donation->getTipAmount());
+        $this->assertSame(204, $response->getStatusCode());
     }
 
     public function testSuccessfulFullRefund(): void
@@ -454,10 +454,10 @@ class StripePaymentsUpdateTest extends StripeTest
         $response = $app->handle($request);
 
         // assert
-        $this->assertEquals('ch_externalId_123', $donation->getChargeId());
-        $this->assertEquals(DonationStatus::Refunded, $donation->getDonationStatus());
-        $this->assertEquals('1.00', $donation->getTipAmount());
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame('ch_externalId_123', $donation->getChargeId());
+        $this->assertSame(DonationStatus::Refunded, $donation->getDonationStatus());
+        $this->assertSame('1.00', $donation->getTipAmount());
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     /**
@@ -515,10 +515,10 @@ class StripePaymentsUpdateTest extends StripeTest
         // We expect a Slack notice about the unusual over-refund.
         $chatterProphecy->send($expectedMessage)->shouldBeCalledOnce();
 
-        $this->assertEquals('ch_externalId_123', $donation->getChargeId());
-        $this->assertEquals(DonationStatus::Refunded, $donation->getDonationStatus());
-        $this->assertEquals('1.00', $donation->getTipAmount());
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame('ch_externalId_123', $donation->getChargeId());
+        $this->assertSame(DonationStatus::Refunded, $donation->getDonationStatus());
+        $this->assertSame('1.00', $donation->getTipAmount());
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     public function testSuccessfulTipRefund(): void
@@ -548,10 +548,10 @@ class StripePaymentsUpdateTest extends StripeTest
 
         $response = $app->handle($request);
 
-        $this->assertEquals('ch_externalId_123', $donation->getChargeId());
-        $this->assertEquals(DonationStatus::Collected, $donation->getDonationStatus());
-        $this->assertEquals('0.00', $donation->getTipAmount());
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame('ch_externalId_123', $donation->getChargeId());
+        $this->assertSame(DonationStatus::Collected, $donation->getDonationStatus());
+        $this->assertSame('0.00', $donation->getTipAmount());
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     public function testUnsupportedOriginalChargeStatusIsSkipped(): void
@@ -584,8 +584,8 @@ class StripePaymentsUpdateTest extends StripeTest
 
         $payload = (string) $response->getBody();
 
-        $this->assertEquals($expectedSerialised, $payload);
-        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertSame($expectedSerialised, $payload);
+        $this->assertSame(400, $response->getStatusCode());
     }
 
     public function testUnsupportedRefundAmount(): void
@@ -612,10 +612,10 @@ class StripePaymentsUpdateTest extends StripeTest
 
         // No change to any donation data. Return 204 for no change. Will also log
         // an error so we can investigate.
-        $this->assertEquals('ch_externalId_123', $donation->getChargeId());
-        $this->assertEquals(DonationStatus::Collected, $donation->getDonationStatus());
-        $this->assertEquals('1.00', $donation->getTipAmount());
-        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertSame('ch_externalId_123', $donation->getChargeId());
+        $this->assertSame(DonationStatus::Collected, $donation->getDonationStatus());
+        $this->assertSame('1.00', $donation->getTipAmount());
+        $this->assertSame(204, $response->getStatusCode());
     }
 
     private function getValidWebhookSecret(Container $container): string

--- a/tests/Application/Actions/Hooks/StripePaymentsUpdateTest.php
+++ b/tests/Application/Actions/Hooks/StripePaymentsUpdateTest.php
@@ -141,7 +141,7 @@ class StripePaymentsUpdateTest extends StripeTest
         $donation = $this->getTestDonation();
         $donation->setTransactionId('pi_externalId_123');
 
-        /** @var array $webhookContent */
+        /** @var array<string, mixed> $webhookContent */
         $webhookContent = json_decode(
             $this->getStripeHookMock('ch_succeeded'),
             associative: true,
@@ -197,7 +197,7 @@ class StripePaymentsUpdateTest extends StripeTest
 
         $donation = $this->getTestDonation('6000.00', currencyCode: 'SEK');
         $this->donationRepository->store($donation);
-        /** @var array $webhookContent */
+        /** @var array<string, mixed> $webhookContent */
         $webhookContent = json_decode(
             $this->getStripeHookMock('ch_succeeded_sek'),
             associative: true,

--- a/tests/Application/Actions/Hooks/StripePaymentsUpdateTest.php
+++ b/tests/Application/Actions/Hooks/StripePaymentsUpdateTest.php
@@ -150,7 +150,6 @@ class StripePaymentsUpdateTest extends StripeTest
 
         /**
          * @psalm-suppress MixedArrayAssignment
-         * @psalm-suppress MixedArrayAccess
          */
         $webhookContent['data']['object']['amount'] = $donation->getAmountFractionalIncTip();
         $body = json_encode($webhookContent, \JSON_THROW_ON_ERROR);
@@ -206,7 +205,6 @@ class StripePaymentsUpdateTest extends StripeTest
 
         /**
          * @psalm-suppress MixedArrayAssignment
-         * @psalm-suppress MixedArrayAccess
          */
         $webhookContent['data']['object']['amount'] = $donation->getAmountFractionalIncTip();
 

--- a/tests/Application/Actions/Hooks/StripePayoutUpdateTest.php
+++ b/tests/Application/Actions/Hooks/StripePayoutUpdateTest.php
@@ -38,7 +38,7 @@ class StripePayoutUpdateTest extends StripeTest
 
         $response = $app->handle($request);
 
-        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertSame(204, $response->getStatusCode());
     }
 
     public function testMissingSignature(): void
@@ -68,8 +68,8 @@ class StripePayoutUpdateTest extends StripeTest
 
         $payload = (string) $response->getBody();
 
-        $this->assertEquals($expectedSerialised, $payload);
-        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertSame($expectedSerialised, $payload);
+        $this->assertSame(400, $response->getStatusCode());
     }
 
     public function testPayoutPaidQueueDispatchError(): void
@@ -96,7 +96,7 @@ class StripePayoutUpdateTest extends StripeTest
 
         $response = $app->handle($request);
 
-        $this->assertEquals(500, $response->getStatusCode());
+        $this->assertSame(500, $response->getStatusCode());
     }
 
     public function testPayoutPaidProcessingQueued(): void
@@ -120,7 +120,7 @@ class StripePayoutUpdateTest extends StripeTest
 
         $response = $app->handle($request);
 
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertCount(1, $transport->getSent());
     }
 
@@ -153,7 +153,7 @@ class StripePayoutUpdateTest extends StripeTest
             ->shouldBeCalledOnce();
         $response = $app->handle($request);
 
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertCount(0, $transport->getSent());
     }
 }

--- a/tests/Application/Actions/RegularGivingMandate/CancelAsAdminTest.php
+++ b/tests/Application/Actions/RegularGivingMandate/CancelAsAdminTest.php
@@ -19,6 +19,7 @@ use MatchBot\Domain\RegularGivingMandate;
 use MatchBot\Domain\RegularGivingMandateRepository;
 use MatchBot\Domain\Salesforce18Id;
 use MatchBot\Tests\TestCase;
+use Psr\Container\ContainerInterface;
 use Ramsey\Uuid\Uuid;
 use Slim\App;
 use Slim\CallableResolver;
@@ -38,7 +39,7 @@ class CancelAsAdminTest extends TestCase
             ->withHeader('x-send-verify-hash', $this->getSalesforceAuthValue(''));
 
         $app = $this->getAppInstance();
-        $this->mockRepositories($app, $mandate);
+        $this->mockRepositories($app, $mandate); // @phpstan-ignore argument.type
 
         $response = $app->handle($request->withAttribute('route', $route));
 
@@ -60,7 +61,7 @@ class CancelAsAdminTest extends TestCase
             ->withHeader('x-send-verify-hash', $this->getSalesforceAuthValue(''));
 
         $app = $this->getAppInstance();
-        $this->mockRepositories($app, $mandate);
+        $this->mockRepositories($app, $mandate); // @phpstan-ignore argument.type
 
         $response = $app->handle($request->withAttribute('route', $route));
 
@@ -103,6 +104,7 @@ class CancelAsAdminTest extends TestCase
         return hash_hmac('sha256', $body, $salesforceSecretKey);
     }
 
+    /** @return Route<null> */
     private function getRouteWithMandateId(string $mandateUuidString): Route
     {
         $route = new Route(
@@ -137,6 +139,7 @@ class CancelAsAdminTest extends TestCase
         return $prophecy->reveal();
     }
 
+    /** @param App<ContainerInterface|null> $app */
     private function mockRepositories(App $app, RegularGivingMandate $mandate): void
     {
         $container = $app->getContainer();

--- a/tests/Application/Actions/RegularGivingMandate/CancelAsAdminTest.php
+++ b/tests/Application/Actions/RegularGivingMandate/CancelAsAdminTest.php
@@ -43,7 +43,7 @@ class CancelAsAdminTest extends TestCase
 
         $response = $app->handle($request->withAttribute('route', $route));
 
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     public function testAlreadyCancelled(): void
@@ -65,7 +65,7 @@ class CancelAsAdminTest extends TestCase
 
         $response = $app->handle($request->withAttribute('route', $route));
 
-        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertSame(400, $response->getStatusCode());
 
         $payload = (string) $response->getBody();
         $expectedPayload = new ActionPayload(400, ['error' => [
@@ -74,7 +74,7 @@ class CancelAsAdminTest extends TestCase
         ]]);
         $expectedSerialised = json_encode($expectedPayload, JSON_PRETTY_PRINT);
 
-        $this->assertEquals($expectedSerialised, $payload);
+        $this->assertSame($expectedSerialised, $payload);
     }
 
     private function getTestMandate(): RegularGivingMandate

--- a/tests/Application/Actions/StatusTest.php
+++ b/tests/Application/Actions/StatusTest.php
@@ -52,8 +52,8 @@ class StatusTest extends TestCase
         $expectedPayload = new ActionPayload(200, ['status' => 'OK']);
         $expectedSerialised = json_encode($expectedPayload, JSON_PRETTY_PRINT);
 
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals($expectedSerialised, $payload);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame($expectedSerialised, $payload);
     }
 
     public function testRedisErrorWithDummyHostname(): void
@@ -72,8 +72,8 @@ class StatusTest extends TestCase
         $expectedPayload = new ActionPayload(500, ['error' => 'Redis not connected']);
         $expectedSerialised = json_encode($expectedPayload, JSON_PRETTY_PRINT);
 
-        $this->assertEquals(500, $response->getStatusCode());
-        $this->assertEquals($expectedSerialised, $payload);
+        $this->assertSame(500, $response->getStatusCode());
+        $this->assertSame($expectedSerialised, $payload);
     }
 
     public function testMissingDoctrineORMProxy(): void
@@ -93,8 +93,8 @@ class StatusTest extends TestCase
         $expectedPayload = new ActionPayload(500, ['error' => 'Doctrine proxies not built']);
         $expectedSerialised = json_encode($expectedPayload, JSON_PRETTY_PRINT);
 
-        $this->assertEquals(500, $response->getStatusCode());
-        $this->assertEquals($expectedSerialised, $payload);
+        $this->assertSame(500, $response->getStatusCode());
+        $this->assertSame($expectedSerialised, $payload);
     }
 
     private function getConnectedMockEntityManager(

--- a/tests/Application/Actions/UpdatePaymentMethodTest.php
+++ b/tests/Application/Actions/UpdatePaymentMethodTest.php
@@ -16,6 +16,7 @@ use Stripe\Collection;
 use Stripe\Service\CustomerService;
 use Stripe\Service\PaymentMethodService;
 use Stripe\StripeClient;
+use Stripe\StripeObject;
 
 /**
  * A lot of this is copied from the DeletePaymentMethodTest - consider refactoring before making a third copy.
@@ -86,6 +87,10 @@ use Stripe\StripeClient;
         $sut->__invoke($request, new Response(), ['payment_method_id' => 'stripe_payment_method_id_35']);
     }
 
+    /**
+     * @param list<array{id: string}> $paymentMethods
+     * @return Stub&Collection<StripeObject>
+     */
     public function stubCollectionOf(array $paymentMethods): Stub&Collection
     {
         $stubCollection = $this->createStub(Collection::class);
@@ -97,6 +102,9 @@ use Stripe\StripeClient;
     /**
      * @psalm-suppress UndefinedPropertyAssignment
      * Not sure why Psalm isn't reading the `@property` annotation on the StripeClient class
+     *
+     * @param ObjectProphecy<CustomerService> $stripeCustomerServiceProphecy
+     * @param ObjectProphecy<PaymentMethodService> $stripePaymentMethodServiceProphecy
      */
     public function fakeStripeClient(
         ObjectProphecy $stripePaymentMethodServiceProphecy,

--- a/tests/Application/Auth/PersonManagementAuthMiddlewareTest.php
+++ b/tests/Application/Auth/PersonManagementAuthMiddlewareTest.php
@@ -72,6 +72,7 @@ class PersonManagementAuthMiddlewareTest extends TestCase
 
     /**
      * Simulate a route returning a 200 OK.
+     * @return Route<null>
      */
     private function getSuccessHandler(): Route
     {

--- a/tests/Application/Auth/PersonWithPasswordAuthMiddlewareTest.php
+++ b/tests/Application/Auth/PersonWithPasswordAuthMiddlewareTest.php
@@ -80,6 +80,7 @@ class PersonWithPasswordAuthMiddlewareTest extends TestCase
 
     /**
      * Simulate a route returning a 200 OK.
+     * @return Route<null>
      */
     private function getSuccessHandler(): Route
     {

--- a/tests/Application/Auth/SalesforceAuthMiddlewareTest.php
+++ b/tests/Application/Auth/SalesforceAuthMiddlewareTest.php
@@ -6,6 +6,7 @@ namespace MatchBot\Tests\Application\Auth;
 
 use MatchBot\Application\Auth\SalesforceAuthMiddleware;
 use MatchBot\Tests\TestCase;
+use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\NullLogger;
 use Slim\CallableResolver;
@@ -63,6 +64,8 @@ class SalesforceAuthMiddlewareTest extends TestCase
     /**
      * Simulate a route returning a 200 OK. Test methods should get here only when they expect auth
      * success from the middleware.
+     *
+     * @return Route<null>
      */
     private function getSuccessHandler(): Route
     {

--- a/tests/Application/Auth/SalesforceAuthMiddlewareTest.php
+++ b/tests/Application/Auth/SalesforceAuthMiddlewareTest.php
@@ -28,7 +28,7 @@ class SalesforceAuthMiddlewareTest extends TestCase
 
         $response = $this->getInstance()->process($request, $this->getSuccessHandler());
 
-        $this->assertEquals(401, $response->getStatusCode());
+        $this->assertSame(401, $response->getStatusCode());
     }
 
     public function testWrongAuthRejected(): void
@@ -39,7 +39,7 @@ class SalesforceAuthMiddlewareTest extends TestCase
 
         $response = $this->getInstance()->process($request, $this->getSuccessHandler());
 
-        $this->assertEquals(401, $response->getStatusCode());
+        $this->assertSame(401, $response->getStatusCode());
     }
 
     public function testCorrectAuthAccepted(): void
@@ -50,7 +50,7 @@ class SalesforceAuthMiddlewareTest extends TestCase
         $request = $this->buildRequest($body, $hash);
         $response = $this->getInstance()->process($request, $this->getSuccessHandler());
 
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     private function buildRequest(string $body, ?string $hash = null): ServerRequestInterface

--- a/tests/Application/Commands/ClaimGiftAidTest.php
+++ b/tests/Application/Commands/ClaimGiftAidTest.php
@@ -55,8 +55,8 @@ class ClaimGiftAidTest extends TestCase
             'Submitted 0 donations to the ClaimBot queue',
             'matchbot:claim-gift-aid complete!',
         ];
-        $this->assertEquals(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
-        $this->assertEquals(0, $commandTester->getStatusCode());
+        $this->assertSame(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
+        $this->assertSame(0, $commandTester->getStatusCode());
     }
 
     public function testSend(): void
@@ -91,8 +91,8 @@ class ClaimGiftAidTest extends TestCase
             'Submitted 1 donations to the ClaimBot queue',
             'matchbot:claim-gift-aid complete!',
         ];
-        $this->assertEquals(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
-        $this->assertEquals(0, $commandTester->getStatusCode());
+        $this->assertSame(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
+        $this->assertSame(0, $commandTester->getStatusCode());
     }
 
     public function testSendWithResends(): void
@@ -129,8 +129,8 @@ class ClaimGiftAidTest extends TestCase
             'Submitted 1 donations to the ClaimBot queue',
             'matchbot:claim-gift-aid complete!',
         ];
-        $this->assertEquals(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
-        $this->assertEquals(0, $commandTester->getStatusCode());
+        $this->assertSame(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
+        $this->assertSame(0, $commandTester->getStatusCode());
     }
 
     /**

--- a/tests/Application/Commands/ExpireMatchFundsTest.php
+++ b/tests/Application/Commands/ExpireMatchFundsTest.php
@@ -37,8 +37,8 @@ class ExpireMatchFundsTest extends TestCase
             "Released 0 donations' matching",
             'matchbot:expire-match-funds complete!',
         ];
-        $this->assertEquals(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
-        $this->assertEquals(0, $commandTester->getStatusCode());
+        $this->assertSame(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
+        $this->assertSame(0, $commandTester->getStatusCode());
     }
 
     public function testTwoExpiries(): void
@@ -61,8 +61,8 @@ class ExpireMatchFundsTest extends TestCase
             "Released 2 donations' matching",
             'matchbot:expire-match-funds complete!',
         ];
-        $this->assertEquals(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
-        $this->assertEquals(0, $commandTester->getStatusCode());
+        $this->assertSame(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
+        $this->assertSame(0, $commandTester->getStatusCode());
     }
 
     /**

--- a/tests/Application/Commands/HandleOutOfSyncFundsTest.php
+++ b/tests/Application/Commands/HandleOutOfSyncFundsTest.php
@@ -52,8 +52,8 @@ class HandleOutOfSyncFundsTest extends TestCase
             'Checked 4 fundings. Found 1 with correct allocations, 1 over-matched and 2 under-matched',
             'matchbot:handle-out-of-sync-funds complete!',
         ];
-        $this->assertEquals(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
-        $this->assertEquals(0, $commandTester->getStatusCode());
+        $this->assertSame(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
+        $this->assertSame(0, $commandTester->getStatusCode());
     }
 
     public function testFix(): void
@@ -77,8 +77,8 @@ class HandleOutOfSyncFundsTest extends TestCase
             'Checked 4 fundings. Found 1 with correct allocations, 1 over-matched and 2 under-matched',
             'matchbot:handle-out-of-sync-funds complete!',
         ];
-        $this->assertEquals(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
-        $this->assertEquals(0, $commandTester->getStatusCode());
+        $this->assertSame(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
+        $this->assertSame(0, $commandTester->getStatusCode());
     }
 
     public function testWithModeMissing(): void
@@ -106,8 +106,8 @@ class HandleOutOfSyncFundsTest extends TestCase
             'Please set the mode to "check" or "fix"',
             'matchbot:handle-out-of-sync-funds complete!',
         ];
-        $this->assertEquals(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
-        $this->assertEquals(1, $commandTester->getStatusCode());
+        $this->assertSame(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
+        $this->assertSame(1, $commandTester->getStatusCode());
     }
 
     /**

--- a/tests/Application/Commands/PushDonationsTest.php
+++ b/tests/Application/Commands/PushDonationsTest.php
@@ -38,8 +38,8 @@ class PushDonationsTest extends TestCase
             'Pushed 1 donations to Salesforce',
             'matchbot:push-donations complete!',
         ];
-        $this->assertEquals(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
-        $this->assertEquals(0, $commandTester->getStatusCode());
+        $this->assertSame(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
+        $this->assertSame(0, $commandTester->getStatusCode());
     }
 
     public function testPushWithOneCancelledAbandonedDonation(): void
@@ -63,8 +63,8 @@ class PushDonationsTest extends TestCase
             'Pushed 1 donations to Salesforce',
             'matchbot:push-donations complete!',
         ];
-        $this->assertEquals(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
-        $this->assertEquals(0, $commandTester->getStatusCode());
+        $this->assertSame(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
+        $this->assertSame(0, $commandTester->getStatusCode());
     }
 
     /**

--- a/tests/Application/Commands/RedistributeMatchFundsTest.php
+++ b/tests/Application/Commands/RedistributeMatchFundsTest.php
@@ -76,8 +76,8 @@ class RedistributeMatchFundsTest extends TestCase
             'Checked 0 donations and redistributed matching for 0',
             'matchbot:redistribute-match-funds complete!',
         ];
-        $this->assertEquals(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
-        $this->assertEquals(0, $commandTester->getStatusCode());
+        $this->assertSame(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
+        $this->assertSame(0, $commandTester->getStatusCode());
     }
 
     /**
@@ -152,8 +152,8 @@ class RedistributeMatchFundsTest extends TestCase
             $shouldRedistribute ? 'Checked 1 donations and redistributed matching for 1' : 'Checked 1 donations and redistributed matching for 0',
             'matchbot:redistribute-match-funds complete!',
         ];
-        $this->assertEquals(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
-        $this->assertEquals(0, $commandTester->getStatusCode());
+        $this->assertSame(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
+        $this->assertSame(0, $commandTester->getStatusCode());
     }
 
     /**
@@ -212,8 +212,8 @@ class RedistributeMatchFundsTest extends TestCase
             'Checked 1 donations and redistributed matching for 1',
             'matchbot:redistribute-match-funds complete!',
         ];
-        $this->assertEquals(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
-        $this->assertEquals(0, $commandTester->getStatusCode());
+        $this->assertSame(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
+        $this->assertSame(0, $commandTester->getStatusCode());
     }
 
     private function getFullyAvailableFunding(FundType $fundType): CampaignFunding

--- a/tests/Application/Commands/ResetMatchingTest.php
+++ b/tests/Application/Commands/ResetMatchingTest.php
@@ -24,7 +24,7 @@ class ResetMatchingTest extends TestCase
 {
     public function testSinglePush(): void
     {
-        $fund = new Fund('GBP', name: 'Test Champion Fund 123', salesforceId: Salesforce18Id::of('sfFundId1234567890'), fundType: FundType::ChampionFund);
+        $fund = new Fund('GBP', name: 'Test Champion Fund 123', salesforceId: Salesforce18Id::ofFund('sfFundId1234567890'), fundType: FundType::ChampionFund);
         $fund->setSalesforceLastPull(new \DateTime());
 
         $campaignFunding = new CampaignFunding(

--- a/tests/Application/Commands/ResetMatchingTest.php
+++ b/tests/Application/Commands/ResetMatchingTest.php
@@ -53,8 +53,8 @@ class ResetMatchingTest extends TestCase
             'Completed matching reset for 1 fundings.',
             'matchbot:reset-matching complete!',
         ];
-        $this->assertEquals(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
-        $this->assertEquals(0, $commandTester->getStatusCode());
+        $this->assertSame(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
+        $this->assertSame(0, $commandTester->getStatusCode());
     }
 
     public function testBlankDb(): void
@@ -96,7 +96,7 @@ class ResetMatchingTest extends TestCase
             'Skipping matching reset as database is empty.',
             'matchbot:reset-matching complete!',
         ];
-        $this->assertEquals(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
-        $this->assertEquals(0, $commandTester->getStatusCode());
+        $this->assertSame(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
+        $this->assertSame(0, $commandTester->getStatusCode());
     }
 }

--- a/tests/Application/Commands/RetrospectivelyMatchTest.php
+++ b/tests/Application/Commands/RetrospectivelyMatchTest.php
@@ -64,8 +64,8 @@ class RetrospectivelyMatchTest extends TestCase
             'Pushed fund totals to Salesforce for 0 funds: ',
             'matchbot:retrospectively-match complete!',
         ];
-        $this->assertEquals(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
-        $this->assertEquals(0, $commandTester->getStatusCode());
+        $this->assertSame(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
+        $this->assertSame(0, $commandTester->getStatusCode());
     }
 
     public function testNonWholeDaysBackIsRounded(): void
@@ -82,8 +82,8 @@ class RetrospectivelyMatchTest extends TestCase
             'Pushed fund totals to Salesforce for 0 funds: ',
             'matchbot:retrospectively-match complete!',
         ];
-        $this->assertEquals(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
-        $this->assertEquals(0, $commandTester->getStatusCode());
+        $this->assertSame(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
+        $this->assertSame(0, $commandTester->getStatusCode());
     }
 
     public function testWholeDaysBackProceeds(): void
@@ -100,8 +100,8 @@ class RetrospectivelyMatchTest extends TestCase
             'Pushed fund totals to Salesforce for 0 funds: ',
             'matchbot:retrospectively-match complete!',
         ];
-        $this->assertEquals(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
-        $this->assertEquals(0, $commandTester->getStatusCode());
+        $this->assertSame(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
+        $this->assertSame(0, $commandTester->getStatusCode());
     }
 
     private function getAllocator(bool $matchingIsAllocated): Allocator

--- a/tests/Application/Commands/SendStatisticsTest.php
+++ b/tests/Application/Commands/SendStatisticsTest.php
@@ -69,8 +69,8 @@ class SendStatisticsTest extends TestCase
             'Sent 2 metrics to CloudWatch',
             'matchbot:send-statistics complete!',
         ];
-        $this->assertEquals(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
-        $this->assertEquals(0, $commandTester->getStatusCode());
+        $this->assertSame(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
+        $this->assertSame(0, $commandTester->getStatusCode());
     }
 
     public function testBusyStatsPushThreeFigures(): void
@@ -121,7 +121,7 @@ class SendStatisticsTest extends TestCase
             'Sent 3 metrics to CloudWatch',
             'matchbot:send-statistics complete!',
         ];
-        $this->assertEquals(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
-        $this->assertEquals(0, $commandTester->getStatusCode());
+        $this->assertSame(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
+        $this->assertSame(0, $commandTester->getStatusCode());
     }
 }

--- a/tests/Application/Commands/UpdateCampaignsTest.php
+++ b/tests/Application/Commands/UpdateCampaignsTest.php
@@ -51,8 +51,8 @@ class UpdateCampaignsTest extends TestCase
             'Updated campaign someCampaignIdxxxx',
             'matchbot:update-campaigns complete!',
         ];
-        $this->assertEquals(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
-        $this->assertEquals(0, $commandTester->getStatusCode());
+        $this->assertSame(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
+        $this->assertSame(0, $commandTester->getStatusCode());
     }
 
     public function testSingleUpdateNotFoundOnSalesforceOutsideProduction(): void
@@ -88,8 +88,8 @@ class UpdateCampaignsTest extends TestCase
             'Skipping unknown sandbox campaign missingOnSfIDxxxxx',
             'matchbot:update-campaigns complete!',
         ];
-        $this->assertEquals(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
-        $this->assertEquals(0, $commandTester->getStatusCode());
+        $this->assertSame(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
+        $this->assertSame(0, $commandTester->getStatusCode());
     }
 
     public function testSingleUpdateHitsTransferExceptionTwice(): void
@@ -132,8 +132,8 @@ class UpdateCampaignsTest extends TestCase
             'Skipping campaign someCampaignIdxxxx due to 2nd transfer error "dummy exc message"',
             'matchbot:update-campaigns complete!',
         ];
-        $this->assertEquals(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
-        $this->assertEquals(0, $commandTester->getStatusCode());
+        $this->assertSame(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
+        $this->assertSame(0, $commandTester->getStatusCode());
     }
 
     /**
@@ -190,11 +190,11 @@ class UpdateCampaignsTest extends TestCase
             'Updated campaign someCampaignIdxxxx',
             'matchbot:update-campaigns complete!',
         ];
-        $this->assertEquals(
+        $this->assertSame(
             implode("\n", $expectedOutputLines) . "\n",
             $commandTester->getDisplay()
         );
-        $this->assertEquals(0, $commandTester->getStatusCode());
+        $this->assertSame(0, $commandTester->getStatusCode());
     }
 
     public function testSingleUpdateSuccessWithAllOption(): void
@@ -228,7 +228,7 @@ class UpdateCampaignsTest extends TestCase
             'Updated campaign someCampaignIdxxxx',
             'matchbot:update-campaigns complete!',
         ];
-        $this->assertEquals(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
-        $this->assertEquals(0, $commandTester->getStatusCode());
+        $this->assertSame(implode("\n", $expectedOutputLines) . "\n", $commandTester->getDisplay());
+        $this->assertSame(0, $commandTester->getStatusCode());
     }
 }

--- a/tests/Application/DonationTestDataTrait.php
+++ b/tests/Application/DonationTestDataTrait.php
@@ -87,7 +87,6 @@ trait DonationTestDataTrait
         // next action, we don't cancel the pending donation.
         $campaign->setName('Big Give General Donations');
 
-        /** @psalm-suppress DeprecatedMethod **/
         $donation = TestCase::someDonation(
             amount: $amount,
             paymentMethodType: $pspMethodType,

--- a/tests/Application/Fees/CalculatorTest.php
+++ b/tests/Application/Fees/CalculatorTest.php
@@ -23,8 +23,8 @@ class CalculatorTest extends TestCase
         );
 
         // 1.5% + 20p
-        $this->assertEquals('2.05', $fees->coreFee);
-        $this->assertEquals('0.41', $fees->feeVat);
+        $this->assertSame('2.05', $fees->coreFee);
+        $this->assertSame('0.41', $fees->feeVat);
     }
 
     public function testStripeUSCardGBPDonation(): void
@@ -39,7 +39,7 @@ class CalculatorTest extends TestCase
         );
 
         // 3.2% + 20p
-        $this->assertEquals('4.14', $fees->coreFee);
+        $this->assertSame('4.14', $fees->coreFee);
     }
 
     public function testStripeUSCardGBPDonationWithTbgClaimingGiftAid(): void
@@ -54,7 +54,7 @@ class CalculatorTest extends TestCase
         );
 
         // 3.2% + 20p + 0.75% (net)
-        $this->assertEquals('4.15', $fees->coreFee);
+        $this->assertSame('4.15', $fees->coreFee);
     }
 
     public function testStripeUKCardSEKDonation(): void
@@ -69,7 +69,7 @@ class CalculatorTest extends TestCase
         );
 
         // 1.5% + 1.80 SEK
-        $this->assertEquals('3.65', $fees->coreFee);
+        $this->assertSame('3.65', $fees->coreFee);
     }
 
     public function testStripeUSCardSEKDonation(): void
@@ -84,7 +84,7 @@ class CalculatorTest extends TestCase
         );
 
         // 3.2% + 1.80 SEK
-        $this->assertEquals('5.74', $fees->coreFee);
+        $this->assertSame('5.74', $fees->coreFee);
     }
 
     /**
@@ -101,8 +101,8 @@ class CalculatorTest extends TestCase
             false,
         );
 
-        $this->assertEquals('3.50', $fees->coreFee);
-        $this->assertEquals('0.00', $fees->feeVat);
+        $this->assertSame('3.50', $fees->coreFee);
+        $this->assertSame('0.00', $fees->feeVat);
     }
 
     /**

--- a/tests/Application/Fees/WebsiteExamplesCalculatorTest.php
+++ b/tests/Application/Fees/WebsiteExamplesCalculatorTest.php
@@ -83,7 +83,7 @@ class WebsiteExamplesCalculatorTest extends TestCase
      *
      * @return array<string, array<array>>
      */
-    public function getFeeWorkedExamples(): array
+    public function getFeeWorkedExamples(): array // @phpstan-ignore missingType.iterableValue
     {
         return array_map(fn(array $args) => [$args], self::WORKED_EXAMPLES);
     }
@@ -97,7 +97,7 @@ class WebsiteExamplesCalculatorTest extends TestCase
      * @psalm-suppress ArgumentTypeCoercion
      * @psalm-suppress PossiblyInvalidArgument
      */
-    public function testItCalculatesFeesAsShownOnWebsite(array $args): void
+    public function testItCalculatesFeesAsShownOnWebsite(array $args): void // @phpstan-ignore missingType.iterableValue
     {
         extract($args);
 

--- a/tests/Application/Fees/WebsiteExamplesCalculatorTest.php
+++ b/tests/Application/Fees/WebsiteExamplesCalculatorTest.php
@@ -77,10 +77,6 @@ class WebsiteExamplesCalculatorTest extends TestCase
     ];
 
     /**
-     * @psalm-suppress MixedReturnStatement
-     * @psalm-suppress MoreSpecificReturnType
-     * @psalm-suppress LessSpecificReturnStatement
-     *
      * @return array<string, array<array>>
      */
     public function getFeeWorkedExamples(): array // @phpstan-ignore missingType.iterableValue
@@ -95,7 +91,6 @@ class WebsiteExamplesCalculatorTest extends TestCase
      * @psalm-suppress MixedArgument
      * @psalm-suppress MixedAssignment
      * @psalm-suppress ArgumentTypeCoercion
-     * @psalm-suppress PossiblyInvalidArgument
      */
     public function testItCalculatesFeesAsShownOnWebsite(array $args): void // @phpstan-ignore missingType.iterableValue
     {

--- a/tests/Application/Matching/ArrayMatchingStorage.php
+++ b/tests/Application/Matching/ArrayMatchingStorage.php
@@ -9,6 +9,7 @@ class ArrayMatchingStorage implements RealTimeMatchingStorage
     /** @var array<string,string> */
     private array $storage;
 
+    /** @var list<string|true> */
     private array $responses = [];
 
     private bool $multiMode = false;

--- a/tests/Application/Messenger/Handler/CharityUpdatedHandlerTest.php
+++ b/tests/Application/Messenger/Handler/CharityUpdatedHandlerTest.php
@@ -8,6 +8,7 @@ use MatchBot\Application\Environment;
 use MatchBot\Application\Messenger\CharityUpdated;
 use MatchBot\Application\Messenger\Handler\CharityUpdatedHandler;
 use MatchBot\Domain\CampaignRepository;
+use MatchBot\Domain\Charity;
 use MatchBot\Domain\Salesforce18Id;
 use MatchBot\Tests\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -17,6 +18,7 @@ class CharityUpdatedHandlerTest extends TestCase
 {
     use ProphecyTrait;
 
+    /** @var Salesforce18Id<Charity> */
     private Salesforce18Id $charityId;
 
     #[\Override]

--- a/tests/Application/Messenger/Handler/FundTotalUpdatedHandlerTest.php
+++ b/tests/Application/Messenger/Handler/FundTotalUpdatedHandlerTest.php
@@ -16,7 +16,7 @@ class FundTotalUpdatedHandlerTest extends TestCase
 {
     public function testSuccessProcessing(): void
     {
-        $fund = new Fund('GBP', 'Testfund', Salesforce18Id::of('sfFundId4567890abc'), fundType: FundType::Pledge);
+        $fund = new Fund('GBP', 'Testfund', Salesforce18Id::ofFund('sfFundId4567890abc'), fundType: FundType::Pledge);
         $updateMessage = FundTotalUpdated::fromFund($fund);
 
         $fundClientProphecy = $this->prophesize(Client\Fund::class);

--- a/tests/Application/Messenger/Handler/GiftAidResultHandlerTest.php
+++ b/tests/Application/Messenger/Handler/GiftAidResultHandlerTest.php
@@ -97,8 +97,8 @@ class GiftAidResultHandlerTest extends TestCase
         $giftAidResultHandler($donationMessage);
 
         $this->assertInstanceOf(\DateTime::class, $testDonationPassedToProphecy->getTbgGiftAidRequestFailedAt());
-        $this->assertEquals('failingCorrId', $testDonationPassedToProphecy->getTbgGiftAidRequestCorrelationId());
-        $this->assertEquals('Donation error deets', $testDonationPassedToProphecy->getTbgGiftAidResponseDetail());
+        $this->assertSame('failingCorrId', $testDonationPassedToProphecy->getTbgGiftAidRequestCorrelationId());
+        $this->assertSame('Donation error deets', $testDonationPassedToProphecy->getTbgGiftAidResponseDetail());
         $this->assertNull($testDonationPassedToProphecy->getTbgGiftAidRequestConfirmedCompleteAt());
     }
 
@@ -138,8 +138,8 @@ class GiftAidResultHandlerTest extends TestCase
             \DateTime::class,
             $testDonationPassedToProphecy->getTbgGiftAidRequestConfirmedCompleteAt(),
         );
-        $this->assertEquals('goodCorrId', $testDonationPassedToProphecy->getTbgGiftAidRequestCorrelationId());
-        $this->assertEquals('Thx for ur submission', $testDonationPassedToProphecy->getTbgGiftAidResponseDetail());
+        $this->assertSame('goodCorrId', $testDonationPassedToProphecy->getTbgGiftAidRequestCorrelationId());
+        $this->assertSame('Thx for ur submission', $testDonationPassedToProphecy->getTbgGiftAidResponseDetail());
         $this->assertNull($testDonationPassedToProphecy->getTbgGiftAidRequestFailedAt());
     }
 

--- a/tests/Application/Messenger/Handler/StripePayoutHandlerTest.php
+++ b/tests/Application/Messenger/Handler/StripePayoutHandlerTest.php
@@ -364,7 +364,7 @@ class StripePayoutHandlerTest extends TestCase
         return $stripeClientProphecy;
     }
 
-    private function getCommonCalloutArgs(): array
+    private function getCommonCalloutArgs(): array // @phpstan-ignore missingType.iterableValue
     {
         return [
             // Based on the date range from our standard test data payout (donation time -6M and +1D).

--- a/tests/Application/Messenger/Handler/StripePayoutHandlerTest.php
+++ b/tests/Application/Messenger/Handler/StripePayoutHandlerTest.php
@@ -164,10 +164,10 @@ class StripePayoutHandlerTest extends TestCase
         $this->invokePayoutHandler($container, new NullLogger());
 
         // We expect donations that are not in 'Collected' status to remain the same.
-        $this->assertEquals(DonationStatus::Failed, $donation->getDonationStatus());
+        $this->assertSame(DonationStatus::Failed, $donation->getDonationStatus());
 
         // Nothing to push to SF.
-        $this->assertEquals(SalesforceWriteProxy::PUSH_STATUS_COMPLETE, $donation->getSalesforcePushStatus());
+        $this->assertSame(SalesforceWriteProxy::PUSH_STATUS_COMPLETE, $donation->getSalesforcePushStatus());
     }
 
     public function testSuccessfulUpdateFromFirstPayout(): void
@@ -208,8 +208,8 @@ class StripePayoutHandlerTest extends TestCase
 
         $this->invokePayoutHandler($container, new NullLogger());
 
-        $this->assertEquals(DonationStatus::Paid, $donation->getDonationStatus());
-        $this->assertEquals(SalesforceWriteProxy::PUSH_STATUS_PENDING_UPDATE, $donation->getSalesforcePushStatus());
+        $this->assertSame(DonationStatus::Paid, $donation->getDonationStatus());
+        $this->assertSame(SalesforceWriteProxy::PUSH_STATUS_PENDING_UPDATE, $donation->getSalesforcePushStatus());
     }
 
     /**
@@ -271,8 +271,8 @@ class StripePayoutHandlerTest extends TestCase
 
         $this->invokePayoutHandler($container, new NullLogger(), self::RETRIED_PAYOUT_ID);
 
-        $this->assertEquals(DonationStatus::Paid, $donation->getDonationStatus());
-        $this->assertEquals(SalesforceWriteProxy::PUSH_STATUS_PENDING_UPDATE, $donation->getSalesforcePushStatus());
+        $this->assertSame(DonationStatus::Paid, $donation->getDonationStatus());
+        $this->assertSame(SalesforceWriteProxy::PUSH_STATUS_PENDING_UPDATE, $donation->getSalesforcePushStatus());
     }
 
     /**
@@ -317,7 +317,7 @@ class StripePayoutHandlerTest extends TestCase
         $this->invokePayoutHandler($container, $loggerProphecy->reveal());
 
         // No change because payout's failed.
-        $this->assertEquals(DonationStatus::Collected, $donation->getDonationStatus());
+        $this->assertSame(DonationStatus::Collected, $donation->getDonationStatus());
     }
 
     /**

--- a/tests/Application/StripeFormattingTrait.php
+++ b/tests/Application/StripeFormattingTrait.php
@@ -12,7 +12,10 @@ trait StripeFormattingTrait
 {
     use ProphecyTrait;
 
-    protected function buildAutoIterableCollection(string $json): Collection|ObjectProphecy
+    /**
+     * @return Collection<StripeObject>
+     */
+    protected function buildAutoIterableCollection(string $json): Collection
     {
         /** @var \stdClass $itemsArray */
         $itemsArray = json_decode($json, false);

--- a/tests/Domain/DonationRepositoryTest.php
+++ b/tests/Domain/DonationRepositoryTest.php
@@ -125,8 +125,8 @@ class DonationRepositoryTest extends TestCase
         // Amount after fee = £955.85
 
         // Deduct tip + fee.
-        $this->assertEquals(48_16, $donation->getAmountToDeductFractional());
-        $this->assertEquals(949_49, $donation->getAmountForCharityFractional());
+        $this->assertSame(48_16, $donation->getAmountToDeductFractional());
+        $this->assertSame(949_49, $donation->getAmountForCharityFractional());
     }
 
     public function testStripeAmountForCharityWithTipUsingUSCard(): void
@@ -145,8 +145,8 @@ class DonationRepositoryTest extends TestCase
         // Amount after fee = £955.85
 
         // Deduct tip + fee.
-        $this->assertEquals(48_16, $donation->getAmountToDeductFractional());
-        $this->assertEquals(949_49, $donation->getAmountForCharityFractional());
+        $this->assertSame(48_16, $donation->getAmountToDeductFractional());
+        $this->assertSame(949_49, $donation->getAmountForCharityFractional());
     }
 
     public function testStripeAmountForCharityWithTip(): void
@@ -165,8 +165,8 @@ class DonationRepositoryTest extends TestCase
         // Amount after fee = £972.64
 
         // Deduct tip + fee.
-        $this->assertEquals(28_01, $donation->getAmountToDeductFractional());
-        $this->assertEquals(969_64, $donation->getAmountForCharityFractional());
+        $this->assertSame(28_01, $donation->getAmountToDeductFractional());
+        $this->assertSame(969_64, $donation->getAmountForCharityFractional());
     }
 
     public function testStripeAmountForCharityAndFeeVatWithTipAndVat(): void
@@ -185,11 +185,11 @@ class DonationRepositoryTest extends TestCase
         // 20% VAT on fee   = £  3.00 (2 d.p)
         // Amount after fee = £969.64
 
-        $this->assertEquals('15.01', $donation->getCharityFee());
-        $this->assertEquals('3.00', $donation->getCharityFeeVat());
+        $this->assertSame('15.01', $donation->getCharityFee());
+        $this->assertSame('3.00', $donation->getCharityFeeVat());
         // Deduct tip + fee inc. VAT.
-        $this->assertEquals(2_801, $donation->getAmountToDeductFractional());
-        $this->assertEquals(96_964, $donation->getAmountForCharityFractional());
+        $this->assertSame(2_801, $donation->getAmountToDeductFractional());
+        $this->assertSame(96_964, $donation->getAmountForCharityFractional());
     }
 
     public function testStripeAmountForCharityWithoutTip(): void
@@ -205,8 +205,8 @@ class DonationRepositoryTest extends TestCase
         // Total fee in vcat = 18.012
         // Amount after fee = £972.64
 
-        $this->assertEquals(18_01, $donation->getAmountToDeductFractional());
-        $this->assertEquals(96_964, $donation->getAmountForCharityFractional());
+        $this->assertSame(18_01, $donation->getAmountToDeductFractional());
+        $this->assertSame(96_964, $donation->getAmountForCharityFractional());
     }
 
     public function testStripeAmountForCharityWithoutTipWhenTbgClaimingGiftAid(): void
@@ -223,8 +223,8 @@ class DonationRepositoryTest extends TestCase
         // Total fee inc vat = £ 26.904
         // Amount after fee = £965.23
 
-        $this->assertEquals(26_90, $donation->getAmountToDeductFractional());
-        $this->assertEquals(96_075, $donation->getAmountForCharityFractional());
+        $this->assertSame(26_90, $donation->getAmountToDeductFractional());
+        $this->assertSame(96_075, $donation->getAmountForCharityFractional());
     }
 
     public function testStripeAmountForCharityWithoutTipRoundingOnPointFive(): void
@@ -238,8 +238,8 @@ class DonationRepositoryTest extends TestCase
         // Total fee    = £ 0.29
         // Total fee inc vat = £ 0.348
         // After fee    = £ 5.96
-        $this->assertEquals(35, $donation->getAmountToDeductFractional());
-        $this->assertEquals(5_90, $donation->getAmountForCharityFractional());
+        $this->assertSame(35, $donation->getAmountToDeductFractional());
+        $this->assertSame(5_90, $donation->getAmountForCharityFractional());
     }
 
     public function testAbandonOldCancelled(): void
@@ -281,7 +281,7 @@ class DonationRepositoryTest extends TestCase
             new ClassMetadata(Donation::class),
         );
 
-        $this->assertEquals(1, $repo->abandonOldCancelled());
+        $this->assertSame(1, $repo->abandonOldCancelled());
     }
 
     public function testFindReadyToClaimGiftAid(): void
@@ -336,7 +336,7 @@ class DonationRepositoryTest extends TestCase
             new ClassMetadata(Donation::class),
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             [$testDonation],
             $repo->findReadyToClaimGiftAid(false),
         );
@@ -377,7 +377,7 @@ class DonationRepositoryTest extends TestCase
             new ClassMetadata(Donation::class),
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             [$testDonation],
             $repo->findWithTransferIdInArray(['tr_externalId_123']),
         );

--- a/tests/Domain/DonationServiceTest.php
+++ b/tests/Domain/DonationServiceTest.php
@@ -315,7 +315,7 @@ class DonationServiceTest extends TestCase
         // act
         $this->getDonationService()->confirmOnSessionDonation($donation, $confirmationTokenId);
 
-        $this->assertEquals('0.52', $donation->getCharityFeeGross());
+        $this->assertSame('0.52', $donation->getCharityFeeGross());
     }
 
 
@@ -342,9 +342,9 @@ class DonationServiceTest extends TestCase
         $donation = $this->getDonationService(campaignRepoProphecy: $campaignRepoProphecy)
             ->buildFromAPIRequest($createPayload, PersonId::nil());
 
-        $this->assertEquals('USD', $donation->currency()->isoCode());
-        $this->assertEquals('123', $donation->getAmount());
-        $this->assertEquals(12_300, $donation->getAmountFractionalIncTip());
+        $this->assertSame('USD', $donation->currency()->isoCode());
+        $this->assertSame('123', $donation->getAmount());
+        $this->assertSame(12_300, $donation->getAmountFractionalIncTip());
     }
 
 

--- a/tests/Domain/DonationTest.php
+++ b/tests/Domain/DonationTest.php
@@ -46,7 +46,7 @@ class DonationTest extends TestCase
         ), $this->getMinimalCampaign(), PersonId::nil());
 
         $this->assertFalse($donation->getDonationStatus()->isSuccessful());
-        $this->assertEquals('pending-create', $donation->getSalesforcePushStatus());
+        $this->assertSame('pending-create', $donation->getSalesforcePushStatus());
         $this->assertNull($donation->getSalesforceId());
         $this->assertFalse($donation->hasGiftAid());
         $this->assertNull($donation->getCharityComms());
@@ -70,10 +70,10 @@ class DonationTest extends TestCase
         $donation = $this->getTestDonation('100.00');
         $donation->setTipAmount('1.13');
 
-        $this->assertEquals('100.00', $donation->getAmount());
-        $this->assertEquals('1.13', $donation->getTipAmount());
-        $this->assertEquals(113, $donation->getTipAmountFractional());
-        $this->assertEquals(10_113, $donation->getAmountFractionalIncTip());
+        $this->assertSame('100.00', $donation->getAmount());
+        $this->assertSame('1.13', $donation->getTipAmount());
+        $this->assertSame(113, $donation->getTipAmountFractional());
+        $this->assertSame(10_113, $donation->getAmountFractionalIncTip());
     }
 
     public function testAmountTooLowNotPersisted(): void
@@ -201,7 +201,7 @@ class DonationTest extends TestCase
         $donation = $this->getTestDonation();
         $donation->setOriginalPspFeeFractional('123');
 
-        $this->assertEquals('1.23', $donation->getOriginalPspFee());
+        $this->assertSame('1.23', $donation->getOriginalPspFee());
     }
 
     public function testtoFrontEndApiModel(): void
@@ -221,14 +221,14 @@ class DonationTest extends TestCase
 
         $donationData = $donation->toFrontEndApiModel();
 
-        $this->assertEquals('john.doe@example.com', $donationData['emailAddress']);
-        $this->assertEquals('1.23', $donationData['matchedAmount']);
+        $this->assertSame('john.doe@example.com', $donationData['emailAddress']);
+        $this->assertSame(1.23, $donationData['matchedAmount']);
         $this->assertIsString($donationData['collectedTime']);
         $this->assertArrayNotHasKey('originalPspFee', $donationData);
 
         $donationDataIncludingPrivate = $donation->toSFApiModel();
         \assert($donationDataIncludingPrivate !== null);
-        $this->assertEquals('1.22', $donationDataIncludingPrivate['originalPspFee']);
+        $this->assertSame(1.22, $donationDataIncludingPrivate['originalPspFee']);
     }
 
     public function testToSfAPIModel(): void
@@ -412,19 +412,19 @@ class DonationTest extends TestCase
         $claimBotMessage = $donation->toClaimBotModel();
 
         $nowInYmd = date('Y-m-d');
-        $this->assertEquals(self::DONATION_UUID, $claimBotMessage->id);
-        $this->assertEquals($nowInYmd, $claimBotMessage->donation_date);
-        $this->assertEquals('', $claimBotMessage->title);
-        $this->assertEquals('John', $claimBotMessage->first_name);
-        $this->assertEquals('Doe', $claimBotMessage->last_name);
-        $this->assertEquals('1', $claimBotMessage->house_no);
-        $this->assertEquals('N1 1AA', $claimBotMessage->postcode);
-        $this->assertEquals(123.45, $claimBotMessage->amount);
-        $this->assertEquals('AB12345', $claimBotMessage->org_hmrc_ref);
-        $this->assertEquals('CCEW', $claimBotMessage->org_regulator);
-        $this->assertEquals('12229', $claimBotMessage->org_regulator_number);
-        $this->assertEquals('Test charity', $claimBotMessage->org_name);
-        $this->assertEquals(false, $claimBotMessage->overseas);
+        $this->assertSame(self::DONATION_UUID, $claimBotMessage->id);
+        $this->assertSame($nowInYmd, $claimBotMessage->donation_date);
+        $this->assertSame('', $claimBotMessage->title);
+        $this->assertSame('John', $claimBotMessage->first_name);
+        $this->assertSame('Doe', $claimBotMessage->last_name);
+        $this->assertSame('1', $claimBotMessage->house_no);
+        $this->assertSame('N1 1AA', $claimBotMessage->postcode);
+        $this->assertSame(123.45, $claimBotMessage->amount);
+        $this->assertSame('AB12345', $claimBotMessage->org_hmrc_ref);
+        $this->assertSame('CCEW', $claimBotMessage->org_regulator);
+        $this->assertSame('12229', $claimBotMessage->org_regulator_number);
+        $this->assertSame('Test charity', $claimBotMessage->org_name);
+        $this->assertFalse($claimBotMessage->overseas);
     }
 
     public function testToClaimBotModelOverseas(): void
@@ -440,11 +440,11 @@ class DonationTest extends TestCase
 
         $claimBotMessage = $donation->toClaimBotModel();
 
-        $this->assertEquals('1 Main St, London', $claimBotMessage->house_no);
-        $this->assertEquals('', $claimBotMessage->postcode);
-        $this->assertEquals(true, $claimBotMessage->overseas);
+        $this->assertSame('1 Main St, London', $claimBotMessage->house_no);
+        $this->assertSame('', $claimBotMessage->postcode);
+        $this->assertTrue($claimBotMessage->overseas);
         $this->assertNull($claimBotMessage->org_regulator);
-        $this->assertEquals('12222', $claimBotMessage->org_regulator_number);
+        $this->assertSame('12222', $claimBotMessage->org_regulator_number);
     }
 
     public function testGetStripePIHelpersWithCard(): void
@@ -462,8 +462,8 @@ class DonationTest extends TestCase
             'on_behalf_of' => 'unitTest_stripeAccount_123',
         ];
 
-        $this->assertEquals($expectedPaymentMethodProperties, $donation->getStripeMethodProperties());
-        $this->assertEquals($expectedOnBehalfOfProperties, $donation->getStripeOnBehalfOfProperties());
+        $this->assertSame($expectedPaymentMethodProperties, $donation->getStripeMethodProperties());
+        $this->assertSame($expectedOnBehalfOfProperties, $donation->getStripeOnBehalfOfProperties());
         $this->assertTrue($donation->supportsSavingPaymentMethod());
     }
 
@@ -486,8 +486,8 @@ class DonationTest extends TestCase
             ],
         ];
 
-        $this->assertEquals($expectedPaymentMethodProperties, $donation->getStripeMethodProperties());
-        $this->assertEquals([], $donation->getStripeOnBehalfOfProperties());
+        $this->assertSame($expectedPaymentMethodProperties, $donation->getStripeMethodProperties());
+        $this->assertSame([], $donation->getStripeOnBehalfOfProperties());
         $this->assertFalse($donation->supportsSavingPaymentMethod());
     }
 
@@ -813,7 +813,7 @@ class DonationTest extends TestCase
         );
         $donation->cancel();
 
-        $this->assertEquals(DonationStatus::Cancelled, $donation->getDonationStatus());
+        $this->assertSame(DonationStatus::Cancelled, $donation->getDonationStatus());
     }
 
     public function testCantCancelPaidDonation(): void

--- a/tests/Domain/DonationTest.php
+++ b/tests/Domain/DonationTest.php
@@ -175,7 +175,6 @@ class DonationTest extends TestCase
         $this->expectException(AssertionFailedException::class);
         $this->expectExceptionMessage('Value "paypal" does not equal expected value "stripe".');
 
-        /** @psalm-suppress InvalidArgument */
         Donation::fromApiModel(
             new DonationCreate(
                 currencyCode: 'GBP',

--- a/tests/Domain/FundRepositoryTest.php
+++ b/tests/Domain/FundRepositoryTest.php
@@ -48,7 +48,7 @@ class FundRepositoryTest extends TestCase
 
         $repo->updateFromSf($fund, autoSave: false); // Don't auto-save as non-DB-backed tests can't persist
 
-        $this->assertEquals('API Fund Name', $fund->getName());
+        $this->assertSame('API Fund Name', $fund->getName());
     }
 
     public function testPullForCampaignAllNew(): void
@@ -105,7 +105,7 @@ class FundRepositoryTest extends TestCase
         $this->assertSame('1500', $campaignFunding->getAmountAvailable());
 
         $fund = $campaignFunding->getFund();
-        $this->assertEquals(FundType::ChampionFund, $fund->getFundType());
+        $this->assertSame(FundType::ChampionFund, $fund->getFundType());
         $this->assertSame('sfFundId4567890abc', $fund->getSalesforceId());
         $this->assertSame('GBP', $fund->getCurrencyCode());
     }

--- a/tests/Domain/FundRepositoryTest.php
+++ b/tests/Domain/FundRepositoryTest.php
@@ -44,7 +44,7 @@ class FundRepositoryTest extends TestCase
         // Setting a salesforceId is the quickest
         // way to ensure this behaves like a newly-found Fund without having to partially mock / prophesise
         // `FundRepository` such that `doPull()` is a real call but `pull()` doesn't try a real DB engine lookup.
-        $fund = new Fund(currencyCode: 'GBP', name: '', salesforceId: Salesforce18Id::of(self::CAMPAIGN_SF_ID), fundType:FundType::ChampionFund);
+        $fund = new Fund(currencyCode: 'GBP', name: '', salesforceId: Salesforce18Id::ofFund(self::CAMPAIGN_SF_ID), fundType:FundType::ChampionFund);
 
         $repo->updateFromSf($fund, autoSave: false); // Don't auto-save as non-DB-backed tests can't persist
 
@@ -260,7 +260,7 @@ class FundRepositoryTest extends TestCase
         $existingFund = new Fund(
             currencyCode: 'GBP',
             name: $shared ? 'Test Shared Champion Fund 456' : 'Test Champion Fund 123',
-            salesforceId: Salesforce18Id::of($shared ? 'sfFundId4567890abc' : 'sfFundId1234567890'),
+            salesforceId: Salesforce18Id::ofFund($shared ? 'sfFundId4567890abc' : 'sfFundId1234567890'),
             fundType: FundType::ChampionFund
         );
         $existingFund->setId($shared ? 456456 : 123123);

--- a/tests/Domain/FundTest.php
+++ b/tests/Domain/FundTest.php
@@ -19,7 +19,7 @@ class FundTest extends TestCase
         $fund = new Fund(
             'GBP',
             'testGetAmounts fund',
-            Salesforce18Id::of('sfFundId4567890abc'),
+            Salesforce18Id::ofFund('sfFundId4567890abc'),
             fundType: FundType::ChampionFund
         );
         $fund->addCampaignFunding(new CampaignFunding(
@@ -38,7 +38,7 @@ class FundTest extends TestCase
 
     public function testToAmountUsedUpdateModel(): void
     {
-        $fund = new Fund('GBP', 'Testfund', Salesforce18Id::of('sfFundId4567890abc'), fundType: FundType::ChampionFund);
+        $fund = new Fund('GBP', 'Testfund', Salesforce18Id::ofFund('sfFundId4567890abc'), fundType: FundType::ChampionFund);
         $fund->addCampaignFunding(new CampaignFunding(
             fund: $fund,
             amount: '123.45',

--- a/tests/Domain/InMemoryDonationRepository.php
+++ b/tests/Domain/InMemoryDonationRepository.php
@@ -41,7 +41,7 @@ class InMemoryDonationRepository implements DonationRepository
         $this->donations[$id] = $donation;
     }
 
-    #[\Override] public function findOneBy(array $criteria, ?array $orderBy = null): ?Donation
+    #[\Override] public function findOneBy(array $criteria): ?Donation
     {
         if (array_keys($criteria) === ['transactionId']) {
             foreach ($this->donations as $donation) {

--- a/tests/Domain/RegularGivingNotifierTest.php
+++ b/tests/Domain/RegularGivingNotifierTest.php
@@ -135,9 +135,7 @@ class RegularGivingNotifierTest extends TestCase
     private function andGivenAnActivatedMandate(PersonId $personId, DonorAccount $donor): array
     {
         $campaign = TestCase::someCampaign(thankYouMessage: 'Thank you for setting up your regular donation to us!');
-        /**
-         * @psalm-suppress PossiblyNullArgument
-         */
+
         $mandate = new RegularGivingMandate(
             donorId: $personId,
             donationAmount: Money::fromPoundsGBP(64),

--- a/tests/Domain/RegularGivingServiceTest.php
+++ b/tests/Domain/RegularGivingServiceTest.php
@@ -187,7 +187,7 @@ class RegularGivingServiceTest extends TestCase
             $this->donations[2]->getPreAuthorizationDate()
         );
 
-        $this->assertEquals(Country::fromEnum(CountryAlpha2::Kiribati)->alpha2->value, $this->donorAccount->getBillingCountryCode());
+        $this->assertSame(Country::fromEnum(CountryAlpha2::Kiribati)->alpha2->value, $this->donorAccount->getBillingCountryCode());
         $this->assertSame('KI0107', $this->donorAccount->getBillingPostcode());
 
         // Pending, and no notification, until Stripe first donation charge succeeded webhook.
@@ -594,10 +594,10 @@ class RegularGivingServiceTest extends TestCase
         $this->donationRepositoryProphecy->findPendingAndPreAuthedForMandate($mandate->getUuid())->willReturn([]);
         $sut->cancelMandate($mandate, 'Because I don\'t have any more money to give', MandateCancellationType::DonorRequestedCancellation);
 
-        $this->assertEquals(MandateStatus::Cancelled, $mandate->getStatus());
-        $this->assertEquals('Because I don\'t have any more money to give', $mandate->cancellationReason());
-        $this->assertEquals(MandateCancellationType::DonorRequestedCancellation, $mandate->cancellationType());
-        $this->assertEquals($now, $mandate->cancelledAt());
+        $this->assertSame(MandateStatus::Cancelled, $mandate->getStatus());
+        $this->assertSame('Because I don\'t have any more money to give', $mandate->cancellationReason());
+        $this->assertSame(MandateCancellationType::DonorRequestedCancellation, $mandate->cancellationType());
+        $this->assertSame($now, $mandate->cancelledAt());
     }
 
     public function testCancellingMandateCancelsPendingDonations(): void

--- a/tests/Monolog/Processor/AwsTraceIdProcessorTest.php
+++ b/tests/Monolog/Processor/AwsTraceIdProcessorTest.php
@@ -57,12 +57,12 @@ class AwsTraceIdProcessorTest extends TestCase
         // This warning *already* happens in fully bootstrapped app unit tests, because there is no Redis cache
         // for Doctrine. So we just inspect the handler's record for that log to check the `extra` param is set,
         // rather than simulating a new log within the test.
-        $this->assertEquals(
+        $this->assertSame(
             'Doctrine falling back to array cache - Redis host dummy-redis-hostname',
             $handler->getRecords()[0]['message'],
         );
-        $this->assertEquals(300, $handler->getRecords()[0]['level']);
-        $this->assertEquals('amz-trace-id-123', $handler->getRecords()[0]['extra']['x-amzn-trace-id']);
+        $this->assertSame(300, $handler->getRecords()[0]['level']);
+        $this->assertSame('amz-trace-id-123', $handler->getRecords()[0]['extra']['x-amzn-trace-id']);
     }
 
     public function testContextNotAdded(): void
@@ -81,11 +81,11 @@ class AwsTraceIdProcessorTest extends TestCase
         $request = $this->createRequest('GET', '/ping');
         $app->handle($request);
 
-        $this->assertEquals(
+        $this->assertSame(
             'Doctrine falling back to array cache - Redis host dummy-redis-hostname',
             $handler->getRecords()[0]['message'],
         );
-        $this->assertEquals(300, $handler->getRecords()[0]['level']);
+        $this->assertSame(300, $handler->getRecords()[0]['level']);
         $this->assertArrayNotHasKey('x-amzn-trace-id', $handler->getRecords()[0]['extra']);
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -47,7 +47,7 @@ class TestCase extends PHPUnitTestCase
     use ProphecyTrait;
 
     /**
-     * @var array<0|1, ?App> array of app instances with and without real redis. Each one may be
+     * @var array<0|1, ?App<ContainerInterface|null>> array of app instances with and without real redis. Each one may be
      *                       initialised up to once per test.
      */
     private array $appInstance = [0 => null, 1 => null];
@@ -73,14 +73,15 @@ class TestCase extends PHPUnitTestCase
     }
 
     /**
-     * @return App
+     * @return App<ContainerInterface|null>
      * @throws Exception
      */
     protected function getAppInstance(bool $withRealRedis = false): App
     {
         $memoizedInstance = $this->appInstance[(int)$withRealRedis];
         if ($memoizedInstance) {
-            return $memoizedInstance;
+            // not sure what's wrong with return type
+            return $memoizedInstance; // @phpstan-ignore return.type
         }
 
         // Instantiate PHP-DI ContainerBuilder
@@ -155,9 +156,11 @@ class TestCase extends PHPUnitTestCase
         $routes($app);
 
         $app->addRoutingMiddleware();
-        $this->appInstance[(int) $withRealRedis] = $app;
+        // not sure what's wrong with assignment here
+        $this->appInstance[(int) $withRealRedis] = $app; // @phpstan-ignore assign.propertyType
 
-        return $app;
+        // not sure what's wrong with return type.
+        return $app; // @phpstan-ignore return.type
     }
 
     /**
@@ -165,8 +168,8 @@ class TestCase extends PHPUnitTestCase
      * @param string $path
      * @param string $bodyString
      * @param array<string, string> $headers
-     * @param array $serverParams
-     * @param array $cookies
+     * @param array<string, string> $serverParams
+     * @param array<string, string> $cookies
      * @return Request
      */
     public static function createRequest(
@@ -213,6 +216,8 @@ class TestCase extends PHPUnitTestCase
     /**
      * Returns some random charity - use if you don't care about the details or will replace them with setters later.
      * Introduced to replace many old calls to instantiate Charity with zero arguments.
+     *
+     * @param Salesforce18Id<Charity>|null $salesforceId
      */
     public static function someCharity(
         ?string $stripeAccountId = null,

--- a/tests/TestLogger.php
+++ b/tests/TestLogger.php
@@ -9,7 +9,7 @@ use Psr\Log\AbstractLogger;
  */
 class TestLogger extends AbstractLogger
 {
-    /** @var list<array{level: mixed, message: string, context: array}>  */
+    /** @var list<array{level: mixed, message: string, context: array<mixed>}>  */
     public array $messages = [];
 
     public string $logString = "";
@@ -18,6 +18,6 @@ class TestLogger extends AbstractLogger
     public function log($level, \Stringable|string $message, array $context = []): void
     {
         $this->messages[] = ['level' => $level, 'message' => (string) $message, 'context' => $context];
-        $this->logString .= "$level: " . (string) $message . "\n";
+        $this->logString .= "$level: " . (string) $message . "\n"; // @phpstan-ignore encapsedStringPart.nonString
     }
 }


### PR DESCRIPTION
The biggest change at this level is that whenever using a generic or iteratable type we have to say what it's of - we can't just have an `array` or  a `Salesforce18Id`, we have to specify what type it an array or Salesforce18Id *of*.