### PR TITLE
MAT-441 – fix & expand Mandate-pushing queue delay stamps

### DIFF
--- a/src/Application/Persistence/RegularGivingMandateEventSubscriber.php
+++ b/src/Application/Persistence/RegularGivingMandateEventSubscriber.php
@@ -3,17 +3,15 @@
 namespace MatchBot\Application\Persistence;
 
 use Doctrine\Common\EventSubscriber;
-use Doctrine\ORM\Event\PostFlushEventArgs;
 use Doctrine\ORM\Event\PostPersistEventArgs;
 use Doctrine\ORM\Event\PostUpdateEventArgs;
 use Doctrine\ORM\Events;
 use MatchBot\Application\Assertion;
 use MatchBot\Application\Messenger\MandateUpserted;
-use MatchBot\Domain\DonorAccount;
 use MatchBot\Domain\DonorAccountRepository;
+use MatchBot\Domain\MandateStatus;
 use MatchBot\Domain\RegularGivingMandate;
 use Psr\Container\ContainerInterface;
-use Stripe\Mandate;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\RoutableMessageBus;
 use Symfony\Component\Messenger\Stamp\DelayStamp;
@@ -76,7 +74,13 @@ class RegularGivingMandateEventSubscriber implements EventSubscriber
 
         // 3s delay when Active to reduce SF record access issues around activation time, when we typically
         // push for Create then Update in fairly quick succession.
-        $stamps = $mandate->getStatus()->apiName() === Mandate::STATUS_ACTIVE ? [new DelayStamp(3_000)] : [];
+        // Slightly longer delay for Cancelled because of contention on associated Contacts. We saw a
+        // record lock issue (different from the upsert dupe one) when donor cancelled in Staging once.
+        $stamps = match ($mandate->getStatus()) {
+            MandateStatus::Active => [new DelayStamp(3_000)],
+            MandateStatus::Cancelled => [new DelayStamp(6_000)],
+            default => [],
+        };
         $this->bus->dispatch(new Envelope(MandateUpserted::fromMandate($mandate, $donor), $stamps));
     }
 }


### PR DESCRIPTION
* Fix comparison to our Active status
* Add a delay for Cancelled status too, to fix a similar but distinct record contention issue