### PR TITLE
BG2-2892: Pass through charity campaign banner with alt-text from SF …

### DIFF
--- a/src/Client/Campaign.php
+++ b/src/Client/Campaign.php
@@ -54,6 +54,7 @@ use MatchBot\Domain\MetaCampaignSlug;
  *     problem: ?string,
  *     solution: ?string,
  *     bannerUri: ?string,
+ *     banner?: array{uri: string, alt_text: ?string}|null,
  *     amountRaised: float,
  *     summary: string,
  *     countries: list<string>,

--- a/src/Domain/CampaignService.php
+++ b/src/Domain/CampaignService.php
@@ -174,14 +174,22 @@ class CampaignService
 
         $stats = $campaign->getStatistics();
 
-        $bannerUri = $sfCampaignData['bannerUri'];
+        $bannerUri = $sfCampaignData['bannerUri'] ?? null;
+        $banner = $sfCampaignData['banner'] ?? null;
+        if ($banner === null && \is_string($bannerUri)) {
+            $banner = [
+                'uri' => $bannerUri, 'alt_text' => null
+            ];
+        }
+
+
         $campaignHttpModel = new CampaignHttpModel(
             id: $campaign->getSalesforceId(),
             amountRaised: $stats->getAmountRaised()->toMajorUnitFloat(),
             additionalImageUris: $sfCampaignData['additionalImageUris'],
             aims: $sfCampaignData['aims'],
             alternativeFundUse: $sfCampaignData['alternativeFundUse'],
-            banner: \is_string($bannerUri) ? ['uri' => $bannerUri, 'alt_text' => null] : null,
+            banner: $banner,
             bannerUri: $bannerUri, // @todo - delete this when FE deploy is done to read 'banner' instead.
             beneficiaries: $sfCampaignData['beneficiaries'],
             budgetDetails: $sfCampaignData['budgetDetails'],


### PR DESCRIPTION
…if present

At the moment SF is not sending a 'banner' object so this shouldn't do anything just yet - depends on future work in SF to be effective.