### PR TITLE
DON-1192: Apply same donation check / lock logic to ryft as stripe do…

### DIFF
--- a/app/dependencies.php
+++ b/app/dependencies.php
@@ -44,6 +44,7 @@ use MatchBot\Application\RedisMatchingStorage;
 use MatchBot\Application\Settings;
 use MatchBot\Application\SlackChannelChatterFactory;
 use MatchBot\Client;
+use MatchBot\Client\RyftClient;
 use MatchBot\Domain\CampaignRepository;
 use MatchBot\Domain\DonationFundsNotifier;
 use MatchBot\Domain\DonationNotifier;
@@ -740,6 +741,7 @@ return function (ContainerBuilder $containerBuilder) {
                     redis: $c->get(Redis::class),
                     confirmRateLimitFactory: $confirmRateLimiterFactory,
                     regularGivingNotifier: $c->get(RegularGivingNotifier::class),
+                    ryftClient: $c->get(RyftClient::class),
                 );
             },
 

--- a/src/Application/Actions/Donations/Confirm.php
+++ b/src/Application/Actions/Donations/Confirm.php
@@ -52,7 +52,6 @@ class Confirm extends Action
         private DonationService $donationService,
         private ClockInterface $clock,
         private LockFactory $lockFactory,
-        private RyftClient $ryftClient,
         Settings $settings,
     ) {
         parent::__construct($logger);
@@ -130,41 +129,6 @@ EOF
             // seams confusing that the amount Ryft tells us is just the amount for the charity
             // (i.e. exclusive of tip & fees) but that's what tests so far show:
             Assertion::same($paymentAmount, $donation->getAmountForCharityFractional());
-
-            $ryftAccountId = $donation->getCampaign()->getCharity()->getRyftAccountId();
-            Assertion::notNull($ryftAccountId, 'Ryft account ID must be set for Ryft PSP');
-            $paymentSession = $this->ryftClient->fetchPaymentSession(
-                $ryftAccountId,
-                $ryftPaymentSessionId
-            );
-
-            $card = new PaymentCard(
-                CardBrand::from(strtolower($paymentSession['paymentMethod']['card']['scheme'])),
-                Country::fromAlpha2($paymentSession['paymentMethod']['card']['binDetails']['issuerCountry'])
-            );
-
-            $donation->setPaymentCard($card);
-
-            $donation->assertIsReadyToConfirm($this->clock->now());
-
-            $capture = $this->ryftClient->capturePayment(
-                $ryftAccountId,
-                $paymentSession,
-                Money::fromPence($donation->getAmountToDeductFractional(), $donation->currency()),
-            );
-
-            $donation->collectFromRyftPaymentSession(
-                paymentSession: $paymentSession,
-                totalPaidByDonor: Money::fromPence($capture['amount'], Currency::fromIsoCode($capture['currency'])),
-                originalFeeFractional: Money::fromPence($capture['platformFee'], Currency::fromIsoCode($capture['currency'])),
-                at: $this->clock->now(),
-            );
-
-           // @todo - integrate with locking / unlocking, expected match amount checks etc below,
-            // instead of letting them only happen for Stripe payments.
-            $this->entityManager->flush();
-            $this->entityManager->commit();
-            return new JsonResponse([]);
         }
 
 
@@ -223,13 +187,16 @@ EOF
         }
 
         $paymentIntentId = $donation->getTransactionId();
