### PR TITLE
MAT-411: Add get campaign route

### DIFF
--- a/app/routes.php
+++ b/app/routes.php
@@ -56,6 +56,12 @@ return function (App $app) {
             Donations\RemoveGiftAidDeclaration::class
         )->add(SalesforceAuthMiddleware::class);
 
+
+        $versionGroup->get(
+            '/campaigns/{salesforceId:[a-zA-Z0-9]{18}}',
+            \MatchBot\Application\Actions\Campaigns\Get::class
+        );
+
         /**
          * Cancel *all* pending donations for the current Donor with the specified query param criteria,
          * currently taking one campaign ID and most useful for Donation Funds tips.

--- a/src/Application/Actions/Campaigns/Get.php
+++ b/src/Application/Actions/Campaigns/Get.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Application\Actions\Campaigns;
+
+use MatchBot\Application\Actions\Action;
+use MatchBot\Application\Assertion;
+use MatchBot\Application\Environment;
+use MatchBot\Client\Campaign as SfCampaignClient;
+use Psr\Log\LoggerInterface;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Exception\HttpNotFoundException;
+
+/**
+ * Gets details of a campaign. For the moment this is just a very thin wrapper around Salesforce, so that frontend
+ * can start to switch over to using matchbot, but the intention is that in future
+ * it should serve from the matchbot db instead of calling SF on demand.
+ *
+ * Not ready for use in prod.
+ */
+class Get extends Action
+{
+    public function __construct(
+        LoggerInterface $logger,
+        private SfCampaignClient $salesforceCampaignClient,
+    ) {
+        parent::__construct($logger);
+    }
+
+    #[\Override]
+    protected function action(Request $request, Response $response, array $args): Response
+    {
+        if (Environment::current()->isProduction()) {
+            throw new HttpNotFoundException($request);
+        }
+
+        $sfId = $args['salesforceId'] ?? throw new HttpNotFoundException($request);
+
+        $campaign = $this->salesforceCampaignClient->getById($sfId, false);
+
+        return $this->respondWithData($response, $campaign);
+    }
+}


### PR DESCRIPTION
For the moment this just proxies to SF, but is added so that FE can start relying on it. Soon it will read the campaign from the matchbot DB and domain model.