### PR TITLE
DON-984: Fix case of changefreq element in xml sitemap

### DIFF
--- a/src/Application/Actions/Sitemap.php
+++ b/src/Application/Actions/Sitemap.php
@@ -55,15 +55,15 @@ class Sitemap extends Action
         foreach ($campaigns as $campaign) {
             $endsInFuture = $campaign->getEndDate() > $this->now;
 
-            $changeFreq = $endsInFuture ? 'daily' : 'monthly';
+            $changefreq = $endsInFuture ? 'daily' : 'monthly';
             if ($campaign->isOpen($this->now)) {
-                $changeFreq = 'hourly';
+                $changefreq = 'hourly';
             }
 
             $this->addUrl(
                 xml: $xml,
                 url: $this->environment->publicDonateURLPrefix() . 'campaign/' . $campaign->getSalesforceId(),
-                changeFreq: $changeFreq,
+                changefreq: $changefreq,
                 priority: $endsInFuture ? '0.5' : '0.25',
             );
 
@@ -73,7 +73,7 @@ class Sitemap extends Action
                 $this->addUrl(
                     xml: $xml,
                     url: $this->environment->publicDonateURLPrefix() . 'donate/' . $campaign->getSalesforceId(),
-                    changeFreq: $changeFreq,
+                    changefreq: $changefreq,
                     priority: '0.5'
                 );
             }
@@ -83,17 +83,17 @@ class Sitemap extends Action
 
         foreach ($metaCampaigns as $metaCampaign) {
             if ($metaCampaign->isOpen($this->now)) {
-                $changeFreq = 'always';
+                $changefreq = 'always';
             } elseif ($metaCampaign->getEndDate() > $this->now->sub(new \DateInterval("P1D"))) {
-                $changeFreq = 'hourly';
+                $changefreq = 'hourly';
             } else {
-                $changeFreq = 'monthly';
+                $changefreq = 'monthly';
             }
 
             $this->addUrl(
                 xml: $xml,
                 url: $this->environment->publicDonateURLPrefix() . $metaCampaign->getSlug()->slug,
-                changeFreq: $changeFreq,
+                changefreq: $changefreq,
                 priority: ($metaCampaign->getEndDate() > $this->now->add(new \DateInterval("P14D"))) ? '0.75' : '0.5',
             );
         }
@@ -107,12 +107,12 @@ class Sitemap extends Action
         return $response->withHeader('Content-Type', 'application/xml');
     }
 
-    private function addUrl(SimpleXMLElement $xml, string $url, string $changeFreq, string $priority): void
+    private function addUrl(SimpleXMLElement $xml, string $url, string $changefreq, string $priority): void
     {
         $urlElement = $xml->addChild('url') ?? throw new \LogicException('Expected child element not returned');
 
         $urlElement->addChild('loc', $url);
-        $urlElement->addChild('changeFreq', $changeFreq); // options: always, hourly, daily, weekly, monthly, yearly, never
+        $urlElement->addChild('changefreq', $changefreq); // options: always, hourly, daily, weekly, monthly, yearly, never
         $urlElement->addChild('priority', $priority); // value betweeon 0 and 1 sets relative priority to other content on same site.
     }
 }

--- a/tests/MatchBot/Application/Actions/SitemapTest.php
+++ b/tests/MatchBot/Application/Actions/SitemapTest.php
@@ -67,17 +67,17 @@ class SitemapTest extends TestCase
             <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
                 <url>
                     <loc>http://example.com/campaign/000000000000000000</loc>
-                    <changeFreq>hourly</changeFreq>
+                    <changefreq>hourly</changefreq>
                     <priority>0.5</priority>
                 </url>
                 <url>
                     <loc>http://example.com/donate/000000000000000000</loc>
-                    <changeFreq>hourly</changeFreq>
+                    <changefreq>hourly</changefreq>
                     <priority>0.5</priority>
                 </url>
                 <url>
                     <loc>http://example.com/this-is-the-metacampaign-slug</loc>
-                    <changeFreq>monthly</changeFreq>
+                    <changefreq>monthly</changefreq>
                     <priority>0.5</priority>
                 </url>
             </urlset> 


### PR DESCRIPTION
Google says they ignore `changefreq` but presumably don't know to ignore `changeFreq`. Potentially other sitemap users may use it only when spelled correctly as at https://www.sitemaps.org/protocol.html .