-        Assertion::notNull($paymentIntentId);
+        if ($psp === 'stripe') {
+            Assertion::notNull($paymentIntentId);
+        }
 
         try {
             $updatedIntent = $this->donationService->confirmOnSessionDonation(
                 $donation,
                 StripeConfirmationTokenId::of($confirmationTokenId),
                 $confirmationTokenFutureUsage,
+                $ryftPaymentSessionId,
             );
         } catch (CardException $exception) {
             $this->entityManager->rollback();
@@ -322,8 +289,8 @@ EOF
 
         return new JsonResponse([
             'paymentIntent' => [
-                'status' => $updatedIntent->status,
-                'client_secret' => $updatedIntent->status === 'requires_action'
+                'status' => $updatedIntent?->status,
+                'client_secret' => $updatedIntent?->status === 'requires_action'
                     ?  $updatedIntent->client_secret
                     : null,
             ],

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -2145,4 +2145,9 @@ class Donation extends SalesforceWriteProxy
 
         return $this->mandateSequenceNumber > 1;
     }
+
+    public function paymentServiceProvider(): ?PaymentServiceProvider
+    {
+        return PaymentServiceProvider::tryFrom($this->psp);
+    }
 }

--- a/src/Domain/DonationService.php
+++ b/src/Domain/DonationService.php
@@ -16,6 +16,7 @@ use MatchBot\Application\Matching\DbErrorPreventedMatch;
 use MatchBot\Application\Messenger\DonationUpserted;
 use MatchBot\Application\Notifier\StripeChatterInterface;
 use MatchBot\Client\NotFoundException;
+use MatchBot\Client\RyftClient;
 use MatchBot\Client\Stripe;
 use MatchBot\Application\HttpModels\DonationCreate;
 use MatchBot\Domain\DomainException\CampaignNotOpen;
@@ -107,6 +108,7 @@ class DonationService
         private \Redis $redis,
         private RateLimiterFactory $confirmRateLimitFactory,
         private RegularGivingNotifier $regularGivingNotifier,
+        private RyftClient $ryftClient,
     ) {
     }
 
@@ -262,28 +264,70 @@ class DonationService
      * @throws RegularGivingDonationTooOldToCollect
      * @throws PaymentIntentNotSucceeded
      * @throws RateLimitExceededException
