### PR TITLE
MAT-405: Fix metacampaign slugs with spurious " from previous migration

### DIFF
--- a/src/Migrations/Version20250708160130.php
+++ b/src/Migrations/Version20250708160130.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250708160130 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Remove spurious quotation marks from metacampaign slugs';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            UPDATE Campaign SET metaCampaignSlug = REPLACE(metaCampaignSlug, '"', '') WHERE metaCampaignSlug is not null;
+            SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        throw new \Exception('no going back');
+    }
+}


### PR DESCRIPTION
This is fixing a mistake in the previous migration https://github.com/thebiggive/matchbot/blob/4edd7dd4ae18e8d324d978786b4b3ff0d7dba458/src/Migrations/Version20250605113222.php#L20 - `->` should have been `->>` to tell MySQL not to add quotes.

https://stackoverflow.com/a/42095228/2526181