### PR TITLE
Catch 'too old' donations when we try to create Regular Giving Payment Intents too

### DIFF
--- a/src/Domain/DomainException/RegularGivingDonationToOldToCollect.php
+++ b/src/Domain/DomainException/RegularGivingDonationToOldToCollect.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace MatchBot\Domain\DomainException;
-
-class RegularGivingDonationToOldToCollect extends DomainException
-{
-}

--- a/src/Domain/DomainException/RegularGivingDonationTooOldToCollect.php
+++ b/src/Domain/DomainException/RegularGivingDonationTooOldToCollect.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace MatchBot\Domain\DomainException;
+
+class RegularGivingDonationTooOldToCollect extends DomainException
+{
+}

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -20,7 +20,7 @@ use MatchBot\Application\Fees\Calculator;
 use MatchBot\Application\HttpModels\DonationCreate;
 use MatchBot\Application\LazyAssertionException;
 use MatchBot\Domain\DomainException\CannotRemoveGiftAid;
-use MatchBot\Domain\DomainException\RegularGivingDonationToOldToCollect;
+use MatchBot\Domain\DomainException\RegularGivingDonationTooOldToCollect;
 use Messages;
 use PrinsFrank\Standards\Country\CountryAlpha2;
 use Ramsey\Uuid\Uuid;
@@ -1893,13 +1893,13 @@ class Donation extends SalesforceWriteProxy
     }
 
     /**
-     * @throws RegularGivingDonationToOldToCollect if PreAuthDate is more than one month in the past.
+     * @throws RegularGivingDonationTooOldToCollect if PreAuthDate is more than one month in the past.
      * @throws \Assert\AssertionFailedException if PreAuthDate is null or in the future.
      */
     public function checkPreAuthDateAllowsCollectionAt(\DateTimeImmutable $now): void
     {
         if (!($this->thisIsInDateRangeToConfirm($now))) {
-            throw new RegularGivingDonationToOldToCollect(
+            throw new RegularGivingDonationTooOldToCollect(
                 "Donation ID {$this->getId()} should have been collected at " .
                 "{$this->getPreAuthorizationDate()?->format('Y-m-d')}, will not at this time",
             );

--- a/src/Domain/DonationService.php
+++ b/src/Domain/DonationService.php
@@ -28,7 +28,7 @@ use MatchBot\Domain\DomainException\MandateNotActive;
 use MatchBot\Domain\DomainException\NoDonorAccountException;
 use MatchBot\Domain\DomainException\PaymentIntentNotSucceeded;
 use MatchBot\Domain\DomainException\RegularGivingCollectionEndPassed;
-use MatchBot\Domain\DomainException\RegularGivingDonationToOldToCollect;
+use MatchBot\Domain\DomainException\RegularGivingDonationTooOldToCollect;
 use MatchBot\Domain\DomainException\StripeAccountIdNotSetForAccount;
 use MatchBot\Domain\DomainException\WrongCampaignType;
 use Psr\Log\LoggerInterface;
@@ -249,7 +249,7 @@ class DonationService
      *
      * @param null|'on_session'|'off_session' $confirmationTokenSetupFutureUsage
      * @throws ApiErrorException
-     * @throws RegularGivingDonationToOldToCollect
+     * @throws RegularGivingDonationTooOldToCollect
      * @throws PaymentIntentNotSucceeded
      */
     public function confirmOnSessionDonation(
@@ -487,7 +487,7 @@ class DonationService
 
     /**
      * Creates a payment intent at Stripe and records the PI ID against the donation.
-     * @throws RegularGivingDonationToOldToCollect
+     * @throws RegularGivingDonationTooOldToCollect
      */
     public function createAndAssociatePaymentIntent(Donation $donation): void
     {


### PR DESCRIPTION
Addressing regression-only data issue with temporary catch code.

And rename a mildly confusing method and fix a typo