### PR TITLE
Phase out `x_` prefix for isMetaCampaign

### DIFF
--- a/src/Application/Actions/Campaigns/Get.php
+++ b/src/Application/Actions/Campaigns/Get.php
@@ -49,7 +49,7 @@ class Get extends Action
 
             try {
                 $campaign = $this->salesforceCampaignClient->getById($sfId->value, false);
-                if ($campaign['x_isMetaCampaign']) {
+                if ($campaign['isMetaCampaign']) {
                     // throwing manually for now. When MAT-405 is done and we serve only from matchbot DB metcampaigns will not be in the same
                     // DB table so this sort of request will naturally generate a 404 response.
                     $this->logger->warning("Metacampaign requested by ID {$sfId->value}, should request via slug {$campaign['slug']} at dedicated metacampaign page instead");

--- a/src/Application/Actions/Campaigns/GetEarlyPreview.php
+++ b/src/Application/Actions/Campaigns/GetEarlyPreview.php
@@ -47,7 +47,7 @@ class GetEarlyPreview extends Action
         );
 
         $campaignData = $this->salesforceCampaignClient->getById($sfId->value, false);
-        if ($campaignData['x_isMetaCampaign']) {
+        if ($campaignData['isMetaCampaign']) {
             throw new HttpNotFoundException($request);
         }
 

--- a/src/Application/Actions/Campaigns/Put.php
+++ b/src/Application/Actions/Campaigns/Put.php
@@ -77,7 +77,7 @@ class Put extends Action
 
         Assertion::eq($campaignData['id'], $args['salesforceId']);
 
-        $isMetaCampaign = $campaignData['x_isMetaCampaign'];
+        $isMetaCampaign = $campaignData['isMetaCampaign'];
 
         if ($isMetaCampaign) {
             /** @var Salesforce18Id<MetaCampaign> $campaignSfId */

--- a/src/Application/Actions/Campaigns/UpsertMany.php
+++ b/src/Application/Actions/Campaigns/UpsertMany.php
@@ -88,7 +88,7 @@ class UpsertMany extends Action
                 $campaignData['id'] ?? throw new HttpBadRequestException($request)
             );
 
-            $isMetaCampaign = $campaignData['x_isMetaCampaign'];
+            $isMetaCampaign = $campaignData['isMetaCampaign'];
 
             if ($isMetaCampaign) {
                 /** @var Salesforce18Id<MetaCampaign> $campaignSfId */

--- a/src/Client/Campaign.php
+++ b/src/Client/Campaign.php
@@ -93,7 +93,6 @@ use MatchBot\Domain\MetaCampaignSlug;
  *     alternativeFundUse: ?string,
  *     additionalImageUris: list<array{order: int, uri: string}>,
  *     isMetaCampaign: ?bool,
- *     x_isMetaCampaign: ?bool,
  *     isEmergencyIMF: bool,
  *     slug: ?string,
  *     campaignFamily: ?string,

--- a/src/Domain/Campaign.php
+++ b/src/Domain/Campaign.php
@@ -292,7 +292,7 @@ class Campaign extends SalesforceReadProxy
         }
 
         Assertion::false(
-            $campaignData['x_isMetaCampaign'] ?? false,
+            $campaignData['isMetaCampaign'] ?? false,
             'Cannot create Charity Campaign using meta campaign data'
         );
 

--- a/src/Domain/MetaCampaign.php
+++ b/src/Domain/MetaCampaign.php
@@ -197,7 +197,7 @@ class MetaCampaign extends SalesforceReadProxy
      */
     public function updateFromSfData(array $data): void
     {
-        Assertion::true($data['x_isMetaCampaign'] ?? true);
+        Assertion::true($data['isMetaCampaign'] ?? true);
 
         $bannerUri = $data['bannerUri'];
         $isRegularGiving = $data['isRegularGiving'] ?? null;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -57,7 +57,6 @@ class TestCase extends PHPUnitTestCase
     public const array CAMPAIGN_FROM_SALESFORCE = [
         'id' => 'a05xxxxxxxxxxxxxxx',
         'isMetaCampaign' => false,
-        'x_isMetaCampaign' => false,
         'aims' => [0 => 'First Aim'],
         'ready' => true,
         'title' => 'Save Matchbot',
@@ -146,7 +145,6 @@ class TestCase extends PHPUnitTestCase
     public const array META_CAMPAIGN_FROM_SALESFORCE = [
         'id' => 'a05xxxxxxxxxxxxxxx',
         'isMetaCampaign' => true,
-        'x_isMetaCampaign' => true,
         'ready' => true,
         'title' => 'This is a meta campaign',
         'video' => null,


### PR DESCRIPTION
Should be only in the list of ignored fields (where I think it needs to stay until SF switches over) after this