### PR TITLE
MAT-405: Link charity campaigns to associated metacampaigns

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -132,7 +132,7 @@
             "MYSQL_SCHEMA=matchbot_test vendor/bin/doctrine orm:schema-tool:drop --full-database --force",
             "@doctrine:migrate",
             "./matchbot matchbot:write-schema-files",
-            "./matchbot matchbot:create-fictional-data"
+            "./matchbot matchbot:create-fictional-data --verbose"
         ],
         "doctrine:update-schema": [
             "@doctrine:cache:clear",

--- a/integrationTests/CampaignRepositoryTest.php
+++ b/integrationTests/CampaignRepositoryTest.php
@@ -22,7 +22,7 @@ class CampaignRepositoryTest extends IntegrationTest
 
         $campaign = new Campaign(
             $this->randomCampaignId(),
-            metaCampaignSfId: null,
+            metaCampaignSlug: null,
             charity: $this->getCharityAwaitingGiftAidApproval(),
             startDate: new \DateTimeImmutable('-10 months'), // less than the 9 month limit
             endDate: new \DateTimeImmutable(-29 * 9 . 'days'),
@@ -70,7 +70,7 @@ class CampaignRepositoryTest extends IntegrationTest
 
         $campaign = new Campaign(
             self::someSalesForce18CampaignId(),
-            metaCampaignSfId: null,
+            metaCampaignSlug: null,
             charity: $this->getCharityAwaitingGiftAidApproval(),
             startDate: new \DateTimeImmutable('-11 months'),
             endDate: new \DateTimeImmutable('-10 months'),

--- a/integrationTests/CampaignRepositoryTest.php
+++ b/integrationTests/CampaignRepositoryTest.php
@@ -22,9 +22,10 @@ class CampaignRepositoryTest extends IntegrationTest
 
         $campaign = new Campaign(
             $this->randomCampaignId(),
-            $this->getCharityAwaitingGiftAidApproval(),
-            startDate: new \DateTimeImmutable('-10 months'),
-            endDate: new \DateTimeImmutable(-29 * 9 . 'days'), // less than the 9 month limit
+            metaCampaignSfId: null,
+            charity: $this->getCharityAwaitingGiftAidApproval(),
+            startDate: new \DateTimeImmutable('-10 months'), // less than the 9 month limit
+            endDate: new \DateTimeImmutable(-29 * 9 . 'days'),
             isMatched: true,
             ready: true,
             status: null,
@@ -32,6 +33,9 @@ class CampaignRepositoryTest extends IntegrationTest
             currencyCode: 'GBP',
             isRegularGiving: false,
             regularGivingCollectionEnd: null,
+            thankYouMessage: null,
+            rawData: [],
+            hidden: false,
         );
 
 
@@ -66,7 +70,8 @@ class CampaignRepositoryTest extends IntegrationTest
 
         $campaign = new Campaign(
             self::someSalesForce18CampaignId(),
-            $this->getCharityAwaitingGiftAidApproval(),
+            metaCampaignSfId: null,
+            charity: $this->getCharityAwaitingGiftAidApproval(),
             startDate: new \DateTimeImmutable('-11 months'),
             endDate: new \DateTimeImmutable('-10 months'),
             isMatched: true,
@@ -76,6 +81,9 @@ class CampaignRepositoryTest extends IntegrationTest
             currencyCode: 'GBP',
             isRegularGiving: false,
             regularGivingCollectionEnd: null,
+            thankYouMessage: null,
+            rawData: [],
+            hidden: false,
         );
 
         $em = $this->getService(EntityManagerInterface::class);

--- a/integrationTests/DonationRepositoryTest.php
+++ b/integrationTests/DonationRepositoryTest.php
@@ -179,7 +179,7 @@ class DonationRepositoryTest extends IntegrationTest
     {
         return new Campaign(
             Salesforce18Id::ofCampaign('campaignId12345678'),
-            metaCampaignSfId: null,
+            metaCampaignSlug: null,
             charity: $charity ?? TestCase::someCharity(),
             startDate: new \DateTimeImmutable('now'),
             endDate: new \DateTimeImmutable('now'),

--- a/integrationTests/DonationRepositoryTest.php
+++ b/integrationTests/DonationRepositoryTest.php
@@ -179,7 +179,8 @@ class DonationRepositoryTest extends IntegrationTest
     {
         return new Campaign(
             Salesforce18Id::ofCampaign('campaignId12345678'),
-            $charity ?? TestCase::someCharity(),
+            metaCampaignSfId: null,
+            charity: $charity ?? TestCase::someCharity(),
             startDate: new \DateTimeImmutable('now'),
             endDate: new \DateTimeImmutable('now'),
             isMatched: true,
@@ -189,6 +190,9 @@ class DonationRepositoryTest extends IntegrationTest
             currencyCode: 'GBP',
             isRegularGiving: false,
             regularGivingCollectionEnd: null,
+            thankYouMessage: null,
+            rawData: [],
+            hidden: false,
         );
     }
 

--- a/integrationTests/PullCharityUpdatedBasedOnSfHookTest.php
+++ b/integrationTests/PullCharityUpdatedBasedOnSfHookTest.php
@@ -102,6 +102,7 @@ class PullCharityUpdatedBasedOnSfHookTest extends IntegrationTest
             'title' => 'Campaign title not relavent',
             'status' => 'Preview',
             'ready' => false,
+            'parentRef' => null,
             'thankYouMessage' => 'Test thank you message',
             'charity' => [
                 'id' => $sfId,

--- a/schema/Campaign.sql
+++ b/schema/Campaign.sql
@@ -24,11 +24,11 @@ CREATE TABLE `Campaign` (
   `thankYouMessage` varchar(500) DEFAULT NULL,
   `salesforceData` json NOT NULL,
   `hidden` tinyint(1) NOT NULL DEFAULT '0',
-  `metaCampaignSfId` varchar(18) DEFAULT NULL,
+  `metaCampaignSlug` varchar(64) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `UNIQ_E663708BD8961D21` (`salesforceId`),
   KEY `IDX_E663708BF5C97E37` (`charity_id`),
   KEY `end_date_and_is_matched` (`endDate`,`isMatched`),
-  KEY `metaCampaignSfId` (`metaCampaignSfId`),
+  KEY `metaCampaignSlug` (`metaCampaignSlug`),
   CONSTRAINT `FK_E663708BF5C97E37` FOREIGN KEY (`charity_id`) REFERENCES `Charity` (`id`)
 )

--- a/schema/Campaign.sql
+++ b/schema/Campaign.sql
@@ -24,9 +24,11 @@ CREATE TABLE `Campaign` (
   `thankYouMessage` varchar(500) DEFAULT NULL,
   `salesforceData` json NOT NULL,
   `hidden` tinyint(1) NOT NULL DEFAULT '0',
+  `metaCampaignSfId` varchar(18) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `UNIQ_E663708BD8961D21` (`salesforceId`),
   KEY `IDX_E663708BF5C97E37` (`charity_id`),
   KEY `end_date_and_is_matched` (`endDate`,`isMatched`),
+  KEY `metaCampaignSfId` (`metaCampaignSfId`),
   CONSTRAINT `FK_E663708BF5C97E37` FOREIGN KEY (`charity_id`) REFERENCES `Charity` (`id`)
 )

--- a/schema/MetaCampaign.sql
+++ b/schema/MetaCampaign.sql
@@ -7,7 +7,7 @@
 
 CREATE TABLE `MetaCampaign` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
-  `slug` varchar(255) NOT NULL,
+  `slug` varchar(64) NOT NULL,
   `title` varchar(255) NOT NULL,
   `currency` varchar(255) NOT NULL,
   `status` varchar(255) NOT NULL,
@@ -21,5 +21,10 @@ CREATE TABLE `MetaCampaign` (
   `salesforceLastPull` datetime DEFAULT NULL,
   `salesforceId` varchar(18) DEFAULT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `UNIQ_C36155ECD8961D21` (`salesforceId`)
+  UNIQUE KEY `UNIQ_C36155EC989D9B62` (`slug`),
+  UNIQUE KEY `UNIQ_C36155ECD8961D21` (`salesforceId`),
+  KEY `slug` (`slug`),
+  KEY `title` (`title`),
+  KEY `status` (`status`),
+  KEY `hidden` (`hidden`)
 )

--- a/src/Domain/Campaign.php
+++ b/src/Domain/Campaign.php
@@ -19,6 +19,7 @@ use MatchBot\Client\Campaign as CampaignClient;
  */
 #[ORM\Table]
 #[ORM\Index(name: 'end_date_and_is_matched', columns: ['endDate', 'isMatched'])]
+#[ORM\Index(name: 'metaCampaignSfId', columns: ['metaCampaignSfId'])]
 #[ORM\Entity(repositoryClass: CampaignRepository::class)]
 #[ORM\HasLifecycleCallbacks]
 class Campaign extends SalesforceReadProxy
@@ -63,6 +64,17 @@ class Campaign extends SalesforceReadProxy
      */
     #[ORM\Column(type: 'string')]
     protected string $name;
+
+
+    /**
+     * 18 digit salesforce ID of the related meta-campaign, if any.
+     *
+     * Might be neater to use our DB numeric ID and possibly a doctrine based join, but that would require having
+     * the metacampaign in the DB before we fetch the campaign from SF. For now using the SfID instead to allow fetching
+     * in either order & filling this in on existing data while we don't yet have metacampaigns in DB.
+     */
+    #[ORM\Column(length: 18, unique: false, nullable: true)]
+    protected ?string $metaCampaignSfId;
 
     /**
      * Full data about this campaign as received from Salesforce. Not for use as-is in Matchbot domain logic but
@@ -134,14 +146,16 @@ class Campaign extends SalesforceReadProxy
 
 
     /**
-     * @param \DateTimeImmutable|null $regularGivingCollectionEnd
      * @param Salesforce18Id<Campaign> $sfId
+     * @param Salesforce18Id<MetaCampaign>|null $metaCampaignSfId
+     * @param \DateTimeImmutable|null $regularGivingCollectionEnd
      * @param 'Active'|'Expired'|'Preview'|null $status
      * @param bool $isRegularGiving
      * @param array<string,mixed> $rawData - data about the campaign as sent from Salesforce
      * */
     public function __construct(
         Salesforce18Id $sfId,
+        ?Salesforce18Id $metaCampaignSfId,
         Charity $charity,
         \DateTimeImmutable $startDate,
         \DateTimeImmutable $endDate,
@@ -167,13 +181,14 @@ class Campaign extends SalesforceReadProxy
             endDate: $endDate,
             isMatched: $isMatched,
             name: $name,
+            metaCampaignSfId: $metaCampaignSfId,
             startDate: $startDate,
             ready: $ready,
             isRegularGiving: $isRegularGiving,
             regularGivingCollectionEnd: $regularGivingCollectionEnd,
             thankYouMessage: $thankYouMessage,
-            sfData: $rawData,
             hidden: $hidden,
+            sfData: $rawData,
         );
     }
 
@@ -217,6 +232,7 @@ class Campaign extends SalesforceReadProxy
 
         return new self(
             sfId: $salesforceId,
+            metaCampaignSfId: null,
             charity: $charity,
             startDate: new \DateTimeImmutable($startDate),
             endDate: new \DateTimeImmutable($endDate),
@@ -382,8 +398,9 @@ class Campaign extends SalesforceReadProxy
     }
 
     /**
-     * @param 'Active'|'Expired'|'Preview'|null $status
      * @param array<string,mixed> $sfData
+     * @param Salesforce18Id<MetaCampaign>|null $metaCampaignSfId
+     * @param 'Active'|'Expired'|'Preview'|null $status
      */
     final public function updateFromSfPull(
         string $currencyCode,
@@ -391,6 +408,7 @@ class Campaign extends SalesforceReadProxy
         \DateTimeInterface $endDate,
         bool $isMatched,
         string $name,
+        ?Salesforce18Id $metaCampaignSfId,
         \DateTimeInterface $startDate,
         bool $ready,
         bool $isRegularGiving,
@@ -421,6 +439,7 @@ class Campaign extends SalesforceReadProxy
         $this->endDate = $endDate;
         $this->isMatched = $isMatched;
         $this->name = $name;
+        $this->metaCampaignSfId = $metaCampaignSfId?->value;
         $this->startDate = $startDate;
         $this->ready = $ready;
         $this->status = $status;
@@ -524,5 +543,17 @@ class Campaign extends SalesforceReadProxy
     public function isHidden(): bool
     {
         return $this->hidden;
+    }
+
+    /**
+     * @return Salesforce18Id<MetaCampaign>|null
+     */
+    public function getMetaCampaignSfId(): ?Salesforce18Id
+    {
+        if ($this->metaCampaignSfId === null) {
+            return null;
+        }
+
+        return Salesforce18Id::ofMetaCampaign($this->metaCampaignSfId);
     }
 }

--- a/src/Domain/Campaign.php
+++ b/src/Domain/Campaign.php
@@ -430,7 +430,7 @@ class Campaign extends SalesforceReadProxy
         Assertion::betweenLength($name, 2, 255);
         Assertion::nullOrMaxLength($thankYouMessage, 500);
         Assertion::nullOrBetweenLength($metaCampaignSlug, 1, 64);
-        Assertion::nullOrRegex($metaCampaignSlug, '/^[-a-z0-9]+$/');
+        Assertion::nullOrRegex($metaCampaignSlug, '/^[-A-Za-z0-9]+$/');
         // needed because SF may send an ID if slug is not filled in - we don't want that in the matchbot DB.
         Assertion::nullOrNotContains($metaCampaignSlug, 'a05', "$metaCampaignSlug appears to be an SF ID, should be a slug");
 

--- a/src/Domain/Campaign.php
+++ b/src/Domain/Campaign.php
@@ -430,7 +430,7 @@ class Campaign extends SalesforceReadProxy
         Assertion::betweenLength($name, 2, 255);
         Assertion::nullOrMaxLength($thankYouMessage, 500);
         Assertion::nullOrBetweenLength($metaCampaignSlug, 1, 64);
-        Assertion::nullOrRegex($metaCampaignSlug, '/^[-a-z50-9]+$/');
+        Assertion::nullOrRegex($metaCampaignSlug, '/^[-a-z0-9]+$/');
         // needed because SF may send an ID if slug is not filled in - we don't want that in the matchbot DB.
         Assertion::nullOrNotContains($metaCampaignSlug, 'a05', "$metaCampaignSlug appears to be an SF ID, should be a slug");
 

--- a/src/Domain/Campaign.php
+++ b/src/Domain/Campaign.php
@@ -74,7 +74,7 @@ class Campaign extends SalesforceReadProxy
      * in either order & filling this in on existing data while we don't yet have metacampaigns in DB.
      */
     #[ORM\Column(length: 18, unique: false, nullable: true)]
-    protected ?string $metaCampaignSfId;
+    private ?string $metaCampaignSfId;
 
     /**
      * Full data about this campaign as received from Salesforce. Not for use as-is in Matchbot domain logic but

--- a/src/Domain/CampaignRepository.php
+++ b/src/Domain/CampaignRepository.php
@@ -432,6 +432,7 @@ class CampaignRepository extends SalesforceReadProxyRepository
             endDate: new DateTime($endDateString),
             isMatched: $campaignData['isMatched'],
             name: $title,
+            metaCampaignSfId: null,
             startDate: new DateTime($startDateString),
             ready: $campaignData['ready'],
             isRegularGiving: $campaignData['isRegularGiving'] ?? false,

--- a/src/Domain/CampaignRepository.php
+++ b/src/Domain/CampaignRepository.php
@@ -432,7 +432,7 @@ class CampaignRepository extends SalesforceReadProxyRepository
             endDate: new DateTime($endDateString),
             isMatched: $campaignData['isMatched'],
             name: $title,
-            metaCampaignSfId: null,
+            metaCampaignSlug: $campaignData['parentRef'],
             startDate: new DateTime($startDateString),
             ready: $campaignData['ready'],
             isRegularGiving: $campaignData['isRegularGiving'] ?? false,

--- a/src/Domain/CampaignService.php
+++ b/src/Domain/CampaignService.php
@@ -109,7 +109,6 @@ class CampaignService
         $parentAmountRaised = $sfCampaignData['parentAmountRaised'];
         $parentDonationCount = $sfCampaignData['parentDonationCount'];
         $parentMatchFundsRemaining = $sfCampaignData['parentMatchFundsRemaining'];
-        $parentRef = $sfCampaignData['parentRef'];
         $parentTarget = $sfCampaignData['parentTarget'];
         $parentUsesSharedFunds = $sfCampaignData['parentUsesSharedFunds'];
 
@@ -174,7 +173,7 @@ class CampaignService
             parentAmountRaised: $parentAmountRaised,
             parentDonationCount: $parentDonationCount,
             parentMatchFundsRemaining: $parentMatchFundsRemaining,
-            parentRef: $parentRef,
+            parentRef: $campaign->getMetaCampaignSfId()?->value,
             parentTarget: $parentTarget,
             parentUsesSharedFunds: $parentUsesSharedFunds,
             problem: $sfCampaignData['problem'],

--- a/src/Domain/CampaignService.php
+++ b/src/Domain/CampaignService.php
@@ -173,7 +173,7 @@ class CampaignService
             parentAmountRaised: $parentAmountRaised,
             parentDonationCount: $parentDonationCount,
             parentMatchFundsRemaining: $parentMatchFundsRemaining,
-            parentRef: $campaign->getMetaCampaignSfId()?->value,
+            parentRef: $campaign->getMetaCampaignSlug(),
             parentTarget: $parentTarget,
             parentUsesSharedFunds: $parentUsesSharedFunds,
             problem: $sfCampaignData['problem'],

--- a/src/Domain/MetaCampaign.php
+++ b/src/Domain/MetaCampaign.php
@@ -18,12 +18,16 @@ use Psr\Http\Message\UriInterface;
     repositoryClass: null // we construct our own repository
 )]
 #[ORM\HasLifecycleCallbacks]
+#[ORM\Index(name: 'slug', columns: ['slug'])]
+#[ORM\Index(name: 'title', columns: ['title'])]
+#[ORM\Index(name: 'status', columns: ['status'])]
+#[ORM\Index(name: 'hidden', columns: ['hidden'])]
 class MetaCampaign extends SalesforceReadProxy
 {
     /**
      * @psalm-suppress UnusedProperty - will be used soon
      */
-    #[ORM\Column()]
+    #[ORM\Column(length: 64, unique: true, nullable: false)]
     private string $slug;
 
     /**

--- a/src/Domain/SalesforceProxy.php
+++ b/src/Domain/SalesforceProxy.php
@@ -10,7 +10,6 @@ use Doctrine\ORM\Mapping as ORM;
  * @see SalesforceReadProxy
  * @see SalesforceWriteProxy
  */
-#[ORM\Index(name: 'salesforceId', columns: ['salesforceId'])]
 abstract class SalesforceProxy extends Model
 {
     /**

--- a/src/Domain/SalesforceProxy.php
+++ b/src/Domain/SalesforceProxy.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Mapping as ORM;
  * @see SalesforceReadProxy
  * @see SalesforceWriteProxy
  */
+#[ORM\Index(name: 'salesforceId', columns: ['salesforceId'])]
 abstract class SalesforceProxy extends Model
 {
     /**

--- a/src/Migrations/Version20250605112912.php
+++ b/src/Migrations/Version20250605112912.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250605112912 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add column Campaign.metaCampaignSfId';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE Campaign ADD metaCampaignSfId VARCHAR(18) DEFAULT NULL');
+        $this->addSql('CREATE INDEX metaCampaignSfId ON Campaign (metaCampaignSfId)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX metaCampaignSfId ON Campaign');
+        $this->addSql('ALTER TABLE Campaign DROP metaCampaignSfId');
+    }
+}

--- a/src/Migrations/Version20250605112912.php
+++ b/src/Migrations/Version20250605112912.php
@@ -11,18 +11,18 @@ final class Version20250605112912 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return 'Add column Campaign.metaCampaignSfId';
+        return 'Add column Campaign.metaCampaignSlug';
     }
 
     public function up(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE Campaign ADD metaCampaignSfId VARCHAR(18) DEFAULT NULL');
-        $this->addSql('CREATE INDEX metaCampaignSfId ON Campaign (metaCampaignSfId)');
+        $this->addSql('ALTER TABLE Campaign ADD metaCampaignSlug VARCHAR(64) DEFAULT NULL');
+        $this->addSql('CREATE INDEX metaCampaignSlug ON Campaign (metaCampaignSlug)');
     }
 
     public function down(Schema $schema): void
     {
-        $this->addSql('DROP INDEX metaCampaignSfId ON Campaign');
-        $this->addSql('ALTER TABLE Campaign DROP metaCampaignSfId');
+        $this->addSql('DROP INDEX metaCampaignSlug ON Campaign');
+        $this->addSql('ALTER TABLE Campaign DROP metaCampaignSlug');
     }
 }

--- a/src/Migrations/Version20250605113222.php
+++ b/src/Migrations/Version20250605113222.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250605113222 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Set new metacampaign field on all campaigns';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            UPDATE Campaign set metaCampaignSfId = salesforceData->'$.parentRef'
+            -- no limit intended, should be quick enough to do ~10k campaigns at once.
+            SQL
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        {
+            $this->addSql(<<<'SQL'
+            UPDATE Campaign set metaCampaignSfId = null
+            -- no limit intended
+            SQL
+            );
+        }
+
+    }
+}

--- a/src/Migrations/Version20250605113222.php
+++ b/src/Migrations/Version20250605113222.php
@@ -17,7 +17,7 @@ final class Version20250605113222 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $this->addSql(<<<'SQL'
-            UPDATE Campaign set metaCampaignSfId = salesforceData->'$.parentRef'
+            UPDATE Campaign set metaCampaignSlug = salesforceData->'$.parentRef'
             -- no limit intended, should be quick enough to do ~10k campaigns at once.
             SQL
         );
@@ -27,7 +27,7 @@ final class Version20250605113222 extends AbstractMigration
     {
         {
             $this->addSql(<<<'SQL'
-            UPDATE Campaign set metaCampaignSfId = null
+            UPDATE Campaign set metaCampaignSlug = null
             -- no limit intended
             SQL
             );

--- a/src/Migrations/Version20250605141453.php
+++ b/src/Migrations/Version20250605141453.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250605141453 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add indexes for MetaCampaign';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE MetaCampaign CHANGE slug slug VARCHAR(64) NOT NULL');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_C36155EC989D9B62 ON MetaCampaign (slug)');
+        $this->addSql('CREATE INDEX slug ON MetaCampaign (slug)');
+        $this->addSql('CREATE INDEX title ON MetaCampaign (title)');
+        $this->addSql('CREATE INDEX status ON MetaCampaign (status)');
+        $this->addSql('CREATE INDEX hidden ON MetaCampaign (hidden)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX UNIQ_C36155EC989D9B62 ON MetaCampaign');
+        $this->addSql('DROP INDEX slug ON MetaCampaign');
+        $this->addSql('DROP INDEX title ON MetaCampaign');
+        $this->addSql('DROP INDEX status ON MetaCampaign');
+        $this->addSql('DROP INDEX hidden ON MetaCampaign');
+        $this->addSql('ALTER TABLE MetaCampaign CHANGE slug slug VARCHAR(255) NOT NULL');
+    }
+}

--- a/tests/Application/DonationTestDataTrait.php
+++ b/tests/Application/DonationTestDataTrait.php
@@ -157,7 +157,7 @@ trait DonationTestDataTrait
     {
         $campaign = new Campaign(
             Salesforce18Id::ofCampaign('234567890pROjecTID'),
-            metaCampaignSfId: null,
+            metaCampaignSlug: null,
             charity: TestCase::someCharity(),
             startDate: new \DateTimeImmutable(),
             endDate: new \DateTimeImmutable(),

--- a/tests/Application/DonationTestDataTrait.php
+++ b/tests/Application/DonationTestDataTrait.php
@@ -157,6 +157,7 @@ trait DonationTestDataTrait
     {
         $campaign = new Campaign(
             Salesforce18Id::ofCampaign('234567890pROjecTID'),
+            metaCampaignSfId: null,
             charity: TestCase::someCharity(),
             startDate: new \DateTimeImmutable(),
             endDate: new \DateTimeImmutable(),
@@ -167,6 +168,9 @@ trait DonationTestDataTrait
             currencyCode: 'GBP',
             isRegularGiving: false,
             regularGivingCollectionEnd: null,
+            thankYouMessage: null,
+            rawData: [],
+            hidden: false,
         );
 
         $donation = TestCase::someDonation(amount: '124.56');

--- a/tests/Domain/CampaignTest.php
+++ b/tests/Domain/CampaignTest.php
@@ -14,6 +14,7 @@ class CampaignTest extends TestCase
     {
         $campaign = new Campaign(
             sfId: Salesforce18Id::ofCampaign('xxxxxxxxxxxxxxxxxx'),
+            metaCampaignSfId: null,
             charity: TestCase::someCharity(),
             startDate: new \DateTimeImmutable('2020-01-01'),
             endDate: new \DateTimeImmutable('2030-12-31'),
@@ -24,6 +25,9 @@ class CampaignTest extends TestCase
             currencyCode: 'GBP',
             isRegularGiving: false,
             regularGivingCollectionEnd: null,
+            thankYouMessage: null,
+            rawData: [],
+            hidden: false,
         );
 
         $this->assertTrue($campaign->isOpen(new \DateTimeImmutable('2025-01-01')));
@@ -32,6 +36,7 @@ class CampaignTest extends TestCase
     {
         $campaign = new Campaign(
             sfId: Salesforce18Id::ofCampaign('xxxxxxxxxxxxxxxxxx'),
+            metaCampaignSfId: null,
             charity: TestCase::someCharity(),
             startDate: new \DateTimeImmutable('2020-01-01'),
             endDate: new \DateTimeImmutable('2030-12-31'),
@@ -42,6 +47,9 @@ class CampaignTest extends TestCase
             currencyCode: 'GBP',
             isRegularGiving: false,
             regularGivingCollectionEnd: null,
+            thankYouMessage: null,
+            rawData: [],
+            hidden: false,
         );
 
         $this->assertFalse($campaign->isOpen(at: new \DateTimeImmutable('2025-01-01')));
@@ -51,6 +59,7 @@ class CampaignTest extends TestCase
     {
         $campaign = new Campaign(
             sfId: Salesforce18Id::ofCampaign('xxxxxxxxxxxxxxxxxx'),
+            metaCampaignSfId: null,
             charity: TestCase::someCharity(),
             startDate: new \DateTimeImmutable('2020-01-01'),
             endDate: new \DateTimeImmutable('2030-12-31'),
@@ -61,6 +70,9 @@ class CampaignTest extends TestCase
             currencyCode: 'GBP',
             isRegularGiving: false,
             regularGivingCollectionEnd: null,
+            thankYouMessage: null,
+            rawData: [],
+            hidden: false,
         );
 
         $this->assertFalse($campaign->isOpen(at: new \DateTimeImmutable('2019-12-31T23:59:59')));
@@ -70,6 +82,7 @@ class CampaignTest extends TestCase
     {
         $campaign = new Campaign(
             sfId: Salesforce18Id::ofCampaign('xxxxxxxxxxxxxxxxxx'),
+            metaCampaignSfId: null,
             charity: TestCase::someCharity(),
             startDate: new \DateTimeImmutable('2020-01-01'),
             endDate: new \DateTimeImmutable('2030-12-31'),
@@ -80,6 +93,9 @@ class CampaignTest extends TestCase
             currencyCode: 'GBP',
             isRegularGiving: false,
             regularGivingCollectionEnd: null,
+            thankYouMessage: null,
+            rawData: [],
+            hidden: false,
         );
 
         $this->assertFalse($campaign->isOpen(at: new \DateTimeImmutable('2030-12-31')));

--- a/tests/Domain/CampaignTest.php
+++ b/tests/Domain/CampaignTest.php
@@ -14,7 +14,7 @@ class CampaignTest extends TestCase
     {
         $campaign = new Campaign(
             sfId: Salesforce18Id::ofCampaign('xxxxxxxxxxxxxxxxxx'),
-            metaCampaignSfId: null,
+            metaCampaignSlug: null,
             charity: TestCase::someCharity(),
             startDate: new \DateTimeImmutable('2020-01-01'),
             endDate: new \DateTimeImmutable('2030-12-31'),
@@ -36,7 +36,7 @@ class CampaignTest extends TestCase
     {
         $campaign = new Campaign(
             sfId: Salesforce18Id::ofCampaign('xxxxxxxxxxxxxxxxxx'),
-            metaCampaignSfId: null,
+            metaCampaignSlug: null,
             charity: TestCase::someCharity(),
             startDate: new \DateTimeImmutable('2020-01-01'),
             endDate: new \DateTimeImmutable('2030-12-31'),
@@ -59,7 +59,7 @@ class CampaignTest extends TestCase
     {
         $campaign = new Campaign(
             sfId: Salesforce18Id::ofCampaign('xxxxxxxxxxxxxxxxxx'),
-            metaCampaignSfId: null,
+            metaCampaignSlug: null,
             charity: TestCase::someCharity(),
             startDate: new \DateTimeImmutable('2020-01-01'),
             endDate: new \DateTimeImmutable('2030-12-31'),
@@ -82,7 +82,7 @@ class CampaignTest extends TestCase
     {
         $campaign = new Campaign(
             sfId: Salesforce18Id::ofCampaign('xxxxxxxxxxxxxxxxxx'),
-            metaCampaignSfId: null,
+            metaCampaignSlug: null,
             charity: TestCase::someCharity(),
             startDate: new \DateTimeImmutable('2020-01-01'),
             endDate: new \DateTimeImmutable('2030-12-31'),

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -266,7 +266,7 @@ class TestCase extends PHPUnitTestCase
 
         return new Campaign(
             $sfId,
-            metaCampaignSfId: null,
+            metaCampaignSlug: null,
             charity: $charity ?? self::someCharity(stripeAccountId: $stripeAccountId),
             startDate: new \DateTimeImmutable('2020-01-01'),
             endDate: new \DateTimeImmutable('3000-01-01'),

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -266,7 +266,8 @@ class TestCase extends PHPUnitTestCase
 
         return new Campaign(
             $sfId,
-            $charity ?? self::someCharity(stripeAccountId: $stripeAccountId),
+            metaCampaignSfId: null,
+            charity: $charity ?? self::someCharity(stripeAccountId: $stripeAccountId),
             startDate: new \DateTimeImmutable('2020-01-01'),
             endDate: new \DateTimeImmutable('3000-01-01'),
             isMatched: false,
@@ -277,6 +278,8 @@ class TestCase extends PHPUnitTestCase
             isRegularGiving: $isRegularGiving,
             regularGivingCollectionEnd: $regularGivingCollectionEnd,
             thankYouMessage: $thankYouMessage,
+            rawData: [],
+            hidden: false,
         );
     }
 


### PR DESCRIPTION
Kernel of this PR is change from

````
$parentRef = $sfCampaignData['parentRef'];
parentRef: $parentRef,
````

to 

````
parentRef: $campaign->getMetaCampaignSfId()?->value,
````

I think needed since MetaCampaignSfId is such a core concept, and the association between campaign and metacampaign will be needed to implement search that it should be fully represented in the matchbot model and not just use data direct from SF without interpreting it, and it needs to be indexed.