### PR TITLE
MAT-454 – set `on_behalf_of` consistently for all Payment Element-compatible payment methods

### DIFF
--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -1367,7 +1367,7 @@ class Donation extends SalesforceWriteProxy
      */
     public function getStripeOnBehalfOfProperties(): array
     {
-        if ($this->paymentMethodType === PaymentMethodType::Card) {
+        if ($this->paymentMethodType?->usesPaymentElement()) {
             return ['on_behalf_of' => $this->getCampaign()->getCharity()->getStripeAccountId()];
         }
 


### PR DESCRIPTION
Should fix an error when Pay By Bank is chosen by a donor and then a new Payment Intent is created