### PR TITLE
BG2-2919: Revert "Merge pull request #1514 from thebiggive/BG2-2919-n…

### DIFF
--- a/src/Application/Actions/Campaigns/GetEarlyPreview.php
+++ b/src/Application/Actions/Campaigns/GetEarlyPreview.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Exception\RequestException;
 use MatchBot\Application\Actions\Action;
 use MatchBot\Application\Environment;
 use MatchBot\Client\Campaign as SfCampaignClient;
+use MatchBot\Client\NotFoundException;
 use MatchBot\Domain\Campaign;
 use MatchBot\Domain\CampaignRepository;
 use MatchBot\Domain\CampaignService;
@@ -45,12 +46,7 @@ class GetEarlyPreview extends Action
             $args['salesforceId'] ?? throw new HttpNotFoundException($request)
         );
 
-        try {
-            $campaignData = $this->salesforceCampaignClient->getById($sfId->value, false);
-        } catch (\MatchBot\Client\NotFoundException) {
-            $this->logger->warning("Campaign not found for preview, id: " . $sfId->value);
-            throw new HttpNotFoundException($request); // see ticket BG2-2919
-        }
+        $campaignData = $this->salesforceCampaignClient->getById($sfId->value, false);
         if ($campaignData['isMetaCampaign']) {
             throw new HttpNotFoundException($request);
         }

--- a/src/Client/Campaign.php
+++ b/src/Client/Campaign.php
@@ -132,8 +132,7 @@ class Campaign extends Common
                 return $campaignResponse;
             } catch (TransferException $exception) {
                 if ($exception instanceof RequestException && $exception->getResponse()?->getStatusCode() === 404) {
-                    // may be safely caught in sandboxes, and when the campaign ID was sent by a client who may have an ID that doesn't exist
-                    // or isn't working.
+                    // may be safely caught in sandboxes
                     throw new NotFoundException(sprintf('Campaign ID %s not found in SF', $id));
                 }
 


### PR DESCRIPTION
…o-alarm-on-fail-to-load-campaign-preview"

This reverts commit b09f680c4b2c5263548736a0beaa5ffb3782800e, reversing changes made to 61663a20bf4ebf7dbb8f42f040686ff8e0aa4c54.

Should be no-longer needed since a change was made in Sf to fix the issie with campaign previews. See ticket BG2-2919 for details.