### PR TITLE
Add more useful info to regular giving exception error log

### DIFF
--- a/src/Application/Commands/TakeRegularGivingDonations.php
+++ b/src/Application/Commands/TakeRegularGivingDonations.php
@@ -237,7 +237,7 @@ class TakeRegularGivingDonations extends LockingCommand
                     }
                 }
             } catch (\Exception $exception) {
-                $this->logger->error('Exception, skipping donation: ' . $exception->getMessage());
+                $this->logger->error('Exception, skipping RG confirmation of donation: ' . $donation->getUuid()->toString() . ", " . \get_class($exception) . ": " . $exception->getMessage());
                 continue;
             }
         }


### PR DESCRIPTION
This error was recently triggered, but without knowing any identifiying details of the donation or its mandate its hard to see what to do about it.