### PR TITLE
`doctrine:delete-and-recreate` – Add missing dev Doctrine migration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -130,6 +130,7 @@
         "doctrine:delete-and-recreate": [
             "@doctrine:cache:clear",
             "doctrine orm:schema-tool:drop --full-database --force",
+            "@doctrine:migrate",
             "./matchbot matchbot:write-schema-files",
             "./matchbot matchbot:create-fictional-data --verbose",
             "MYSQL_SCHEMA=matchbot_test vendor/bin/doctrine orm:schema-tool:drop --full-database --force",


### PR DESCRIPTION
I don't think it is possible to reset and get a usable DB without this, as we use the `:drop` command but not the one that tries to introspect to create schemas without migrations