### PR TITLE
MAT-429 – stop expecting wallets as Payment Intent types from Donate

### DIFF
--- a/src/Domain/PaymentMethodType.php
+++ b/src/Domain/PaymentMethodType.php
@@ -14,7 +14,6 @@ enum PaymentMethodType: string
     {
         return match ($pspMethodType) {
             'card' => self::Card,
-            'apple_pay', 'google_pay' => self::Card, // from Matchbot's perspective apple and google payments work like card payments.
             'customer_balance' => self::CustomerBalance,
             'pay_by_bank' => self::PayByBank,
             default => throw new \InvalidArgumentException("Unknown payment method type: $pspMethodType"),


### PR DESCRIPTION
To merge after recent Donate change is in Production