### PR TITLE
MAT-411: Check campaign rendered from matchbot against what SF sent us.

### DIFF
--- a/src/Domain/Campaign.php
+++ b/src/Domain/Campaign.php
@@ -63,7 +63,6 @@ class Campaign extends SalesforceReadProxy
      * Full data about this campaign as received from Salesforce. Not for use as-is in Matchbot domain logic but
      * may be used in ad-hoc queries, migrations, and perhaps for outputting to FE to provide compatibility with the SF
      * API. Charity data is ommitted here to avoid duplication with {@see Charity::$salesforceData}.
-     * @psalm-suppress UnusedProperty
      * @var array<string, mixed>
      */
     #[ORM\Column(type: "json", nullable: false)]
@@ -429,5 +428,11 @@ class Campaign extends SalesforceReadProxy
     public function getStartDate(): \DateTimeImmutable
     {
         return \DateTimeImmutable::createFromInterface($this->startDate);
+    }
+
+    /** @return array<string, mixed> */
+    public function getSalesforceData(): array
+    {
+        return $this->salesforceData;
     }
 }

--- a/src/Domain/CampaignRenderCompatibilityChecker.php
+++ b/src/Domain/CampaignRenderCompatibilityChecker.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace MatchBot\Domain;
+
+use Assert\Assert;
+use Assert\LazyAssertion;
+use Assert\LazyAssertionException;
+
+/**
+ * Checks that a campaign as rendered to an array by new matchbot code is compatible with how it was
+ * rendered by the SF API.
+ */
+class CampaignRenderCompatibilityChecker
+{
+    /**
+     * @param array<array-key,mixed> $actual
+     * @param array<array-key,mixed> $expected
+     *
+     * @throws LazyAssertionException
+     */
+    public static function checkCampaignHttpModelMatchesModelFromSF(
+        array $actual,
+        array $expected
+    ): void {
+        $lazyAsert = Assert::lazy();
+
+        self::recursiveCompare(
+            $actual,
+            $expected,
+            $lazyAsert
+        );
+
+        $lazyAsert->verifyNow();
+    }
+
+    /**
+     * @param array<array-key, mixed> $actual
+     * @param array<array-key, mixed> $expected
+     * @param LazyAssertion $lazyAssert
+     */
+    private static function recursiveCompare(
+        array $actual,
+        array $expected,
+        LazyAssertion $lazyAssert,
+        string $path = '',
+    ): void {
+        /** @var mixed $expectedValue */
+        foreach ($expected as $key => $expectedValue) {
+            /** @var mixed $value */
+
+            $value = \array_key_exists($key, $actual) ?
+                $actual[$key] : '<UNDEFINED>';
+
+            if (\is_array($expectedValue) && \is_array($value)) {
+                self::recursiveCompare($value, $expectedValue, $lazyAssert, "{$key}.");
+            } else {
+                $lazyAssert->that($value)->eq($expectedValue, null, "{$path}{$key}");
+            }
+        }
+    }
+}

--- a/src/Domain/CampaignService.php
+++ b/src/Domain/CampaignService.php
@@ -2,6 +2,8 @@
 
 namespace MatchBot\Domain;
 
+use Assert\InvalidArgumentException;
+use Assert\LazyAssertionException;
 use MatchBot\Application\Assertion;
 use MatchBot\Application\HttpModels\Campaign as CampaignHttpModel;
 use MatchBot\Domain\Campaign as CampaignDomainModel;
@@ -15,8 +17,10 @@ class CampaignService
      * we may need to call out to SF to get the most current data as required for some fields, e.g. amountRaised,
      * although if SF is not available or doesn't know this campaign we could fall back to a null or default value
      * perhaps.
+     *
+     * @return array<string, mixed> Campaign as associative array ready to render as JSON and send to FE
      */
-    public function renderCampaign(CampaignDomainModel $campaign): CampaignHttpModel
+    public function renderCampaign(CampaignDomainModel $campaign): array
     {
         $charity = $campaign->getCharity();
 
@@ -45,7 +49,7 @@ class CampaignService
         Assertion::inArray($campaignStatus, ['Active','Expired','Preview']);
         /** @var 'Active'|'Expired'|'Preview' $campaignStatus */
 
-        return new CampaignHttpModel(
+        $campaignHttpModel = new CampaignHttpModel(
             id: $campaign->getSalesforceId(),
             amountRaised: 0, // MAT-411-todo-before merge - replace this and similar placeholder values
             additionalImageUris: [],
@@ -94,5 +98,34 @@ class CampaignService
             usesSharedFunds: false,
             video: null,
         );
+
+        /** @var array<string, mixed> $campaignHttpModelArray */
+        $campaignHttpModelArray = \json_decode(
+            json: \json_encode($campaignHttpModel, \JSON_THROW_ON_ERROR),
+            associative: true,
+            depth: 512,
+            flags: JSON_THROW_ON_ERROR
+        );
+
+        // We could just return $modelGeneratedFromSF to FE and not need to generate anything else with matchbot
+        // logic, but that would keep FE indirectly coupled to the SF service. By making sure matchbot is able to
+        // semi-independently regenerate the same thing we should be able to break the dependency and then later evolve
+        // the mathbot<->frontend interface without needing to change SF.
+        $modelGeneratedFromSF = $campaign->getSalesforceData() + ['charity' => $campaign->getCharity()->getSalesforceData()];
+
+        try {
+            CampaignRenderCompatibilityChecker::checkCampaignHttpModelMatchesModelFromSF($campaignHttpModelArray, $modelGeneratedFromSF);
+        } catch (LazyAssertionException $exception) {
+            $errorMessages = \array_map(
+                fn(InvalidArgumentException $e) => ["{$e->getPropertyPath()}: {$e->getMessage()}"],
+                $exception->getErrorExceptions()
+            );
+
+            \ksort($errorMessages);
+
+            $campaignHttpModelArray['errors'] = $errorMessages;
+        }
+
+        return $campaignHttpModelArray;
     }
 }

--- a/src/Domain/Charity.php
+++ b/src/Domain/Charity.php
@@ -53,7 +53,6 @@ class Charity extends SalesforceReadProxy
      * Full data about this charity as received from Salesforce. Not for use as-is in Matchbot domain logic but
      * may be used in ad-hoc queries, migrations, and perhaps for outputting to FE to provide compatibility with the SF
      * API.
-     * @psalm-suppress UnusedProperty
      * @var array<string, mixed>
      */
     #[ORM\Column(type: "json", nullable: false)]
@@ -422,5 +421,11 @@ class Charity extends SalesforceReadProxy
         }
 
         return EmailAddress::of($this->emailAddress);
+    }
+
+    /** @return array<string, mixed> */
+    public function getSalesforceData(): array
+    {
+        return $this->salesforceData;
     }
 }


### PR DESCRIPTION
In future we will probably want to generate an alarm and/or throw if this doesn't match. Right now we know it doesn't match so we just include the list of errors in the response, and FE can display it on the donation page (at least outside prod) until we've fixed them all.

To test make a donation on local to force matchbot to pull a campaign from SF, then view the API response at e.g.
http://localhost:30030/v1/campaigns/a05S900000IdO9lIAF

You should see quite a long list of errors something like this. (one of them is because I edited the campaign title in my my matchbot db)

![image](https://github.com/user-attachments/assets/b87722d6-1fa5-4ba7-9601-cfe6683d6fcf)

My plan next is to make FE display these all near the top of the donate page.