### PR TITLE
MAT-419: Remove new view that failed to deploy to one environment

### DIFF
--- a/schema/donation-summary-no-orm.sql
+++ b/schema/donation-summary-no-orm.sql
@@ -1,8 +1,0 @@
--- Auto generated file, do not edit.
--- run ./matchbot matchbot:write-schema-files to update
-
--- Note that CHARSET and COLLATE details have been removed to allow sucessful comparisons between schemas
--- on dev machines and CircleCI. Do not use these files to create a database. They are provided for
--- information only.
-
-CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`%` SQL SECURITY DEFINER VIEW `donation-summary-no-orm` AS select `Donation`.`id` AS `id`,`Donation`.`salesforceId` AS `salesforceId`,`Donation`.`createdAt` AS `createdAt`,`Donation`.`amount` AS `amount`,`Donation`.`donationStatus` AS `donationStatus`,`Charity`.`name` AS `CharityName`,`Campaign`.`name` AS `CampaignName` from ((`Donation` join `Campaign` on((`Campaign`.`id` = `Donation`.`campaign_id`))) join `Charity` on((`Charity`.`id` = `Campaign`.`charity_id`)))

--- a/src/Migrations/Version20250520210732.php
+++ b/src/Migrations/Version20250520210732.php
@@ -16,20 +16,7 @@ final class Version20250520210732 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql(<<<'SQL'
-                create definer = root@`%` view `donation-summary-no-orm` as
-        select `Donation`.`id`             AS `id`,
-               `Donation`.`salesforceId`   AS `salesforceId`,
-               `Donation`.`createdAt`      AS `createdAt`,
-               `Donation`.`amount`         AS `amount`,
-               `Donation`.`donationStatus` AS `donationStatus`,
-               `Charity`.`name`            AS `CharityName`,
-               `Campaign`.`name`           AS `CampaignName`
-        from ((`Donation` join `Campaign`
-               on ((`Campaign`.`id` = `Donation`.`campaign_id`))) join `Charity`
-              on ((`Charity`.`id` = `Campaign`.`charity_id`)));
-        SQL
-        );
+        // no-op - previously this was creating a view but that failed in one environment due to permissions issue.
     }
 
     public function down(Schema $schema): void


### PR DESCRIPTION
THink we may have some config drift between different non-prod environments that meant this migration was able to run in one but not the other.