### PR TITLE
DON-1136:  Prevent donations from being confirmed without expected match funds

### DIFF
--- a/app/routes.php
+++ b/app/routes.php
@@ -42,6 +42,7 @@ return function (App $app) {
             $group->get('', Donations\Get::class);
             $group->put('', Donations\Update::class); // Includes cancelling.
             $group->post('/confirm', Donations\Confirm::class);
+            $group->post('/remove-matching-expectation', Donations\RemoveMatchingExpecation::class);
         })
             ->add(DonationPublicAuthMiddleware::class);
 

--- a/integrationTests/DonationPersistenceTest.php
+++ b/integrationTests/DonationPersistenceTest.php
@@ -101,6 +101,8 @@ class DonationPersistenceTest extends IntegrationTest
             'payoutSuccessful' => 0,
             'paymentCard_brand' => null,
             'paymentCard_country' => null,
+            'expectedMatchAmount_amountInPence' => 0,
+            'expectedMatchAmount_currency' => 'GBP',
             'updatedAt' => '1970-01-01',
             'createdAt' => '1970-01-01'
         ];

--- a/schema/Donation.sql
+++ b/schema/Donation.sql
@@ -59,6 +59,8 @@ CREATE TABLE `Donation` (
   `payoutSuccessful` tinyint(1) DEFAULT NULL,
   `paymentCard_brand` varchar(255) DEFAULT NULL,
   `paymentCard_country` varchar(255) DEFAULT NULL,
+  `expectedMatchAmount_amountInPence` int NOT NULL,
+  `expectedMatchAmount_currency` varchar(3) NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `UNIQ_C893E3F6D17F50A6` (`uuid`),
   UNIQUE KEY `UNIQ_C893E3F6C2F43114` (`transactionId`),

--- a/src/Application/Actions/Donations/RemoveMatchingExpecation.php
+++ b/src/Application/Actions/Donations/RemoveMatchingExpecation.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Application\Actions\Donations;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Laminas\Diactoros\Response\JsonResponse;
+use MatchBot\Application\Actions\Action;
+use MatchBot\Application\Messenger\DonationUpserted;
+use MatchBot\Client\NotFoundException;
+use MatchBot\Domain\Donation;
+use MatchBot\Domain\DonationRepository;
+use MatchBot\Domain\Money;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Log\LoggerInterface;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * Records that the donor no longer expects any match funds to be used for their donation.
+ * This allows matchbot to safely confirm the donation even if match funds have expired.
+ */
+class RemoveMatchingExpecation extends Action
+{
+    public function __construct(
+        LoggerInterface $logger,
+        private DonationRepository $donationRepository,
+        private EntityManagerInterface $entityManager,
+    ) {
+        parent::__construct($logger);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    #[\Override]
+    protected function action(Request $request, Response $response, array $args): Response
+    {
+        \assert(isset($args['donationId']));
+        $donation = $this->donationRepository->findAndLockOneByUUID(Uuid::fromString($args['donationId']));
+        if (!$donation) {
+            throw new NotFoundException();
+        }
+
+        $donation->setExpectedMatchAmount(Money::zero($donation->currency()));
+
+        $this->entityManager->flush();
+
+        $this->logger->info(
+            sprintf(
+                'Removed matching expectation for donation %s',
+                $donation->getUuid()->toString()
+            )
+        );
+
+        return new JsonResponse([
+            'status' => 'success',
+            'donation' => $donation->toFrontEndApiModel(),
+        ]);
+    }
+}

--- a/src/Application/Matching/Allocator.php
+++ b/src/Application/Matching/Allocator.php
@@ -6,12 +6,15 @@ namespace MatchBot\Application\Matching;
 
 use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\ORM\EntityManagerInterface;
+use MatchBot\Application\Actions\Donations\Confirm;
 use MatchBot\Application\Assertion;
 use MatchBot\Domain\CampaignFunding;
 use MatchBot\Domain\CampaignFundingRepository;
 use MatchBot\Domain\Donation;
 use MatchBot\Domain\FundingWithdrawal;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Lock\Exception\LockConflictedException;
+use Symfony\Component\Lock\LockFactory;
 
 class Allocator
 {
@@ -20,6 +23,7 @@ class Allocator
         private EntityManagerInterface $entityManager,
         private LoggerInterface $logger,
         private CampaignFundingRepository $campaignFundingRepository,
+        private LockFactory $lockFactory,
     ) {
     }
 
@@ -102,11 +106,14 @@ class Allocator
      * @psalm-internal MatchBot\Domain
      * @param Donation $donation
      * @throws TerminalLockException
+     * @throws LockConflictedException in case there is a confirmation or pre-auth attempt happening at the same time.
      */
     public function releaseMatchFunds(Donation $donation): void
     {
         $startTime = microtime(true);
         try {
+            $lock = $this->lockFactory->createLock(Confirm::donationConfirmLockKey($donation), autoRelease: true);
+            $lock->acquire(blocking: false);
             $totalAmountReleased = $this->adapter->releaseAllFundsForDonation($donation);
             $this->entityManager->flush();
             $endTime = microtime(true);
@@ -123,6 +130,14 @@ class Allocator
                 " after {$waitTime}s: {$exception->getMessage()}"
             );
             throw $exception; // Re-throw exception after logging the details if not recoverable
+        } catch (LockConflictedException $conflictedException) {
+            // presumably a conflict because someone is trying to confirm the donation at the same moment we're trying
+            // to release its match funds. Lets do nothing and let them confirm. Although this shouldn't happen as the
+            // FE should have predicted that the lock would expire.
+            $this->logError(
+                'Match release error: ID ' . $donation->getUuid()->toString() . 'attempting to release funds while confirmation in progress'
+            );
+            throw $conflictedException;
         }
 
         $this->logInfo("Taking from ID {$donation->getUuid()} released match funds totalling {$totalAmountReleased}");

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -127,6 +127,17 @@ class Donation extends SalesforceWriteProxy
     #[ORM\Column(type: 'decimal', precision: 18, scale: 2)]
     protected readonly string $amount;
 
+    /**
+     * @var Money Amount of match funds the donor expects to be allocated to this donation. Can vary between zero
+     * and the donation amount. (And perhaps more in future if any funders want to match on a more-generous-than-121
+     * basis.) If the matchFundsReserved is less than this then the donation should not be confirmed.
+     *
+     * Ignore values on donations from before August 2025 deployment.
+     *
+     * @psalm-suppress UnusedProperty - will be used soon.
+     */
+    #[ORM\Embedded()]
+    private Money $expectedMatchAmount;
 
     /**
      * Total amount paid by donor - recorded from the Stripe charge, and reduced to reflect the new total
@@ -455,6 +466,11 @@ class Donation extends SalesforceWriteProxy
         }
 
         $this->amount = $amount;
+
+        /** The donor shouldn't definitively expect any match funds unless we actually reserve funds for them which will be done after
+         * the donation is constructed but before its first returned to the browser */
+        $this->expectedMatchAmount = Money::zero($this->currency());
+
         $this->paymentMethodType = $paymentMethodType;
         $this->createdNow(); // Mimic ORM persistence hook attribute, calling its fn explicitly instead.
         $this->setPsp('stripe');
@@ -1831,7 +1847,7 @@ class Donation extends SalesforceWriteProxy
      */
     private function assertionsForConfirmOrPreAuth(): \Assert\LazyAssertion
     {
-        return Assert::lazy()
+        $assertion = Assert::lazy()
             ->that($this->donorFirstName, 'donorFirstName')->notNull('Missing Donor First Name')
             ->that($this->donorLastName, 'donorLastName')->notNull('Missing Donor Last Name')
             ->that($this->donorEmailAddress)->notNull('Missing Donor Email Address')
@@ -1845,6 +1861,14 @@ class Donation extends SalesforceWriteProxy
                 "Donation status is '{$this->donationStatus->value}', must be " .
                 "'Pending' or 'PreAuthorized' to confirm payment"
             );
+
+        if (! Environment::current()->isProduction()) {
+            // we can't assert this in prod just yet because we have to deploy and update to FE to have it tell us when the donor no longer
+            // expects their donation to be matched, and give time for any pending donations from before then to be confirmed or cancelled.
+            $assertion->that($this->matchedAmount()->amountInPence, 'matchedAmount')->greaterOrEqualThan($this->expectedMatchAmount->amountInPence);
+        }
+
+        return $assertion;
     }
 
     /**
@@ -2044,5 +2068,10 @@ class Donation extends SalesforceWriteProxy
         }
 
         return new PaymentCard($this->paymentCardBrand, Country::fromEnum($this->paymentCardCountry));
+    }
+
+    public function setExpectedMatchAmount(Money $expectedMatchAmount): void
+    {
+        $this->expectedMatchAmount = $expectedMatchAmount;
     }
 }

--- a/src/Migrations/Version20250806170146.php
+++ b/src/Migrations/Version20250806170146.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250806170146 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add Donation.expectedMatchAmount';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE Donation ADD expectedMatchAmount_amountInPence INT NOT NULL DEFAULT 0, ADD expectedMatchAmount_currency VARCHAR(3) NOT NULL DEFAULT \'GBP\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE Donation DROP expectedMatchAmount_amountInPence, DROP expectedMatchAmount_currency');
+    }
+}

--- a/src/Migrations/Version20250807132901.php
+++ b/src/Migrations/Version20250807132901.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250807132901 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Make donation.expectedMatchAmount non-null as required for an embeddable';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE Donation CHANGE expectedMatchAmount_amountInPence expectedMatchAmount_amountInPence INT NOT NULL, CHANGE expectedMatchAmount_currency expectedMatchAmount_currency VARCHAR(3) NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE Donation CHANGE expectedMatchAmount_amountInPence expectedMatchAmount_amountInPence INT DEFAULT 0 NOT NULL, CHANGE expectedMatchAmount_currency expectedMatchAmount_currency VARCHAR(3) DEFAULT \'GBP\' NOT NULL');
+    }
+}

--- a/tests/Application/Actions/Donations/CancelAllTest.php
+++ b/tests/Application/Actions/Donations/CancelAllTest.php
@@ -28,6 +28,8 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
 use Slim\Exception\HttpUnauthorizedException;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\Store\InMemoryStore;
 
 class CancelAllTest extends TestCase
 {
@@ -193,6 +195,8 @@ class CancelAllTest extends TestCase
         $container->set(CampaignRepository::class, $this->prophesize(CampaignRepository::class)->reveal());
         $container->set(DonorAccountRepository::class, $this->prophesize(DonorAccountRepository::class)->reveal());
         $container->set(FundRepository::class, $this->createStub(FundRepository::class));
+
+        $container->set(LockFactory::class, new LockFactory(new InMemoryStore()));
 
         if ($stripeProphecy !== null) {
             $container->set(Stripe::class, $stripeProphecy->reveal());

--- a/tests/Application/Actions/Donations/ConfirmTest.php
+++ b/tests/Application/Actions/Donations/ConfirmTest.php
@@ -37,6 +37,7 @@ use Stripe\PaymentIntent;
 use Stripe\PaymentMethod;
 use Stripe\StripeObject;
 use Symfony\Component\Clock\MockClock;
+use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Messenger\RoutableMessageBus;
 use Symfony\Component\Notifier\ChatterInterface;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
@@ -84,6 +85,7 @@ class ConfirmTest extends TestCase
             entityManager: $this->entityManagerProphecy->reveal(),
             bus: $messageBusStub,
             clock: new MockClock('2025-01-01'),
+            lockFactory: $this->createStub(LockFactory::class),
             donationService: new DonationService(
                 allocator: $this->createStub(Allocator::class),
                 donationRepository: $this->getDonationRepository(),

--- a/tests/Application/Actions/Donations/UpdateTest.php
+++ b/tests/Application/Actions/Donations/UpdateTest.php
@@ -40,6 +40,8 @@ use Stripe\Exception\UnknownApiErrorException;
 use Stripe\PaymentIntent;
 use Symfony\Component\Clock\ClockInterface;
 use Symfony\Component\Clock\MockClock;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\Store\InMemoryStore;
 
 class UpdateTest extends TestCase
 {
@@ -1634,6 +1636,8 @@ class UpdateTest extends TestCase
         $container->set(CampaignRepository::class, $this->prophesize(CampaignRepository::class)->reveal());
         $container->set(DonorAccountRepository::class, $this->prophesize(DonorAccountRepository::class)->reveal());
         $container->set(ClockInterface::class, new MockClock());
+
+        $container->set(LockFactory::class, new LockFactory(new InMemoryStore()));
     }
 
     /**
@@ -1652,6 +1656,9 @@ class UpdateTest extends TestCase
             ->will(function (array $args): mixed {
                 return $args[0]();
             });
+
+        // We don't need to mock the connection for LockFactory anymore
+        // since we're providing an InMemoryStore directly
 
         $entityManagerProphecy->getRepository(CampaignFunding::class)->willReturn($this->createStub(CampaignFundingRepository::class));
 

--- a/tests/Application/Actions/Hooks/StripePaymentsUpdateTest.php
+++ b/tests/Application/Actions/Hooks/StripePaymentsUpdateTest.php
@@ -31,6 +31,8 @@ use Ramsey\Uuid\Uuid;
 use Stripe\BalanceTransaction;
 use Stripe\Service\BalanceTransactionService;
 use Stripe\StripeClient;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\Store\InMemoryStore;
 use Symfony\Component\Notifier\Bridge\Slack\Block\SlackHeaderBlock;
 use Symfony\Component\Notifier\Bridge\Slack\Block\SlackSectionBlock;
 use Symfony\Component\Notifier\Bridge\Slack\SlackOptions;
@@ -615,6 +617,8 @@ class StripePaymentsUpdateTest extends StripeTest
         $container = parent::getContainer();
         \assert($container instanceof Container);
         $container->set(DonorAccountRepository::class, $this->createStub(DonorAccountRepository::class));
+
+        $container->set(LockFactory::class, new LockFactory(new InMemoryStore()));
 
         return $container;
     }

--- a/tests/Application/Matching/AllocatorTest.php
+++ b/tests/Application/Matching/AllocatorTest.php
@@ -21,6 +21,7 @@ use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Log\NullLogger;
+use Symfony\Component\Lock\LockFactory;
 
 class AllocatorTest extends TestCase
 {
@@ -56,10 +57,11 @@ class AllocatorTest extends TestCase
         );
 
         $this->sut = new Allocator(
-            $matchingAdapter,
-            $this->emProphecy->reveal(),
-            new NullLogger(),
-            $this->campaignFundingsRepositoryProphecy->reveal(),
+            adapter: $matchingAdapter,
+            entityManager: $this->emProphecy->reveal(),
+            logger: new NullLogger(),
+            campaignFundingRepository: $this->campaignFundingsRepositoryProphecy->reveal(),
+            lockFactory: $this->createStub(LockFactory::class),
         );
 
         $this->campaign = \MatchBot\Tests\TestCase::someCampaign();
@@ -320,10 +322,11 @@ class AllocatorTest extends TestCase
         $donation = $this->getTestDonation();
 
         $sut = new Allocator(
-            $matchingAdapterProphecy->reveal(),
-            $this->emProphecy->reveal(),
-            new NullLogger(),
-            $this->campaignFundingsRepositoryProphecy->reveal(),
+            adapter: $matchingAdapterProphecy->reveal(),
+            entityManager: $this->emProphecy->reveal(),
+            logger: new NullLogger(),
+            campaignFundingRepository: $this->campaignFundingsRepositoryProphecy->reveal(),
+            lockFactory: $this->createStub(LockFactory::class)
         );
 
         /** @psalm-suppress InternalMethod */


### PR DESCRIPTION
This will need a three step deploy to prod - first this PR, then something in Frontend to let matchbot know when a donor has accepted loss of their reserved match funds, and finally another change to matchbot to active the blocking of donations that don't have the expected match funds at the time of confirmation.

It works by adding a new field to donations that records the amount of match funds the donor expects to match. This is initially set to whatever match funds we allocate to the donation. If a donor gets an expiry alert and clicks OK then it will be set to zero. When the donor confirms their donation we will check that the match funds allocated are (at least) what they expect.