### PR TITLE
Replace stats error message with info

### DIFF
--- a/src/Application/Commands/UpdateCampaignDonationStats.php
+++ b/src/Application/Commands/UpdateCampaignDonationStats.php
@@ -109,7 +109,7 @@ class UpdateCampaignDonationStats extends LockingCommand
             );
         } catch (AssertionFailedException $exception) {
             $errorMessage = "Error updating statistics for campaign ID {$campaignId} ({$campaign->getSalesforceId()}): {$exception->getMessage()}";
-            $this->logger->error($errorMessage);
+            $this->logger->info($errorMessage);
             $output->writeln("<error>$errorMessage</error>");
             return false; // Not re-throwing for now so that we can get a complete list of campaigns with issues in one go.
         }


### PR DESCRIPTION
Afaik the stats are not yet really used for anything in production, and the error is very noisy, so replacing it with an info.