### PR TITLE
DON-1107: Add metacampaign info to shared funds

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -630,6 +630,12 @@ components:
         isMatched:
           type: boolean
           description: Whether the campaign is matched
+        parentUsesSharedFunds:
+          type: boolean
+          description: Whether the campaign is part of a metacampaign that has shared funds
+        parentRef:
+          type: string
+          description: slug of related metacampaign, if any
         matchFundsRemaining:
           type: number
           description: Amount of match funds remaining

--- a/src/Domain/CampaignService.php
+++ b/src/Domain/CampaignService.php
@@ -42,6 +42,9 @@ class CampaignService
         $sfCampaignData = $campaign->getSalesforceData();
         $stats = $campaign->getStatistics();
 
+        $slug = $campaign->getMetaCampaignSlug();
+        $metaCampaign = $slug ? $this->metaCampaignRepository->getBySlug($slug) : null;
+
         return [
             'charity' => [
                 'id' => $campaign->getCharity()->getSalesforceId(),
@@ -64,6 +67,8 @@ class CampaignService
             'championName' => $sfCampaignData['championName'],
             'imageUri' => $sfCampaignData['bannerUri'],
             'target' => $sfCampaignData['target'],
+            'parentUsesSharedFunds' => $metaCampaign && $metaCampaign->usesSharedFunds(),
+            'parentRef' => $metaCampaign?->getSlug()->slug,
 
             // FE model also currently has a key-optional 'percentRaised' field, but SF never sends it and nothing in FE
             // runtime touches it - SF is currently doing its own division to calculate percent raised in


### PR DESCRIPTION
`parentUsesSharedFunds` is needed properly avoid showing a progress bar in that case. The parentRef is just added for possible future uses.