### PR TITLE
MAT-434: Allow reducing funds for campaigns before opening date

### DIFF
--- a/app/repositories.php
+++ b/app/repositories.php
@@ -25,6 +25,7 @@ use MatchBot\Domain\MetaCampaignRepository;
 use MatchBot\Domain\RegularGivingMandateRepository;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Clock\ClockInterface;
 
 return static function (ContainerBuilder $containerBuilder) {
     $containerBuilder->addDefinitions([
@@ -42,6 +43,7 @@ return static function (ContainerBuilder $containerBuilder) {
             $repo->setClient($c->get(Client\Campaign::class));
             $repo->setLogger($c->get(LoggerInterface::class));
             $repo->setFundRepository($c->get(FundRepository::class));
+            $repo->setClock($c->get(ClockInterface::class));
 
             return $repo;
         },

--- a/src/Application/Commands/PullIndividualCampaignFromSF.php
+++ b/src/Application/Commands/PullIndividualCampaignFromSF.php
@@ -28,6 +28,7 @@ class PullIndividualCampaignFromSF extends LockingCommand
         private Environment $environment,
         private CampaignRepository $campaignRepository,
         private FundRepository $fundRepository,
+        private \DateTimeImmutable $now,
     ) {
         parent::__construct();
     }
@@ -66,7 +67,7 @@ class PullIndividualCampaignFromSF extends LockingCommand
             $output->writeln("Campaign {$this->campaignFullName($campaign)} not found, pulled from SF");
         }
 
-        $this->fundRepository->pullForCampaign($campaign);
+        $this->fundRepository->pullForCampaign($campaign, $this->now);
         $output->writeln("Fund data updated for campaign " . $this->campaignFullName($campaign));
 
         return 0;

--- a/src/Application/Commands/PullMetaCampaignFromSF.php
+++ b/src/Application/Commands/PullMetaCampaignFromSF.php
@@ -55,7 +55,7 @@ class PullMetaCampaignFromSF extends LockingCommand
         foreach ($campaigns as $campaign) {
             $i++;
             $output->writeln("Pulling funds for ($i of $total) '{$campaign->getCampaignName()}'");
-            $this->fundRepository->pullForCampaign($campaign);
+            $this->fundRepository->pullForCampaign($campaign, $this->now);
         }
 
         $output->writeln("Fetched $total campaigns total from Salesforce for '$metaCampaginSlug->slug'");

--- a/src/Application/Commands/UpdateCampaigns.php
+++ b/src/Application/Commands/UpdateCampaigns.php
@@ -27,7 +27,8 @@ class UpdateCampaigns extends LockingCommand
         /** @var EntityManager|EntityManagerInterface $entityManager */
         private EntityManagerInterface $entityManager,
         private FundRepository $fundRepository,
-        private LoggerInterface $logger
+        private LoggerInterface $logger,
+        private \DateTimeImmutable $now,
     ) {
         parent::__construct();
     }
@@ -122,7 +123,7 @@ EOT
     protected function pull(Campaign $campaign, OutputInterface $output): void
     {
         $this->campaignRepository->updateFromSf($campaign);
-        $this->fundRepository->pullForCampaign($campaign);
+        $this->fundRepository->pullForCampaign($campaign, $this->now);
         $output->writeln('Updated campaign ' . $campaign->getSalesforceId());
     }
 }

--- a/src/Domain/CampaignRepository.php
+++ b/src/Domain/CampaignRepository.php
@@ -13,6 +13,7 @@ use MatchBot\Client;
 use MatchBot\Client\NotFoundException;
 use MatchBot\Domain\DomainException\DomainCurrencyMustNotChangeException;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Clock\ClockInterface;
 
 use function is_string;
 use function trim;
