### PR TITLE
Fix regression not actually cancelling stale mandates

### DIFF
--- a/src/Application/Commands/TakeRegularGivingDonations.php
+++ b/src/Application/Commands/TakeRegularGivingDonations.php
@@ -176,11 +176,14 @@ class TakeRegularGivingDonations extends LockingCommand
                         $now,
                         MandateCancellationType::BigGiveCancelled,
                     );
+                    $this->donationService->cancel($donation);
                 }
                 $this->logger->error($e->getMessage());
                 $io->error($e->getMessage());
             }
         }
+
+        $this->em->flush();
     }
 
     private function confirmPreCreatedDonationsThatHaveReachedPaymentDate(


### PR DESCRIPTION
Should cancel donations too, aligning the logic with other cancellation scenarios