### PR TITLE
MAT-405: Throw 404 error when metacampaign requested as if it were a …

### DIFF
--- a/src/Application/Actions/Campaigns/Get.php
+++ b/src/Application/Actions/Campaigns/Get.php
@@ -48,6 +48,12 @@ class Get extends Action
 
         try {
             $campaign = $this->salesforceCampaignClient->getById($sfId->value, false);
+            if ($campaign['x_isMetaCampaign']) {
+                // throwing manually for now. When MAT-405 is done and we serve only from matchbot DB metcampaigns will not be in the same
+                // DB table so this sort of request will naturally generate a 404 response.
+                $this->logger->warning("Metacampaign requested by ID {$sfId->value}, should request via slug {$campaign['slug']} at dedicated metacampaign page instead");
+                throw new HttpNotFoundException($request);
+            }
             $this->campaignService->checkCampaignCanBeHandledByMatchbotDB($campaign, $sfId);
             return $this->respondWithData($response, $campaign);
         } catch (NotFoundException | RequestException $e) {


### PR DESCRIPTION
…charity campaign

We only support loading metacampaigns at their dedicated slug-based address.