### PR TITLE
MAT-405: Don't log error for failing to emit 'x_' fields to FE

### DIFF
--- a/src/Domain/CampaignRenderCompatibilityChecker.php
+++ b/src/Domain/CampaignRenderCompatibilityChecker.php
@@ -46,6 +46,11 @@ class CampaignRenderCompatibilityChecker
     ): void {
         /** @var mixed $expectedValue */
         foreach ($expected as $key => $expectedValue) {
+            if (is_string($key) && \str_starts_with(haystack: $key, needle: 'x_')) {
+                // field is intended for use within matchbot only, does not need to be emitted to FE
+                continue;
+            }
+
             /** @var mixed $value */
 
             $value = \array_key_exists($key, $actual) ?


### PR DESCRIPTION
These field(s) are intented only for use within matchbot