### PR TITLE
Turn off #regression-alarms temporarily to end vicious cycle

### DIFF
--- a/app/dependencies.php
+++ b/app/dependencies.php
@@ -282,7 +282,7 @@ return function (ContainerBuilder $containerBuilder) {
             $alarmChannelName = match (getenv('APP_ENV')) {
                 'production' => 'production-alarms',
                 'staging' => 'staging-alarms',
-                'regression' => 'regression-alarms',
+//                'regression' => 'regression-alarms', // TODO reinstate once dubious RG mandates are cancelled
                 default => null,
             };
 


### PR DESCRIPTION
Slack rate limits, and sending every single error individually, currently mean that code which would be fixing the data issue is never reached.