### PR TITLE
BG2-2919: Don't generate alarm when failing to load a campaign preview

### DIFF
--- a/src/Client/Campaign.php
+++ b/src/Client/Campaign.php
@@ -132,7 +132,8 @@ class Campaign extends Common
                 return $campaignResponse;
             } catch (TransferException $exception) {
                 if ($exception instanceof RequestException && $exception->getResponse()?->getStatusCode() === 404) {
-                    // may be safely caught in sandboxes
+                    // may be safely caught in sandboxes, and when the campaign ID was sent by a client who may have an ID that doesn't exist
+                    // or isn't working.
                     throw new NotFoundException(sprintf('Campaign ID %s not found in SF', $id));
                 }
 


### PR DESCRIPTION
This may have been a long standing issue that some campaign previews are not available in SF when people expect them, but now generates more noise since matchbot is involved.