+     * @return \Stripe\PaymentIntent|null payment intent for stripe, null for ryft.
      */
     public function confirmOnSessionDonation(
         Donation $donation,
-        StripeConfirmationTokenId $tokenId,
+        ?StripeConfirmationTokenId $tokenId,
         ?string $confirmationTokenSetupFutureUsage,
-    ): \Stripe\PaymentIntent {
+        ?string $ryftPaymentSessionId,
+    ): ?\Stripe\PaymentIntent {
         $confirmationToken = $this->stripe->retrieveConfirmationToken($tokenId);
+        $psp = $donation->paymentServiceProvider();
+        Assertion::notNull($psp, 'Donation must have a payment service provider');
+        if ($psp == PaymentServiceProvider::Stripe) {
+            Assertion::notNull($tokenId);
 
-        /**
-         * phpstan is newly reporting a variable type issue here, hard to see at a glance exactly what the issue
-         * is as the type involved is rather complicated.
-         *
-         * @var StripeObject&object{
-         *     card: null|object{country: string, brand: string, fingerprint: string},
-         *     pay_by_bank: null|StripeObject
-         * } $paymentMethodPreview
-         */
-        $paymentMethodPreview = $confirmationToken->payment_method_preview; // @phpstan-ignore varTag.type
+            /**
+             * phpstan is newly reporting a variable type issue here, hard to see at a glance exactly what the issue
+             * is as the type involved is rather complicated.
+             *
+             * @var StripeObject&object{
+             *     card: null|object{country: string, brand: string, fingerprint: string},
+             *     pay_by_bank: null|StripeObject
+             * } $paymentMethodPreview
+             */
+            $paymentMethodPreview = $confirmationToken->payment_method_preview; // @phpstan-ignore varTag.type
 
-        $this->limitNewPaymentCardUsageRate($paymentMethodPreview, $donation);
+            $this->limitNewPaymentCardUsageRate($paymentMethodPreview, $donation);
+            $card = null;
+        } elseif ($psp === PaymentServiceProvider::Ryft) {
+            Assertion::notNull($ryftPaymentSessionId, 'Ryft payment session ID must be set for Ryft PSP');
 
-        $this->updateDonationFeesFromConfirmationToken($donation, $confirmationToken);
+            $ryftAccountId = $donation->getCampaign()->getCharity()->getRyftAccountId();
+            Assertion::notNull($ryftAccountId, 'Ryft account ID must be set for Ryft PSP');
+            $paymentSession = $this->ryftClient->fetchPaymentSession(
+                $ryftAccountId,
+                $ryftPaymentSessionId
+            );
+
+            $card = new PaymentCard(
+                CardBrand::from(strtolower($paymentSession['paymentMethod']['card']['scheme'])),
+                Country::fromAlpha2($paymentSession['paymentMethod']['card']['binDetails']['issuerCountry'])
+            );
+        } else {
+            throw new \InvalidArgumentException('Unsupported payment service provider: ' . $psp->name);
+        }
+
+        $this->updateDonationFeesFromConfirmationTokenOrCard($donation, $confirmationToken, $card);
+
+        if ($psp === PaymentServiceProvider::Ryft) {
+            \assert(isset($paymentSession));
+            \assert(isset($ryftAccountId));
+
+            $capture = $this->ryftClient->capturePayment(
+                $ryftAccountId,
+                $paymentSession,
+                Money::fromPence($donation->getAmountToDeductFractional(), $donation->currency()),
+            );
+
+            $donation->collectFromRyftPaymentSession(
+                paymentSession: $paymentSession,
+                totalPaidByDonor: Money::fromPence($capture['amount'], Currency::fromIsoCode($capture['currency'])),
+                originalFeeFractional: Money::fromPence($capture['platformFee'], Currency::fromIsoCode($capture['currency'])),
+                at: $this->clock->now(),
+            );
+        }
 
         // We flush now to make sure the actual fees we're charging are recorded. If there's any DB error at this point
         // we prefer to crash without collecting the donation over collecting the donation without a proper record
@@ -300,36 +344,50 @@ class DonationService
         // following line has no mutation coverage but I think its fine to delete anyway given new assertion above.
         $donation->checkPreAuthDateAllowsCollectionAt($this->clock->now());
 
-        $paymentIntent = $this->stripe->retrievePaymentIntent($paymentIntentId);
+        if ($psp == PaymentServiceProvider::Stripe) {
+            \assert(isset($paymentMethodPreview));
+            $paymentIntent = $this->stripe->retrievePaymentIntent($paymentIntentId);
 
-        // Check if PaymentIntent has a payment_method of a different type
-        /** @var string|null $paymentMethodId */
-        $paymentMethodId = $paymentIntent->payment_method ?? null;
-        if ($paymentMethodId !== null) {
-            $paymentIntent = $this->updatePaymentMethodFromStripe(
-                donation: $donation,
-                paymentMethodId: $paymentMethodId,
-                paymentMethodPreview: $paymentMethodPreview,
-                paymentIntentId: $paymentIntentId,
-                paymentIntent: $paymentIntent
+            // Check if PaymentIntent has a payment_method of a different type
+            /** @var string|null $paymentMethodId */
+            $paymentMethodId = $paymentIntent->payment_method ?? null;
+            if ($paymentMethodId !== null) {
+                $paymentIntent = $this->updatePaymentMethodFromStripe(
+                    donation: $donation,
+                    paymentMethodId: $paymentMethodId,
+                    paymentMethodPreview: $paymentMethodPreview,
+                    paymentIntentId: $paymentIntentId,
+                    paymentIntent: $paymentIntent
+                );
+            }
+
+            if ($confirmationTokenSetupFutureUsage === null && $paymentIntent->setup_future_usage !== null) {
+                $paymentIntentId = $this->replacePaymentIntent($donation, $paymentIntentId);
+            }
+
+            $updatedIntent = $this->stripe->confirmPaymentIntent(
+                $paymentIntentId, // May have changed just above, if setup_future_usage did.
+                [
+                    'confirmation_token' => $tokenId->stripeConfirmationTokenId,
+                    'return_url' => $donation->getReturnUrl(),
+                ]
+            );
+
+            $this->throwIfUnsuccessful($updatedIntent);
+        } else {
+            // @phpstan-ignore-next-line - (phpstan reasonably wants us to use match to check this statically)
+            \assert($psp === PaymentServiceProvider::Ryft, 'Unexpected payment service provider');
+            \assert(isset($paymentSession));
+            \assert(isset($ryftAccountId));
+
+            $this->ryftClient->capturePayment(
+                $ryftAccountId,
+                $paymentSession,
+                Money::fromPence($donation->getAmountToDeductFractional(), $donation->currency()),
             );
         }
 
-        if ($confirmationTokenSetupFutureUsage === null && $paymentIntent->setup_future_usage !== null) {
-            $paymentIntentId = $this->replacePaymentIntent($donation, $paymentIntentId);
-        }
-
-        $updatedIntent = $this->stripe->confirmPaymentIntent(
-            $paymentIntentId, // May have changed just above, if setup_future_usage did.
-            [
-                'confirmation_token' => $tokenId->stripeConfirmationTokenId,
-                'return_url' => $donation->getReturnUrl(),
-            ]
-        );
-
-        $this->throwIfUnsuccessful($updatedIntent);
-
-        return $updatedIntent;
+        return $updatedIntent ?? null;
     }
 
     /**
@@ -489,9 +547,10 @@ class DonationService
         }
     }
 
-    private function updateDonationFeesFromConfirmationToken(
+    private function updateDonationFeesFromConfirmationTokenOrCard(
         Donation $donation,
-        ConfirmationToken $confirmationToken
+        ?ConfirmationToken $confirmationToken,
+        ?PaymentCard $paymentCard,
     ): void {
         /**
          *  phpstan is newly reporting a variable type issue here, hard to see at a glance exactly what the issue
@@ -501,9 +560,11 @@ class DonationService
          *     pay_by_bank: null|StripeObject
          * } $paymentMethodPreview
          */
-        $paymentMethodPreview = $confirmationToken->payment_method_preview; // @phpstan-ignore varTag.type
+        $paymentMethodPreview = $confirmationToken?->payment_method_preview; // @phpstan-ignore varTag.type
 
-        if ($paymentMethodPreview->card !== null) {
+        if ($paymentCard !== null) {
+            $card = $paymentCard;
+        } elseif ($paymentMethodPreview->card !== null) {
             $cardBrand = CardBrand::fromNameOrNull($paymentMethodPreview->card->brand) ?? throw new \Exception('Missing card brand');
             $cardCountry = Country::fromAlpha2OrNull($paymentMethodPreview->card->country) ?? throw new \Exception('Missing card country');
 
@@ -514,13 +575,14 @@ class DonationService
                 $cardCountry,
             ));
 
-            $donation->setPaymentCard(new PaymentCard($cardBrand, $cardCountry));
+            $card = new PaymentCard($cardBrand, $cardCountry);
         } else {
             // if we had a ctoken at all we're not using Donation Funds so must be using Pay By Bank, which
             // has no card / default fees.
             \assert($paymentMethodPreview->pay_by_bank !== null);
-            $donation->setPaymentCard(null);
+            $card = null;
         }
+        $donation->setPaymentCard($card);
 
         $this->doUpdateDonationFees(
             donation: $donation,

--- a/src/Domain/RegularGivingService.php
+++ b/src/Domain/RegularGivingService.php
@@ -201,7 +201,12 @@ readonly class RegularGivingService
             if ($confirmationTokenId) {
                 // The client should be setting every RG card to off_session so we don't need to compare the token's
                 // `setup_future_usage` for the 3rd arg here.
-                $this->donationService->confirmOnSessionDonation($firstDonation, $confirmationTokenId, ConfirmationToken::SETUP_FUTURE_USAGE_OFF_SESSION);
+                $this->donationService->confirmOnSessionDonation(
+                    donation: $firstDonation,
+                    tokenId: $confirmationTokenId,
+                    confirmationTokenSetupFutureUsage: ConfirmationToken::SETUP_FUTURE_USAGE_OFF_SESSION,
+                    ryftPaymentSessionId: null,
+                );
             } else {
                 \assert($donorsSavedPaymentMethod !== null);
                 $this->donationService->confirmDonationWithSavedPaymentMethod($firstDonation, $donorsSavedPaymentMethod, false);

--- a/tests/Application/Actions/Donations/ConfirmTest.php
+++ b/tests/Application/Actions/Donations/ConfirmTest.php
@@ -116,11 +116,11 @@ class ConfirmTest extends TestCase
                 redis: $redisProphecy->reveal(),
                 confirmRateLimitFactory: $stubRateLimiter,
                 regularGivingNotifier: $this->createStub(RegularGivingNotifier::class),
+                ryftClient: $this->createStub(RyftClient::class),
             ),
             clock: new MockClock('2025-01-01'),
             lockFactory: $this->createStub(LockFactory::class),
             settings: Settings::fromEnvVars(\getenv()),
-            ryftClient: $this->createStub(RyftClient::class),
         );
     }
 

