### PR TITLE
Fix minor typo in automatic mandate cancellation reason

### DIFF
--- a/src/Application/Commands/ExpirePendingMandates.php
+++ b/src/Application/Commands/ExpirePendingMandates.php
@@ -46,7 +46,7 @@ class ExpirePendingMandates extends LockingCommand
             try {
                 $this->regularGivingService->cancelMandate(
                     $mandate,
-                    'pending mandate expired at ' . $now->format('c') . ", donor may have walked away from 3DS",
+                    'Pending mandate expired at ' . $now->format('c') . ", donor may have walked away from 3DS",
                     MandateCancellationType::FirstDonationUnsuccessful
                 );
             } catch (CouldNotCancelStripePaymentIntent $e) {

--- a/src/Domain/RegularGivingService.php
+++ b/src/Domain/RegularGivingService.php
@@ -532,7 +532,7 @@ readonly class RegularGivingService
         foreach ($mandatesToCancel as $mandate) {
             $this->cancelMandate(
                 $mandate,
-                'Cancelled from to make way for new mandate',
+                'Cancelled to make way for new mandate',
                 MandateCancellationType::ReplacedByNewMandate,
             );
         }


### PR DESCRIPTION
Mostly just trying to make it clear to devs that there isn't an ID or something missing