### PR TITLE
MAT-433: Accept a list of charities from to update instead of just a …

### DIFF
--- a/app/routes.php
+++ b/app/routes.php
@@ -82,7 +82,7 @@ return function (App $app) {
             '/charities/upsert-many',
             \MatchBot\Application\Actions\Charities\UpsertMany::class
         )->add(SalesforceAuthMiddleware::class);
-        
+
         $versionGroup->get(
             '/charities/{charitySalesforceId:[a-zA-Z0-9]{18}}/campaigns',
             \MatchBot\Application\Actions\Campaigns\GetSummariesForCharity::class

--- a/app/routes.php
+++ b/app/routes.php
@@ -77,6 +77,12 @@ return function (App $app) {
             \MatchBot\Application\Actions\Charities\Put::class
         )->add(SalesforceAuthMiddleware::class);
 
+
+        $versionGroup->post(
+            '/charities/upsert-many',
+            \MatchBot\Application\Actions\Charities\UpsertMany::class
+        )->add(SalesforceAuthMiddleware::class);
+        
         $versionGroup->get(
             '/charities/{charitySalesforceId:[a-zA-Z0-9]{18}}/campaigns',
             \MatchBot\Application\Actions\Campaigns\GetSummariesForCharity::class

--- a/integrationTests/AcceptCharityPushFromSFTest.php
+++ b/integrationTests/AcceptCharityPushFromSFTest.php
@@ -77,4 +77,72 @@ class AcceptCharityPushFromSFTest extends \MatchBot\IntegrationTests\Integration
         $this->assertSame('Updated Charity Name', $updatedCharity->getName());
         $this->assertSame('acc_123456', $updatedCharity->getStripeAccountId());
     }
+
+    public function testItAcceptsAPushOfNewCharityFromSfUsingList(): void
+    {
+        // Extract charity data from the campaign data
+        $charityData = TestCase::CAMPAIGN_FROM_SALESOFRCE['charity'];
+
+        // Randomize ID to prevent duplicate issues
+        $charitySfId = Salesforce18Id::ofCharity(self::randomString());
+        $charityData['id'] = $charitySfId->value;
+
+        $body = \json_encode(['charities' => [$charityData]], JSON_THROW_ON_ERROR);
+
+        $response = $this->getApp()->handle(new ServerRequest(
+            method: 'POST',
+            uri: '/v1/charities/upsert-many',
+            headers: [
+                SalesforceAuthMiddleware::HEADER_NAME => TestCase::getSalesforceAuthValue($body),
+            ],
+            body: $body
+        ));
+        $this->assertSame(200, $response->getStatusCode());
+
+        $charity = $this->getContainer()->get(CharityRepository::class)->findOneBySalesforceId($charitySfId);
+        $this->assertNotNull($charity);
+
+        $this->assertSame('Society for the advancement of bots and matches', $charity->getName());
+        $this->assertSame('acc_123456', $charity->getStripeAccountId());
+    }
+
+    public function testItUpdatesExistingCharityFromSfUsingList(): void
+    {
+        // First create a charity
+        $charitySfId = Salesforce18Id::ofCharity(self::randomString());
+        $charity = TestCase::someCharity(
+            salesforceId: $charitySfId,
+            name: 'Original Charity Name',
+            stripeAccountId: 'original_stripe_account'
+        );
+
+        $this->em->persist($charity);
+        $this->em->flush();
+
+        // Now update it
+        $charityData = TestCase::CAMPAIGN_FROM_SALESOFRCE['charity'];
+        $charityData['id'] = $charitySfId->value;
+        $charityData['name'] = 'Updated Charity Name';
+
+        $body = \json_encode(['charities' => [$charityData]], JSON_THROW_ON_ERROR);
+
+        $response = $this->getApp()->handle(new ServerRequest(
+            method: 'POST',
+            uri: '/v1/charities/upsert-many',
+            headers: [
+                SalesforceAuthMiddleware::HEADER_NAME => TestCase::getSalesforceAuthValue($body),
+            ],
+            body: $body
+        ));
+        $this->assertSame(200, $response->getStatusCode());
+
+        // Clear entity manager to ensure we get fresh data
+        $this->em->clear();
+
+        $updatedCharity = $this->getContainer()->get(CharityRepository::class)->findOneBySalesforceId($charitySfId);
+        $this->assertNotNull($updatedCharity);
+
+        $this->assertSame('Updated Charity Name', $updatedCharity->getName());
+        $this->assertSame('acc_123456', $updatedCharity->getStripeAccountId());
+    }
 }

--- a/src/Application/Actions/Charities/UpsertMany.php
+++ b/src/Application/Actions/Charities/UpsertMany.php
@@ -67,7 +67,7 @@ class UpsertMany extends Action
             $charitySfId = Salesforce18Id::ofCharity($charityData['id']);
             $this->upsertCharity($charityData, $charitySfId);
         }
-        
+
         return new JsonResponse([], 200);
     }
 

