### PR TITLE
MAT-405: Reject messages from SF if timestamped and time mismatches b…

### DIFF
--- a/app/dependencies.php
+++ b/app/dependencies.php
@@ -554,7 +554,8 @@ return function (ContainerBuilder $containerBuilder) {
             function (ContainerInterface $c) {
                 return new Auth\SalesforceAuthMiddleware(
                     sfApiKey: $c->get(Settings::class)->salesforce['apiKey'],
-                    logger: $c->get(LoggerInterface::class)
+                    logger: $c->get(LoggerInterface::class),
+                    clock: $c->get(ClockInterface::class),
                 );
             },
 


### PR DESCRIPTION
…y over 2 minutes

Could indicate bad clock skew between Salesforce and Matchbot, or an attacker somehow getting hold of an old message and replaying it