### PR TITLE
BG2-2960: Add order by id in campaign search to fix pagination

### DIFF
--- a/src/Domain/CampaignRepository.php
+++ b/src/Domain/CampaignRepository.php
@@ -636,6 +636,13 @@ class CampaignRepository extends SalesforceReadProxyRepository
         } else {
             $qb->addOrderBy($safeSortField, ($sortDirection === 'asc') ? 'asc' : 'desc');
         }
+
+        // order additionally by id to make sure we have a total order in case other fields are equal.
+        // Total order is required so we don't lose items in pagination, even with the (still required)
+        // assumption that the user pages through campaigns faster than the data in the db changes.
+
+        // This means campaigns that were set up earlier will show first, which seems reasonable.
+        $qb->addOrderBy('campaign.id');
     }
 
     /**


### PR DESCRIPTION
We think one campaign is getting missed out of the page because the order wasn't totally defined - we're not telling the system whether it should be in e.g. the first or second set of six results so sometimes it appears in neither as they are requested separately.