--- a/src/Application/Actions/Charities/UpsertMany.php
+++ b/src/Application/Actions/Charities/UpsertMany.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Application\Actions\Charities;
+
+use Doctrine\ORM\EntityManager;
+use JetBrains\PhpStorm\Pure;
+use Laminas\Diactoros\Response\JsonResponse;
+use MatchBot\Application\Actions\Action;
+use MatchBot\Application\Assertion;
+use MatchBot\Application\Environment;
+use MatchBot\Domain\CampaignRepository;
+use MatchBot\Domain\Charity;
+use MatchBot\Domain\CharityRepository;
+use MatchBot\Domain\EmailAddress;
+use MatchBot\Domain\PostalAddress;
+use MatchBot\Domain\Salesforce18Id;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Log\LoggerInterface;
+use Slim\Exception\HttpBadRequestException;
+use Slim\Exception\HttpNotFoundException;
+use Symfony\Component\Clock\Clock;
+
+/**
+ * @psalm-import-type SFCharityApiResponse from \MatchBot\Client\Campaign
+ */
+class UpsertMany extends Action
+{
+    #[Pure]
+    public function __construct(
+        LoggerInterface $logger,
+        private CharityRepository $charityRepository,
+        private EntityManager $entityManager,
+        private Clock $clock,
+    ) {
+        parent::__construct($logger);
+    }
+
+    #[\Override]
+    protected function action(Request $request, Response $response, array $args): Response
+    {
+        // not yet ready for use in prod
+        if (Environment::current()->isProduction()) {
+            throw new HttpNotFoundException($request);
+        }
+
+        try {
+            $requestBody = json_decode(
+                $request->getBody()->getContents(),
+                true,
+                512,
+                \JSON_THROW_ON_ERROR
+            );
+        } catch (\JsonException) {
+            throw new HttpBadRequestException($request, 'Cannot parse request body as JSON');
+        }
+        \assert(\is_array($requestBody));
+
+        if (!isset($requestBody['charities']) || !is_array($requestBody['charities'])) {
+            throw new HttpBadRequestException($request, 'Missing or invalid charity data');
+        }
+
+        /** @var SFCharityApiResponse $charityData */
+        foreach ($requestBody['charities'] as $charityData) {
+            $charitySfId = Salesforce18Id::ofCharity($charityData['id']);
+            $this->upsertCharity($charityData, $charitySfId);
+        }
+        
+        return new JsonResponse([], 200);
+    }
+
+    /**
+     * @param SFCharityApiResponse $charityData
+     * @param Salesforce18Id<Charity> $charitySfId
+     */
+    public function upsertCharity(array $charityData, Salesforce18Id $charitySfId): void
+    {
+        // Extract data
+        $name = $charityData['name'];
+        $stripeAccountId = $charityData['stripeAccountId'];
+        $regulatorRegion = $charityData['regulatorRegion'];
+        $regulatorNumber = self::nullOrStringValue($charityData, 'regulatorNumber');
+
+        // Optional fields
+        $hmrcReferenceNumber = self::nullOrStringValue($charityData, 'hmrcReferenceNumber');
+        $giftAidOnboardingStatus = self::nullOrStringValue($charityData, 'giftAidOnboardingStatus');
+        $website = self::nullOrStringValue($charityData, 'website');
+        $logoUri = self::nullOrStringValue($charityData, 'logoUri');
+        $phoneNumber = self::nullOrStringValue($charityData, 'phoneNumber');
+
+        // Get postal address data
+        $address = CampaignRepository::arrayToPostalAddress($charityData['postalAddress'] ?? null, $this->logger);
+
+        $emailRaw = $charityData['emailAddress'] ?? null;
+        $emailString = is_string($emailRaw) ? $emailRaw : null;
+        $emailAddress = $emailString !== null && trim($emailString) !== '' ? EmailAddress::of($emailString) : null;
+
+        $charity = $this->charityRepository->findOneBySalesforceId($charitySfId);
+
+        if (! $charity) {
+            $charity = new Charity(
+                salesforceId: $charitySfId->value,
+                charityName: $name,
+                stripeAccountId: $stripeAccountId,
+                hmrcReferenceNumber: $hmrcReferenceNumber,
+                giftAidOnboardingStatus: $giftAidOnboardingStatus,
+                regulator: CampaignRepository::getRegulatorHMRCIdentifier($regulatorRegion),
+                regulatorNumber: $regulatorNumber,
+                time: \DateTime::createFromInterface($this->clock->now()),
+                rawData: $charityData,
+                websiteUri: $website,
+                logoUri: $logoUri,
+                phoneNumber: $phoneNumber,
+                address: $address,
+                emailAddress: $emailAddress,
+            );
+            $this->entityManager->persist($charity);
+
+            $this->logger->info("Saving new charity from SF: {$charity->getName()} {$charity->getSalesforceId()}");
+        } else {
+            $charity->updateFromSfPull(
+                charityName: $name,
+                websiteUri: $website,
+                logoUri: $logoUri,
+                stripeAccountId: $stripeAccountId,
+                hmrcReferenceNumber: $hmrcReferenceNumber,
+                giftAidOnboardingStatus: $giftAidOnboardingStatus,
+                regulator: CampaignRepository::getRegulatorHMRCIdentifier($regulatorRegion),
+                regulatorNumber: $regulatorNumber,
+                rawData: $charityData,
+                time: new \DateTime('now'),
+                phoneNumber: $phoneNumber,
+                address: $address,
+                emailAddress: $emailAddress,
+            );
+            $this->logger->info("Updating charity {$charity->getSalesforceId()} from SF: {$charity->getName()}");
+        }
+
+        $this->entityManager->flush();
+    }
+
+    /**
+     * Returns a null or string value from an array.
+     *
+     * @param array<string, mixed> $data The array to extract the value from
+     * @param string $key The key to extract
+     * @return string|null The extracted value, or null if not present or not a string
+     */
+    private static function nullOrStringValue(array $data, string $key): ?string
+    {
+        if (!isset($data[$key])) {
+            return null;
+        }
+
+        Assertion::nullOrString($data[$key], "$key must be a string or null");
+        return is_string($data[$key]) ? $data[$key] : null;
+    }
+}


### PR DESCRIPTION
…single charity

Code copied from \MatchBot\Application\Actions\Charities\Put to new \MatchBot\Application\Actions\Charities\UpsertMany

We may DRY up in future by deleting one or the other controller, probably the older one that only accepts a single charity at a time.