### PR TITLE
In regression environment, auto-cancel mandates if not collected for …

### DIFF
--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -1900,8 +1900,8 @@ class Donation extends SalesforceWriteProxy
     {
         if (!($this->thisIsInDateRangeToConfirm($now))) {
             throw new RegularGivingDonationToOldToCollect(
-                "Donation #{$this->getId()}} should have been collected at " . "
-                {$this->getPreAuthorizationDate()?->format('Y-m-d')}, will not at this time",
+                "Donation #{$this->getId()}} should have been collected at " .
+                "{$this->getPreAuthorizationDate()?->format('Y-m-d')}, will not at this time",
             );
         }
     }

--- a/src/Domain/DonationService.php
+++ b/src/Domain/DonationService.php
@@ -487,6 +487,7 @@ class DonationService
 
     /**
      * Creates a payment intent at Stripe and records the PI ID against the donation.
+     * @throws RegularGivingDonationToOldToCollect
      */
     public function createAndAssociatePaymentIntent(Donation $donation): void
     {

--- a/src/Domain/RegularGivingMandateRepository.php
+++ b/src/Domain/RegularGivingMandateRepository.php
@@ -127,6 +127,7 @@ class RegularGivingMandateRepository
             LEFT JOIN MatchBot\Domain\Charity c WITH r.charityId = c.salesforceId
             WHERE r.status = '{$active}'
             AND (r.donationsCreatedUpTo IS NULL OR r.donationsCreatedUpTo <= :now)
+            ORDER BY r.createdAt ASC
         DQL
         );
 


### PR DESCRIPTION
…a long time

Also increase regular giving mandate batch processing size from 20 to 500

And send errors to log when already existing pre-authed regular giving donation is too old to confirm.