### PR TITLE
MAT-452: Adjust future regular donations for one mandate to be at exp…

### DIFF
--- a/schema/RegularGivingMandate.sql
+++ b/schema/RegularGivingMandate.sql
@@ -29,6 +29,7 @@ CREATE TABLE `RegularGivingMandate` (
   `cancellationType` varchar(50) DEFAULT NULL,
   `cancellationReason` varchar(500) DEFAULT NULL,
   `cancelledAt` datetime DEFAULT NULL COMMENT '(DC2Type:datetime_immutable)',
+  `paymentDateOffsetMonths` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `UNIQ_F638CA2BD17F50A6` (`uuid`),
   UNIQUE KEY `UNIQ_F638CA2BD8961D21` (`salesforceId`),

--- a/src/Domain/RegularGivingMandate.php
+++ b/src/Domain/RegularGivingMandate.php
@@ -60,6 +60,18 @@ class RegularGivingMandate extends SalesforceWriteProxy
     #[ORM\Column()]
     private readonly bool $giftAid;
 
+    /**
+     * How many months later than normal should donations be taken. For use via db migrations in case of errors or
+     * unusual situations. E.g. if we need to take donations one month earlier than standard for this mandate set to -1,
+     * if we need to take donations one month later set to +1.
+     *
+     * Adjustments to this only affect donation records created in the future, as the pre-auth date on each
+     * donation is set at creation time.
+     *
+     * Currently no setter as only set via db migrations, no getter as only used within this class.
+     */
+    #[ORM\Column(options: ['default' => 0])]
+    private int $paymentDateOffsetMonths = 0;
 
     /**
      * @var bool When the mandate was created, did the donor give or refuse permission for Big Give to send marketing
@@ -363,7 +375,7 @@ class RegularGivingMandate extends SalesforceWriteProxy
             throw new \Exception('Cannot generate pre-authorized first donation');
         }
 
-        $offset = $sequenceNumber->number - 2;
+        $offset = $sequenceNumber->number - 2 + $this->paymentDateOffsetMonths;
 
         $preAuthorizationDate = $secondDonationDate->modify("+$offset months");
 

--- a/src/Migrations/Version20251007142615.php
+++ b/src/Migrations/Version20251007142615.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20251007142615 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add RegularGivingMandate.paymentDateOffsetMonths';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE RegularGivingMandate ADD paymentDateOffsetMonths INT NOT NULL DEFAULT 0');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE RegularGivingMandate DROP paymentDateOffsetMonths');
+    }
+}

--- a/src/Migrations/Version20251007142800.php
+++ b/src/Migrations/Version20251007142800.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * As we had a bug that meant we took two donations in quick sucession when this mandate was set up and we had
+ * to refund one of them, if we do nothing the future donations will be one month later than expected. This
+ * adjusts them to happen when they would as if that second refunded donation was never made.
+ */
+final class Version20251007142800 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Move donations one month earlier for one mandate';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+    UPDATE RegularGivingMandate SET RegularGivingMandate.paymentDateOffsetMonths = -1
+    WHERE RegularGivingMandate.uuid = '28b5918b-31aa-473d-bcd0-b1ad5ab4f3cb' LIMIT 1
+SQL
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+    UPDATE regularGivingMandate SET RegularGivingMandate.paymentDateOffsetMonths = 0 
+    WHERE RegularGivingMandate.uuid = '28b5918b-31aa-473d-bcd0-b1ad5ab4f3cb' LIMIT 1
+SQL
+        );
+    }
+}


### PR DESCRIPTION
…ected dates instead of one month later

This is a mandate that was made after 11pm, when the dates where different in London time and UTC, and a bug meant that we collected the second donation very shortly after the first intead of waiting a month as we should have. That donation was refunded but now we have to fix the problem that all future donations would be one month late as the refunded donation is included in the count of how many months later each donation should be taken.