@@ -26,6 +27,8 @@ use function trim;
 class CampaignRepository extends SalesforceReadProxyRepository
 {
     private FundRepository $fundRepository; // @phpstan-ignore property.uninitialized
+
+    private ClockInterface $clock;  // @phpstan-ignore property.uninitialized
 
     /**
      * Gets campaigns that it is particular important matchbot has up-to-date information about.
@@ -288,7 +291,7 @@ class CampaignRepository extends SalesforceReadProxyRepository
 
         if ($count === 0) {
             $campaign = $this->pullNewFromSf($campaignId);
-            $this->fundRepository->pullForCampaign($campaign);
+            $this->fundRepository->pullForCampaign($campaign, $this->clock->now());
         }
     }
 
@@ -410,6 +413,11 @@ class CampaignRepository extends SalesforceReadProxyRepository
         \assert($count >= 0);
 
         return $count;
+    }
+
+    public function setClock(ClockInterface $clock): void
+    {
+        $this->clock = $clock;
     }
 
     /**

--- a/src/Domain/DonationService.php
+++ b/src/Domain/DonationService.php
@@ -175,7 +175,7 @@ class DonationService
                 $this->logger->warning("Unexpected individual campaign {$campaign->getSalesforceId()} pulled from SF - should have been prewarmed");
             }
 
-            $this->fundRepository->pullForCampaign($campaign);
+            $this->fundRepository->pullForCampaign($campaign, $this->clock->now());
 
             $this->entityManager->flush();
 

--- a/src/Domain/SalesforceReadProxy.php
+++ b/src/Domain/SalesforceReadProxy.php
@@ -17,12 +17,9 @@ abstract class SalesforceReadProxy extends SalesforceProxy
     #[ORM\Column(nullable: true)]
     protected ?DateTime $salesforceLastPull = null;
 
-    /**
-     * @param DateTime $salesforceLastPull
-     */
-    public function setSalesforceLastPull(DateTime $salesforceLastPull): void
+    public function setSalesforceLastPull(\DateTimeInterface $salesforceLastPull): void
     {
-        $this->salesforceLastPull = $salesforceLastPull;
+        $this->salesforceLastPull = DateTime::createFromInterface($salesforceLastPull);
     }
 
     public function getSalesforceLastPull(): ?\DateTimeImmutable

--- a/tests/Application/Commands/UpdateCampaignsTest.php
+++ b/tests/Application/Commands/UpdateCampaignsTest.php
@@ -15,6 +15,7 @@ use MatchBot\Domain\CampaignRepository;
 use MatchBot\Domain\FundRepository;
 use MatchBot\Domain\Salesforce18Id;
 use MatchBot\Tests\TestCase;
+use Prophecy\Argument;
 use Psr\Container\ContainerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -22,6 +23,14 @@ use Symfony\Component\Lock\LockFactory;
 
 class UpdateCampaignsTest extends TestCase
 {
+    private \DateTimeImmutable $now;
+
+    #[\Override]
+    public function setUp(): void
+    {
+        $this->now = new \DateTimeImmutable('2020-01-01T00:00:00z');
+    }
+
     public function testSingleUpdateSuccess(): void
     {
         $campaign = TestCase::someCampaign(sfId: Salesforce18Id::ofCampaign('SOMeCAMPaIGNIdXXXX'));
@@ -32,13 +41,14 @@ class UpdateCampaignsTest extends TestCase
         $campaignRepoProphecy->updateFromSf($campaign)->shouldBeCalledOnce();
 
         $fundRepoProphecy = $this->prophesize(FundRepository::class);
-        $fundRepoProphecy->pullForCampaign($campaign)->shouldBeCalledOnce();
+        $fundRepoProphecy->pullForCampaign($campaign, $this->now)->shouldBeCalledOnce();
 
         $command = new UpdateCampaigns(
             $campaignRepoProphecy->reveal(),
             $this->getContainer()->get(EntityManagerInterface::class),
             $fundRepoProphecy->reveal(),
             new NullLogger(),
+            $this->now,
         );
         $command->setLockFactory(new LockFactory(new AlwaysAvailableLockStore()));
         $command->setLogger(new NullLogger());
@@ -69,13 +79,14 @@ class UpdateCampaignsTest extends TestCase
         $campaignRepoProphecy->updateFromSf($campaign)->willThrow(NotFoundException::class)->shouldBeCalledOnce();
 
         $fundRepoProphecy = $this->prophesize(FundRepository::class);
-        $fundRepoProphecy->pullForCampaign($campaign)->shouldNotBeCalled(); // Exception reached before this call
+        $fundRepoProphecy->pullForCampaign($campaign, $this->now)->shouldNotBeCalled(); // Exception reached before this call
 
         $command = new UpdateCampaigns(
             $campaignRepoProphecy->reveal(),
             $this->getContainer()->get(EntityManagerInterface::class),
             $fundRepoProphecy->reveal(),
             new NullLogger(),
+            $this->now
         );
         $command->setLockFactory(new LockFactory(new AlwaysAvailableLockStore()));
         $command->setLogger(new NullLogger());
@@ -113,13 +124,14 @@ class UpdateCampaignsTest extends TestCase
             ->shouldBeCalledTimes(2);
 
         $fundRepoProphecy = $this->prophesize(FundRepository::class);
-        $fundRepoProphecy->pullForCampaign($campaign)->shouldNotBeCalled(); // Exception reached before this call
+        $fundRepoProphecy->pullForCampaign($campaign, $this->now)->shouldNotBeCalled(); // Exception reached before this call
 
         $command = new UpdateCampaigns(
             $campaignRepoProphecy->reveal(),
             $this->getContainer()->get(EntityManagerInterface::class),
             $fundRepoProphecy->reveal(),
             new NullLogger(),
+            $this->now
         );
         $command->setLockFactory(new LockFactory(new AlwaysAvailableLockStore()));
         $command->setLogger(new NullLogger());
@@ -171,13 +183,14 @@ class UpdateCampaignsTest extends TestCase
 
         $fundRepoProphecy = $this->prophesize(FundRepository::class);
         // On retry, this should succeed
-        $fundRepoProphecy->pullForCampaign($campaign)->shouldBeCalledOnce();
+        $fundRepoProphecy->pullForCampaign($campaign, $this->now)->shouldBeCalledOnce();
 
         $command = new UpdateCampaigns(
             $campaignRepo,
             $this->getContainer()->get(EntityManagerInterface::class),
             $fundRepoProphecy->reveal(),
             new NullLogger(),
+            $this->now
         );
         $command->setLockFactory(new LockFactory(new AlwaysAvailableLockStore()));
         $command->setLogger(new NullLogger());
@@ -209,13 +222,14 @@ class UpdateCampaignsTest extends TestCase
         $campaignRepoProphecy->updateFromSf($campaign)->shouldBeCalledOnce();
 
         $fundRepoProphecy = $this->prophesize(FundRepository::class);
-        $fundRepoProphecy->pullForCampaign($campaign)->shouldBeCalledOnce();
+        $fundRepoProphecy->pullForCampaign($campaign, $this->now)->shouldBeCalledOnce();
 
         $command = new UpdateCampaigns(
             $campaignRepoProphecy->reveal(),
             $this->getContainer()->get(EntityManagerInterface::class),
             $fundRepoProphecy->reveal(),
             new NullLogger(),
+            $this->now
         );
         $command->setLockFactory(new LockFactory(new AlwaysAvailableLockStore()));
         $command->setLogger(new NullLogger());

--- a/tests/Domain/DonationServiceTest.php
+++ b/tests/Domain/DonationServiceTest.php
@@ -373,7 +373,7 @@ class DonationServiceTest extends TestCase
         $campaignRepoProphecy->pullNewFromSf(Salesforce18Id::ofCampaign(self::CAMPAIGN_ID))
             ->willReturn($dummyCampaign);
 
-        $fundRepositoryProphecy->pullForCampaign(Argument::type(Campaign::class))->shouldBeCalled();
+        $fundRepositoryProphecy->pullForCampaign(Argument::type(Campaign::class), Argument::type(\DateTimeImmutable::class))->shouldBeCalled();
 
         $createPayload = new DonationCreate(
             currencyCode: 'GBP',

--- a/tests/Domain/FundRepositoryTest.php
+++ b/tests/Domain/FundRepositoryTest.php
@@ -23,6 +23,15 @@ use Psr\Log\NullLogger;
 class FundRepositoryTest extends TestCase
 {
     public const string CAMPAIGN_SF_ID = 'SFFaKEID987XXxXXXX';
+    private \DateTimeImmutable $now;
+
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->now = new \DateTimeImmutable('2020-01-01T00:00:00z'); // specific date doesn't matter for now.
+    }
 
     public function testPull(): void
     {
@@ -96,7 +105,7 @@ class FundRepositoryTest extends TestCase
 
         $campaign = TestCase::someCampaign(sfId: Salesforce18Id::ofCampaign(self::CAMPAIGN_SF_ID));
 
-        $repo->pullForCampaign($campaign);
+        $repo->pullForCampaign($campaign, $this->now);
 
         $this->assertInstanceOf(CampaignFunding::class, $campaignFunding);
         $this->assertInstanceOf(\DateTime::class, $campaignFunding->getCreatedDate());
@@ -145,7 +154,7 @@ class FundRepositoryTest extends TestCase
 
         $campaign = TestCase::someCampaign(sfId: Salesforce18Id::ofCampaign(self::CAMPAIGN_SF_ID));
 
-        $repo->pullForCampaign($campaign);
+        $repo->pullForCampaign($campaign, $this->now);
     }
 
     public function testPullForCampaignAllExistingWithBalanceUpdated(): void
@@ -202,7 +211,7 @@ class FundRepositoryTest extends TestCase
 
         $campaign = TestCase::someCampaign(sfId: Salesforce18Id::ofCampaign(self::CAMPAIGN_SF_ID));
 
-        $repo->pullForCampaign($campaign);
+        $repo->pullForCampaign($campaign, $this->now);
     }
 
     /**
@@ -252,7 +261,7 @@ class FundRepositoryTest extends TestCase
 
         $campaign = TestCase::someCampaign(sfId: Salesforce18Id::ofCampaign(self::CAMPAIGN_SF_ID));
 
-        $repo->pullForCampaign($campaign);
+        $repo->pullForCampaign($campaign, $this->now);
     }
 
     private function getExistingFund(bool $shared): Fund
@@ -264,7 +273,7 @@ class FundRepositoryTest extends TestCase
             fundType: FundType::ChampionFund
         );
         $existingFund->setId($shared ? 456456 : 123123);
-        $existingFund->setSalesforceLastPull(new \DateTime());
+        $existingFund->setSalesforceLastPull($this->now);
 
         return $existingFund;
     }


### PR DESCRIPTION
Currently matchbot doesn't generally know about funds much or at all before the opening date, so it wouldn't be concerned about reduction in funds. But in future MB will know about the campaigns much earlier which means it will be able to see fund reductions. Reducing funds if necessary before a campaign opens is OK.