### PR TITLE
DON-1120: Tell frontend to use new banner style when displaying `local-test` metacampaign only.

### DIFF
--- a/src/Application/HttpModels/MetaCampaign.php
+++ b/src/Application/HttpModels/MetaCampaign.php
@@ -29,6 +29,8 @@ readonly class MetaCampaign
         /** Approved participating campaign count*/
         public int $campaignCount,
         public bool $usesSharedFunds,
+        /** Whether the page for this campaign uses the new style of banner display created in ticket DON-1120 */
+        public bool $useDon1120Banner = false,
     ) {
     }
 }

--- a/src/Domain/CampaignService.php
+++ b/src/Domain/CampaignService.php
@@ -81,6 +81,11 @@ class CampaignService
         $salesforceId = $metaCampaign->getSalesforceId();
         Assertion::notNull($salesforceId);
 
+        $usesDon1120Banner = match ($metaCampaign->getSlug()->slug) {
+            'local-test' => true,
+            default => false,
+        };
+
         return new MetaCampaignHttpModel(
             id: $salesforceId,
             title: $metaCampaign->getTitle(),
@@ -98,6 +103,7 @@ class CampaignService
             matchFundsTotal: $metaCampaign->getMatchFundsTotal()->toMajorUnitFloat(),
             campaignCount: $this->campaignRepository->countCampaignsInMetaCampaign($metaCampaign),
             usesSharedFunds: $metaCampaign->usesSharedFunds(),
+            useDon1120Banner: $usesDon1120Banner,
         );
     }
 


### PR DESCRIPTION
This allows testing the new banner style on local machines as we develop it. In future we'll apply the same to one and eventually all metacampaigns on staging and then production.