--- a/tests/Application/Actions/Donations/UpdateHandlesLockExceptionTest.php
+++ b/tests/Application/Actions/Donations/UpdateHandlesLockExceptionTest.php
@@ -12,6 +12,7 @@ use MatchBot\Application\Actions\Donations\Update;
 use MatchBot\Application\Matching\Adapter;
 use MatchBot\Application\Matching\Allocator;
 use MatchBot\Application\Settings;
+use MatchBot\Client\RyftClient;
 use MatchBot\Client\Stripe;
 use MatchBot\Domain\CampaignRepository;
 use MatchBot\Domain\Donation;
@@ -252,6 +253,7 @@ class UpdateHandlesLockExceptionTest extends TestCase
                 redis: $this->prophesize(\Redis::class)->reveal(),
                 confirmRateLimitFactory: $stubRateLimiter,
                 regularGivingNotifier: $this->createStub(RegularGivingNotifier::class),
+                ryftClient: $this->createStub(RyftClient::class),
             ),
             settings: Settings::fromEnvVars(getenv()),
         );

--- a/tests/Domain/DonationServiceTest.php
+++ b/tests/Domain/DonationServiceTest.php
@@ -9,6 +9,7 @@ use MatchBot\Application\Matching\Adapter;
 use MatchBot\Application\Matching\Allocator;
 use MatchBot\Application\Notifier\StripeChatterInterface;
 use Doctrine\ORM\EntityManagerInterface;
