### PR TITLE
BG2-2907: Update SCW 2025 campaigns from SF

### DIFF
--- a/src/Domain/CampaignRepository.php
+++ b/src/Domain/CampaignRepository.php
@@ -58,6 +58,7 @@ class CampaignRepository extends SalesforceReadProxyRepository
                 charity.tbgApprovedToClaimGiftAid = 0 AND
                 c.endDate >= :extendedLookbackDate
             )
+            OR c.metaCampaignSlug = 'small-charity-week-2025' -- to cover changes to funding allocations
             OR c.isRegularGiving = 1
             ORDER BY c.createdAt ASC
             DQL


### PR DESCRIPTION
Only needs to be in prod long enough to run once, then can be reverted, although if left will just increase our running costs marginally.