### PR TITLE
MAT-448: Use London time consistently in regular giving signup emails

### DIFF
--- a/src/Domain/RegularGivingNotifier.php
+++ b/src/Domain/RegularGivingNotifier.php
@@ -28,6 +28,8 @@ class RegularGivingNotifier
         $signUpDate = $mandate->getActiveFrom();
         Assertion::notNull($signUpDate);
 
+        $tz = new \DateTimeZone('Europe/London');
+
         $this->mailer->send(EmailMessage::donorMandateConfirmation(
             $donorAccount->emailAddress,
             [
@@ -36,9 +38,9 @@ class RegularGivingNotifier
                 'campaignName' => $campaign->getCampaignName(),
                 'charityNumber' => $charity->getRegulatorNumber(),
                 'campaignThankYouMessage' => $campaign->getThankYouMessage(),
-                'signupDate' => $signUpDate->format('d/m/Y H:i'),
+                'signupDate' => $signUpDate->setTimezone($tz)->format('j F Y, H:i T'),
                 'schedule' => $mandate->describeSchedule(),
-                'nextPaymentDate' => $mandate->firstPaymentDayAfter($this->clock->now())->format('d/m/Y'),
+                'nextPaymentDate' => $mandate->firstPaymentDayAfter($this->clock->now())->setTimezone($tz)->format('j F Y'),
                 'amount' => $mandate->getDonationAmount()->format(),
                 'giftAidValue' => $mandate->getGiftAidAmount()->format(),
                 'totalIncGiftAid' => $mandate->totalIncGiftAid()->format(),

--- a/tests/Domain/RegularGivingNotifierTest.php
+++ b/tests/Domain/RegularGivingNotifierTest.php
@@ -46,7 +46,7 @@ class RegularGivingNotifierTest extends TestCase
         $donor = $this->givenADonor();
         list($campaign, $mandate, $firstDonation, $clock) = $this->andGivenAnActivatedMandate($this->personId, $donor);
 
-        $this->thenThisRequestShouldBeSentToMatchbot(EmailMessage::donorMandateConfirmation(
+        $this->thenThisRequestShouldBeSentToMailer(EmailMessage::donorMandateConfirmation(
             EmailAddress::of("donor@example.com"),
             [
                 "donorName" => "Jenny Generous",
@@ -54,9 +54,9 @@ class RegularGivingNotifierTest extends TestCase
                 "campaignName" => "someCampaign",
                 "charityNumber" => "Reg-no",
                 "campaignThankYouMessage" => 'Thank you for setting up your regular donation to us!',
-                "signupDate" => "01/12/2024 00:00",
+                "signupDate" => "1 December 2024, 00:00 GMT",
                 "schedule" => "Monthly on day #12",
-                "nextPaymentDate" => "12/12/2024",
+                "nextPaymentDate" => "12 December 2024",
                 "amount" => "£64.00",
                 "giftAidValue" => "£16.00",
                 "totalIncGiftAid" => "£80.00",
@@ -178,7 +178,7 @@ class RegularGivingNotifierTest extends TestCase
         return [$campaign, $mandate, $firstDonation, $clock];
     }
 
-    private function thenThisRequestShouldBeSentToMatchbot(EmailMessage $sendEmailCommand): void
+    private function thenThisRequestShouldBeSentToMailer(EmailMessage $sendEmailCommand): void
     {
         $this->mailerProphecy->send(Argument::any())
             ->shouldBeCalledOnce()


### PR DESCRIPTION
Currently we have a mix of London time and UTC being output

Slightly complicated because part of the date rendering for this email is done here, and part (within the template partial for donation details) is done in the mailer repo