### PR TITLE
MAT-421 – simplify by removing old or over-complicated retry logic

### DIFF
--- a/src/Domain/DonationService.php
+++ b/src/Domain/DonationService.php
@@ -377,12 +377,10 @@ class DonationService
         // tracking instead so that a retry can work.
         $this->entityManager->beginTransaction();
 
-        // Must persist before Stripe work to have ID available. Outer fn throws if all attempts fail.
-        // @todo-MAT-388: remove runWithPossibleRetry if we determine its not useful and unwrap body of function below
-        $this->runWithPossibleRetry(function () use ($donation) {
-            $this->entityManager->persist($donation);
-            $this->entityManager->flush();
-        }, 'Donation Create persist before stripe work');
+        // Must persist before Stripe work to have ID available. No retries at this level as it's cleaner to begin
+        // again with a fresh donation.
+        $this->entityManager->persist($donation);
+        $this->entityManager->flush();
 
         if ($campaign->isMatched() && $attemptMatching) {
             try {

--- a/src/Domain/DonationService.php
+++ b/src/Domain/DonationService.php
@@ -381,13 +381,7 @@ class DonationService
         // @todo-MAT-388: remove runWithPossibleRetry if we determine its not useful and unwrap body of function below
         $this->runWithPossibleRetry(function () use ($donation) {
             $this->entityManager->persist($donation);
-            try {
-                $this->entityManager->flush();
-            } catch (\Throwable $exception) {
-                $this->entityManager->rollback();
-                $this->entityManager->detach($donation);
-                throw $exception;
-            }
+            $this->entityManager->flush();
         }, 'Donation Create persist before stripe work');
 
         if ($campaign->isMatched() && $attemptMatching) {


### PR DESCRIPTION
Also reduce donation enrol tries from 6 (which we didn't really decide on deliberately) to 2.