### PR TITLE
BG2-2960: Add optional alt_text property to campaign additional images

### DIFF
--- a/src/Application/Commands/CreateFictionalData.php
+++ b/src/Application/Commands/CreateFictionalData.php
@@ -226,7 +226,7 @@ class CreateFictionalData extends Command
             'additionalImageUris' => [
                 [
                     'uri' => 'https://picsum.photos/seed/' . \random_int(1, 100) . ' /1700/500',
-                    'order' => '1',
+                    'order' => 1,
                     'alt_text' => 'This is the image alt-text',
                 ]
             ],

--- a/src/Application/HttpModels/Campaign.php
+++ b/src/Application/HttpModels/Campaign.php
@@ -55,8 +55,8 @@ readonly class Campaign
                 type: "object",
                 properties: [
                     new OA\Property(property: "uri", type: "string", example: "https://example.com/image1.jpg"),
-                    new OA\Property(property: "alt_text", type: "string", example: "https://example.com/image1.jpg"),
-                    new OA\Property(property: "order", type: "integer", example: "The USC smoke stack stands tall before the bright blue, partly cloudy sky.", nullable: true)
+                    new OA\Property(property: "alt_text", type: "string", example: "The USC smoke stack stands tall before the bright blue, partly cloudy sky.", nullable: true),
+                    new OA\Property(property: "order", type: "integer", example: 1)
                 ]
             )
         )]


### PR DESCRIPTION
We don't really define the shape of additional image objects in PHP, so this just means adding it to the fictional campaigns, and addding it to the oauth spec