### PR TITLE
Add images from https://picsum.photos/ to fictional campaigns for dev…

### DIFF
--- a/src/Application/Commands/CreateFictionalData.php
+++ b/src/Application/Commands/CreateFictionalData.php
@@ -140,6 +140,8 @@ class CreateFictionalData extends Command
      */
     private function getFictionalCampaignData(string $sfId, string $name, bool $isRegularGiving, bool $isMatched): array
     {
+        $randomSeed = \random_int(1, 100);
+
         return [ // @phpstan-ignore return.type
             'id' => $sfId,
             'charity' => [],
@@ -157,7 +159,7 @@ class CreateFictionalData extends Command
             'summary' => "We can $name",
             'updates' => [],
             'solution' => 'do the saving',
-            'bannerUri' => null,
+            'bannerUri' => "https://picsum.photos/seed/$randomSeed/1700/500",
             'countries' => [0 => 'United Kingdom',],
             'isMatched' => $isMatched,
             'parentRef' => null,
@@ -199,12 +201,14 @@ class CreateFictionalData extends Command
      */
     private function getFictionalCharityData(SymfonyStyle $io): array
     {
+        $randomSeed = \random_int(1, 100);
+
         $stripeAccountId = $this->createStripeAccount($io);
 
         return [
             'id' => self::SF_ID_ZERO,
             'name' => 'Society for the advancement of bots and matches',
-            'logoUri' =>  null,
+            'logoUri' =>  "https://picsum.photos/seed/$randomSeed/200/200",
             'twitter' => null,
             'website' => 'https://society-for-the-advancement-of-bots-and-matches.localhost',
             'facebook' => 'https://www.facebook.com/botsAndMatches',

--- a/src/Application/Commands/CreateFictionalData.php
+++ b/src/Application/Commands/CreateFictionalData.php
@@ -159,6 +159,7 @@ class CreateFictionalData extends Command
             'summary' => "We can $name",
             'updates' => [],
             'solution' => 'do the saving',
+            // in prod bannerUri is available in multiple sizes with a `width` param added by FE. Picsum will always send the image at 1700px wide.
             'bannerUri' => "https://picsum.photos/seed/$randomSeed/1700/500",
             'countries' => [0 => 'United Kingdom',],
             'isMatched' => $isMatched,


### PR DESCRIPTION
… environment

Should make working with dev copies of the site marginally more fun, plus allows us to notice if displaying the campaign ever breaks.

![image](https://github.com/user-attachments/assets/37aa8161-44d0-41ff-978a-3156b38dfa11)

![image](https://github.com/user-attachments/assets/78dbc412-dbea-4237-aaba-1c81696228bf)
