### PR TITLE
DON-984: Include metacampaigns in sitemap

### DIFF
--- a/app/routes.php
+++ b/app/routes.php
@@ -28,7 +28,7 @@ use MatchBot\Application\Actions\RegularGivingMandate;
 return function (App $app) {
     $app->get('/ping', Status::class);
 
-    $app->get('/sitemap', Sitemap::class);
+    $app->get('/sitemap', Sitemap::class)->add(SalesforceAuthMiddleware::class);
 
     $app->group('/v1', function (RouteCollectorProxy $versionGroup) {
         // Provides real IP for e.g. rate limiter

--- a/app/routes.php
+++ b/app/routes.php
@@ -28,7 +28,7 @@ use MatchBot\Application\Actions\RegularGivingMandate;
 return function (App $app) {
     $app->get('/ping', Status::class);
 
-    $app->get('/sitemap', Sitemap::class)->add(SalesforceAuthMiddleware::class);
+    $app->get('/sitemap', Sitemap::class)->add(CacheableResponseMiddleware::class);
 
     $app->group('/v1', function (RouteCollectorProxy $versionGroup) {
         // Provides real IP for e.g. rate limiter

--- a/src/Application/Actions/Sitemap.php
+++ b/src/Application/Actions/Sitemap.php
@@ -6,7 +6,9 @@ namespace MatchBot\Application\Actions;
 
 use JetBrains\PhpStorm\Pure;
 use MatchBot\Application\Environment;
+use MatchBot\Application\HttpModels\MetaCampaign;
 use MatchBot\Domain\CampaignRepository;
+use MatchBot\Domain\MetaCampaignRepository;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Log\LoggerInterface;
@@ -21,8 +23,8 @@ class Sitemap extends Action
 {
     #[Pure]
     public function __construct(
-        private CacheInterface $cache,
         private CampaignRepository $campaignRepository,
+        private MetaCampaignRepository $metaCampaignRepository,
         private Environment $environment,
         private \DateTimeImmutable $now,
         LoggerInterface $logger,
@@ -40,61 +42,73 @@ class Sitemap extends Action
 
         // @todo:
         // - add charity pages as well as campaigns.
-        // - add metacampaigns
         // - add some of the most important other pages, e.g. static content. But afaik its not essential for
         //   a sitemap to be comprehensive to be useful
         // - consider if the 100k limit is appropriate.
         // - increase cache duration, maybe explicitly expire cache when content changes. Consider persisting
         // - something that would be cheaper to access than this to make additions to when we add a campaign.
-        // - add integration test
         // - submit sitemap to search engines and/or list in robots.txt
-        $sitemapXml = $this->cache->get('sitemap', function (ItemInterface $cacheItem) {
-            $cacheItem->expiresAfter(60 * 10); // ten minutes
 
-            $xml = new SimpleXMLElement('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>');
-            $campaigns = $this->campaignRepository->search(
-                sortField: 'amountRaised',
-                sortDirection:  'asc',
-                offset: 0,
-                limit: 100_000,
-                status: null,
-                metaCampaignSlug: null,
-                fundSlug: null,
-                jsonMatchInListConditions: [],
-                term:null,
-            );
+        $xml = new SimpleXMLElement('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>');
+        $campaigns = $this->campaignRepository->search(
+            sortField: 'amountRaised',
+            sortDirection:  'asc',
+            offset: 0,
+            limit: 100_000,
+            status: null,
+            metaCampaignSlug: null,
+            fundSlug: null,
+            jsonMatchInListConditions: [],
+            term:null,
+        );
 
-            foreach ($campaigns as $campaign) {
-                $endsInFuture = $campaign->getEndDate() > $this->now;
+        foreach ($campaigns as $campaign) {
+            $endsInFuture = $campaign->getEndDate() > $this->now;
 
-                $changeFreq = $endsInFuture ? 'daily' : 'monthly';
-                if ($campaign->isOpen($this->now)) {
-                    $changeFreq = 'hourly';
-                }
-
-                $this->addUrl(
-                    xml: $xml,
-                    url: $this->environment->publicDonateURLPrefix() . 'campaign/' . $campaign->getSalesforceId(),
-                    updatedAt: \DateTimeImmutable::createFromInterface($campaign->getUpdatedDate()),
-                    changeFreq: $changeFreq,
-                    priority: $endsInFuture ? '0.5' : '0.25',
-                );
-
-                if ($campaign->isOpen($this->now) && ! $campaign->isRegularGiving()) {
-                    // regular giving donate pages are at a different address and in any case behind a login-wall,
-                    // so not worth listing in sitemap.
-                    $this->addUrl(
-                        xml: $xml,
-                        url: $this->environment->publicDonateURLPrefix() . 'donate/' . $campaign->getSalesforceId(),
-                        updatedAt: \DateTimeImmutable::createFromInterface($campaign->getUpdatedDate()),
-                        changeFreq: $changeFreq,
-                        priority: '0.5'
-                    );
-                }
+            $changeFreq = $endsInFuture ? 'daily' : 'monthly';
+            if ($campaign->isOpen($this->now)) {
+                $changeFreq = 'hourly';
             }
 
-            return $xml->asXML();
-        });
+            $this->addUrl(
+                xml: $xml,
+                url: $this->environment->publicDonateURLPrefix() . 'campaign/' . $campaign->getSalesforceId(),
+                changeFreq: $changeFreq,
+                priority: $endsInFuture ? '0.5' : '0.25',
+            );
+
+            if ($campaign->isOpen($this->now) && ! $campaign->isRegularGiving()) {
+                // regular giving donate pages are at a different address and in any case behind a login-wall,
+                // so not worth listing in sitemap.
+                $this->addUrl(
+                    xml: $xml,
+                    url: $this->environment->publicDonateURLPrefix() . 'donate/' . $campaign->getSalesforceId(),
+                    changeFreq: $changeFreq,
+                    priority: '0.5'
+                );
+            }
+        }
+
+        $metaCampaigns = $this->metaCampaignRepository->allNonHidden();
+
+        foreach ($metaCampaigns as $metaCampaign) {
+            if ($metaCampaign->isOpen($this->now)) {
+                $changeFreq = 'always';
+            } elseif ($metaCampaign->getEndDate() > $this->now->sub(new \DateInterval("P1D"))) {
+                $changeFreq = 'hourly';
+            } else {
+                $changeFreq = 'monthly';
+            }
+
+            $this->addUrl(
+                xml: $xml,
+                url: $this->environment->publicDonateURLPrefix() . $metaCampaign->getSlug()->slug,
+                changeFreq: $changeFreq,
+                priority: ($metaCampaign->getEndDate() > $this->now->add(new \DateInterval("P14D"))) ? '0.75' : '0.5',
+            );
+        }
+
+        $sitemapXml =  $xml->asXML();
 
         \assert(\is_string($sitemapXml));
 
@@ -103,12 +117,11 @@ class Sitemap extends Action
         return $response->withHeader('Content-Type', 'application/xml');
     }
 
-    private function addUrl(SimpleXMLElement $xml, string $url, \DateTimeImmutable $updatedAt, string $changeFreq, string $priority): void
+    private function addUrl(SimpleXMLElement $xml, string $url, string $changeFreq, string $priority): void
     {
         $urlElement = $xml->addChild('url') ?? throw new \LogicException('Expected child element not returned');
 
         $urlElement->addChild('loc', $url);
-        $urlElement->addChild('lastmod', $updatedAt->format('c'));
         $urlElement->addChild('changeFreq', $changeFreq); // options: always, hourly, daily, weekly, monthly, yearly, never
         $urlElement->addChild('priority', $priority); // value betweeon 0 and 1 sets relative priority to other content on same site.
     }

--- a/src/Domain/MetaCampaign.php
+++ b/src/Domain/MetaCampaign.php
@@ -352,4 +352,9 @@ class MetaCampaign extends SalesforceReadProxy
     {
         return $this->campaignFamily;
     }
+
+    public function isOpen(\DateTimeImmutable $at): bool
+    {
+        return $at >= $this->startDate && $at <= $this->endDate;
+    }
 }

--- a/src/Domain/MetaCampaignRepository.php
+++ b/src/Domain/MetaCampaignRepository.php
@@ -125,4 +125,15 @@ class MetaCampaignRepository
     {
         return $this->doctrineRepository->findOneBy(['salesforceId' => $sfId->value]);
     }
+
+    /**
+     * Returns a full list of our metacampaigns, other than any that we have chosen to hide. Used as part of our
+     * sitemap.
+     *
+     * @return list<MetaCampaign>
+     */
+    public function allNonHidden(): array
+    {
+        return $this->doctrineRepository->findBy(['hidden' => false]);
+    }
 }

--- a/tests/MatchBot/Application/Actions/SitemapTest.php
+++ b/tests/MatchBot/Application/Actions/SitemapTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace MatchBot\Application\Actions;
+
+use GuzzleHttp\Psr7\ServerRequest;
+use Laminas\Diactoros\Response;
+use MatchBot\Application\Environment;
+use MatchBot\Domain\Campaign;
+use MatchBot\Domain\CampaignFamily;
+use MatchBot\Domain\CampaignRepository;
+use MatchBot\Domain\Currency;
+use MatchBot\Domain\MetaCampaign;
+use MatchBot\Domain\MetaCampaignRepository;
+use MatchBot\Domain\MetaCampaignSlug;
+use MatchBot\Domain\Money;
+use MatchBot\Domain\Salesforce18Id;
+use MatchBot\IntegrationTests\IntegrationTest;
+use MatchBot\Tests\TestCase;
+use Psr\Log\NullLogger;
+
+class SitemapTest extends TestCase
+{
+    public function testItGeneratesASitemap(): void
+    {
+        // arrange
+        $campaignRepositoryProphecy = $this->prophesize(CampaignRepository::class);
+        $metaCampaignRepositoryProphecy = $this->prophesize(MetaCampaignRepository::class);
+
+        // would like to use named params below, but apparently it doesn't work with Prophecy and PHPStan
+        $campaignRepositoryProphecy->search(
+            'amountRaised',
+            'asc',
+            0,
+            100_000,
+            null,
+            null,
+            null,
+            [],
+            null,
+        )->willReturn([
+            self::someCampaign(sfId: Salesforce18Id::ofCampaign('000000000000000000')),
+        ]);
+
+        $metaCampaignRepositoryProphecy->allNonHidden()->willReturn([
+            $this->someMetaCampaign(false, false, slug: MetaCampaignSlug::of('this-is-the-metacampaign-slug')),
+        ]);
+
+        $sut = new Sitemap(
+            $campaignRepositoryProphecy->reveal(),
+            $metaCampaignRepositoryProphecy->reveal(),
+            Environment::Test,
+            new \DateTimeImmutable('2025-01-01'),
+            new NullLogger(),
+        );
+
+        // act
+        $response = $sut(new ServerRequest('GET', 'url'), new Response(), []);
+
+        // assert
+        $response->getBody()->rewind();
+        $content = $response->getBody()->getContents();
+
+        $this->assertXmlStringEqualsXmlString(
+            <<<'XML'
+            <?xml version="1.0"?>
+            <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                <url>
+                    <loc>http://example.com/campaign/000000000000000000</loc>
+                    <changeFreq>hourly</changeFreq>
+                    <priority>0.5</priority>
+                </url>
+                <url>
+                    <loc>http://example.com/donate/000000000000000000</loc>
+                    <changeFreq>hourly</changeFreq>
+                    <priority>0.5</priority>
+                </url>
+                <url>
+                    <loc>http://example.com/this-is-the-metacampaign-slug</loc>
+                    <changeFreq>monthly</changeFreq>
+                    <priority>0.5</priority>
+                </url>
+            </urlset> 
+            XML,
+            $content
+        );
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -552,10 +552,10 @@ class TestCase extends PHPUnitTestCase
         return hash_hmac('sha256', $body, $salesforceSecretKey);
     }
 
-    public static function someMetaCampaign(bool $isRegularGiving, bool $isEmergencyIMF, ?Money $imfCampaignTargetOverride = null, ?Money $matchFundsTotal = null): MetaCampaign
+    public static function someMetaCampaign(bool $isRegularGiving, bool $isEmergencyIMF, ?Money $imfCampaignTargetOverride = null, ?Money $matchFundsTotal = null, ?MetaCampaignSlug $slug = null): MetaCampaign
     {
         return new MetaCampaign(
-            slug: MetaCampaignSlug::of('not-relevant-' . TestCase::randomHex()),
+            slug: $slug ?? MetaCampaignSlug::of('not-relevant-' . TestCase::randomHex()),
             salesforceId: IntegrationTest::randomSalesForce18Id(MetaCampaign::class),
             title: 'not relevant ' . TestCase::randomHex(),
             currency: Currency::GBP,


### PR DESCRIPTION
Before merging we may need to just hide any historic metacampaigns that we don't have accurate data or descriptions for in the DB.