### PR TITLE
MAT-431: Allow campaigns to have USD currency instead of only GBP

### DIFF
--- a/src/Domain/Currency.php
+++ b/src/Domain/Currency.php
@@ -22,7 +22,7 @@ enum Currency: string
 
         // other currencies have some tests but are not fully supported. USD is also not fully tested but we have considered
         // USA a little more and have data relating to that in prod.
-        if (! defined('RUNNING_UNIT_TESTS') && ! \in_array($isoCode, ['GBP', 'USD'])) {
+        if (! defined('RUNNING_UNIT_TESTS') && ! \in_array($isoCode, ['GBP', 'USD'], true)) {
             throw new \UnexpectedValueException("Unexpected Currency ISO Code " . $isoCode);
         }
 

--- a/src/Domain/Currency.php
+++ b/src/Domain/Currency.php
@@ -20,8 +20,9 @@ enum Currency: string
         Assertion::alnum($isoCode);
         $isoCode = strtoupper($isoCode);
 
-        // other currencies have some tests but are not fully supported
-        if (! defined('RUNNING_UNIT_TESTS') && $isoCode !== 'GBP') {
+        // other currencies have some tests but are not fully supported. USD is also not fully tested but we have considered
+        // USA a little more and have data relating to that in prod.
+        if (! defined('RUNNING_UNIT_TESTS') && ! \in_array($isoCode, ['GBP', 'USD'])) {
             throw new \UnexpectedValueException("Unexpected Currency ISO Code " . $isoCode);
         }
 
@@ -36,6 +37,7 @@ enum Currency: string
     {
         return match ($this) {
             self::GBP => '£',
+            self::USD => '$',
             default => throw new \Exception("Unexpected currency " . $this->isoCode()),
         };
     }


### PR DESCRIPTION
There are a few USD campaigns in our live SF, although none have been opened so far or are currently planned to be opened any time soon.