### PR TITLE
MAT-446 – fix search / list limits

### DIFF
--- a/src/Domain/CampaignRepository.php
+++ b/src/Domain/CampaignRepository.php
@@ -690,6 +690,7 @@ class CampaignRepository extends SalesforceReadProxyRepository
             ->join('campaign.campaignStatistics', 'campaignStatistics')
             ->leftJoin('campaign.campaignFundings', 'campaignFunding')
             ->leftJoin('campaignFunding.fund', 'fund')
+            ->groupBy('campaign.id')
             ->setFirstResult($offset)
             ->setMaxResults($limit);
 


### PR DESCRIPTION
Need to group on Campaign so that left-joined funding links don't break results' size in confusing ways.