+use MatchBot\Client\RyftClient;
 use MatchBot\Client\Stripe;
 use MatchBot\Domain\Campaign;
 use MatchBot\Domain\CampaignRepository;
@@ -253,6 +254,7 @@ class DonationServiceTest extends TestCase
             redis: $redisProphecy->reveal(),
             confirmRateLimitFactory: $stubRateLimiter,
             regularGivingNotifier: $this->createStub(RegularGivingNotifier::class),
+            ryftClient: $this->createStub(RyftClient::class),
         );
     }
 
@@ -297,6 +299,7 @@ class DonationServiceTest extends TestCase
             redis: $redisProphecy->reveal(),
             confirmRateLimitFactory: $rateLimiterFactory,
             regularGivingNotifier: $this->createStub(RegularGivingNotifier::class),
+            ryftClient: $this->createStub(RyftClient::class),
         );
 
 
@@ -323,7 +326,8 @@ class DonationServiceTest extends TestCase
             $sut->confirmOnSessionDonation(
                 donation: $donation,
                 tokenId: $tokenId,
-                confirmationTokenSetupFutureUsage: 'on_session'
+                confirmationTokenSetupFutureUsage: 'on_session',
+                ryftPaymentSessionId: null,
             );
         }
     }
@@ -422,6 +426,7 @@ class DonationServiceTest extends TestCase
             $donation,
             $confirmationTokenId,
             ConfirmationToken::SETUP_FUTURE_USAGE_ON_SESSION,
+            null,
         );
 
         $this->assertSame('0.52', $donation->getCharityFeeGross());
@@ -470,7 +475,7 @@ class DonationServiceTest extends TestCase
         )->willReturn($currentPaymentMethod);
         $this->entityManagerProphecy->flush()->shouldBeCalled();
 
-        $this->sut->confirmOnSessionDonation($donation, $stripeConfirmationTokenId, null);
+        $this->sut->confirmOnSessionDonation($donation, $stripeConfirmationTokenId, null, null);
 
         // then the existing payment method at stripe should be set to null before any futher update.
         if ($shouldClearPaymentMethod) {

--- a/tests/Domain/RegularGivingNotifierTest.php
+++ b/tests/Domain/RegularGivingNotifierTest.php
@@ -9,6 +9,7 @@ use MatchBot\Application\Matching\Adapter as MatchingAdapter;
 use MatchBot\Application\Matching\Allocator;
 use MatchBot\Application\Notifier\StripeChatterInterface;
 use MatchBot\Client\Mailer;
+use MatchBot\Client\RyftClient;
 use MatchBot\Client\Stripe;
 use MatchBot\Domain\Campaign;
 use MatchBot\Domain\CampaignFunding;
@@ -362,6 +363,7 @@ class RegularGivingNotifierTest extends TestCase
             $this->createStub(\Redis::class),
             $rateLimiterFactory,
             $this->sut,
+            $this->createStub(RyftClient::class),
         );
 
         $paymentIntent = new PaymentIntent();

--- a/tests/Domain/RegularGivingServiceTest.php
+++ b/tests/Domain/RegularGivingServiceTest.php
@@ -297,6 +297,7 @@ class RegularGivingServiceTest extends TestCase
             Argument::type(Donation::class),
             $confirmationTokenId,
             ConfirmationToken::SETUP_FUTURE_USAGE_OFF_SESSION,
+            null,
         )
             ->shouldBeCalledOnce()
             ->will(/**


### PR DESCRIPTION
Moving ryft-specific logic out of Confirm handler and putting it in Donation service, closer to where we do the equivalent with Stripe so that we can more easily do the same thing for both types of donation.

This also naturally means the same things like locking and unlocking the donation before and after capturing the funds happen with both services.