### PR TITLE
MAT-405 – fix Metacampaign summary length

### DIFF
--- a/schema/MetaCampaign.sql
+++ b/schema/MetaCampaign.sql
@@ -12,7 +12,7 @@ CREATE TABLE `MetaCampaign` (
   `currency` varchar(255) NOT NULL,
   `status` varchar(255) DEFAULT NULL,
   `hidden` tinyint(1) NOT NULL,
-  `summary` varchar(255) DEFAULT NULL,
+  `summary` varchar(1000) DEFAULT NULL,
   `bannerURI` varchar(255) DEFAULT NULL,
   `startDate` datetime NOT NULL COMMENT '(DC2Type:datetime_immutable)',
   `endDate` datetime NOT NULL COMMENT '(DC2Type:datetime_immutable)',

--- a/src/Domain/MetaCampaign.php
+++ b/src/Domain/MetaCampaign.php
@@ -53,7 +53,7 @@ class MetaCampaign extends SalesforceReadProxy
     #[ORM\Column()]
     private bool $hidden;
 
-    #[ORM\Column(nullable: true)]
+    #[ORM\Column(length: 1_000, nullable: true)]
     private ?string $summary;
 
     #[ORM\Column(nullable: true)]

--- a/src/Migrations/Version20250709090013.php
+++ b/src/Migrations/Version20250709090013.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Make MetaCampaign.summary long enough for existing records.
+ */
+final class Version20250709090013 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Make MetaCampaign.summary long enough for existing records';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE MetaCampaign CHANGE summary summary VARCHAR(1000) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE MetaCampaign CHANGE summary summary VARCHAR(255) DEFAULT NULL');
+    }
+}


### PR DESCRIPTION
We know 255 characters was insufficient. I suspect 500 would be OK for meta-campaigns but going with 1,000 for now to be reasonably safe.

Technically the Salesforce field supports 130,000 but it's also used by charity campaigns including imported ones, so I don't know if we can very quickly decide a sensible lower limit or enforce one at source for meta-campaigns. As far as I can see we don't have a dedicated equivalent to this field for charity campaigns, so can probably rely on JSON typed fields being much longer and assume we won't have an equivalent bug for those.