### PR TITLE
MAT-421: Run integration tests without process isolation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,12 @@ jobs:
       - run: ./matchbot matchbot:write-schema-files --check
 
       - run: composer run integration-test
+      - run: composer run integration-test
+      - run: composer run integration-test
+      - run: composer run integration-test
+      - run: composer run integration-test
+      - run: composer run integration-test
+      - run: composer run integration-test
 
       - store_test_results:
           path: reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,12 +74,6 @@ jobs:
       - run: ./matchbot matchbot:write-schema-files --check
 
       - run: composer run integration-test
-      - run: composer run integration-test
-      - run: composer run integration-test
-      - run: composer run integration-test
-      - run: composer run integration-test
-      - run: composer run integration-test
-      - run: composer run integration-test
 
       - store_test_results:
           path: reports

--- a/integrationTests/CreateRegularGivingMandateTest.php
+++ b/integrationTests/CreateRegularGivingMandateTest.php
@@ -95,6 +95,8 @@ class CreateRegularGivingMandateTest extends IntegrationTest
     public function tearDown(): void
     {
         $this->getContainer()->set(MessageBusInterface::class, $this->originalMessageBus);
+
+        parent::tearDown();
     }
 
     public function testItCreatesRegularGivingMandate(): void

--- a/integrationTests/DonationMatchingTest.php
+++ b/integrationTests/DonationMatchingTest.php
@@ -80,6 +80,12 @@ class DonationMatchingTest extends IntegrationTest
                 'Throwing after subtracting funds to test how our system handles the crash',
                 $e->getMessage(),
             );
+
+             // in prod the transaction would be effectively rolled back by the db session
+            // ending without a commit. Here we share the db session with subsequent tests
+            // so we have to explicitly rollback.
+
+            $this->db()->rollBack();
         }
 
         // assert

--- a/integrationTests/IntegrationTest.php
+++ b/integrationTests/IntegrationTest.php
@@ -102,6 +102,13 @@ abstract class IntegrationTest extends TestCase
         return Salesforce18Id::ofCampaign(self::randomString());
     }
 
+    #[\Override]
+    public function tearDown(): void
+    {
+        $this->assertFalse($this->db()->isTransactionActive());
+        $this->clearPreviousCampaignsCharitiesAndRelated();
+    }
+
     public static function setContainer(ContainerInterface $container): void
     {
         self::$integrationTestContainer = $container;

--- a/integrationTests/IntegrationTest.php
+++ b/integrationTests/IntegrationTest.php
@@ -105,8 +105,14 @@ abstract class IntegrationTest extends TestCase
     #[\Override]
     public function tearDown(): void
     {
-        $this->assertFalse($this->db()->isTransactionActive());
+        $this->assertFalse(
+            $this->db()->isTransactionActive(),
+            'Transaction should not be left open at end of test, will affect following tests. Please commit or rollback'
+        );
+
         $this->clearPreviousCampaignsCharitiesAndRelated();
+
+        parent::tearDown();
     }
 
     public static function setContainer(ContainerInterface $container): void

--- a/integrationTests/PullCharityUpdatedBasedOnSfHookTest.php
+++ b/integrationTests/PullCharityUpdatedBasedOnSfHookTest.php
@@ -20,6 +20,8 @@ class PullCharityUpdatedBasedOnSfHookTest extends IntegrationTest
     {
         $this->getContainer()->set(Client\Fund::class, null);
         $this->getContainer()->set(Client\Campaign::class, null);
+
+        parent::tearDown();
     }
 
     public function testItPullsCharityUpdateAfterSalesforceSendsHook(): void

--- a/phpunit-integration.xml
+++ b/phpunit-integration.xml
@@ -11,7 +11,7 @@
         convertErrorsToExceptions="true"
         convertNoticesToExceptions="true"
         convertWarningsToExceptions="true"
-        processIsolation="true"
+        processIsolation="false"
         stopOnFailure="false"
         bootstrap="integrationTests/bootstrap.php">
   <coverage processUncoveredFiles="true">


### PR DESCRIPTION
We need to make sure that any db transactions opened during an integration test are committed or rolled back by the end so that it doesn't affect subsequent tests.

This change cuts about 40 seconds off the integration test runtime, which feels like a big saving to me given how often I'm pushing matchbot changes and waiting for a result.