### PR TITLE
Revert "BG2-3129 Temporarily call `updateFromSf()` again for any Campaigns eligible for up-to-date fund info"

### DIFF
--- a/src/Application/Commands/UpdateCampaigns.php
+++ b/src/Application/Commands/UpdateCampaigns.php
@@ -117,7 +117,6 @@ class UpdateCampaigns extends LockingCommand
      */
     protected function pull(Campaign $campaign, OutputInterface $output): void
     {
-        $this->campaignRepository->updateFromSf($campaign);
         $this->fundRepository->pullForCampaign($campaign, $this->now);
         $output->writeln('Updated campaign ' . $campaign->getSalesforceId());
     }

--- a/src/Domain/CampaignRepository.php
+++ b/src/Domain/CampaignRepository.php
@@ -42,10 +42,6 @@ class CampaignRepository extends SalesforceReadProxyRepository
      * This simplifies this query and dramatically reduces the maximum time we must look back for
      * 'pulls' of funds.
      *
-     * To ensure champion names are up to date core Campaigns are also temporarily pulled again but
-     * just for the narrower new date range.
-     * @todo Once Salesforce pushes changes to that, we will remove pulls of campaign data again.
-     *
      * @return Campaign[]
      */
     public function findCampaignsWhereFundsNeedToBeUpToDate(): array

--- a/tests/Application/Commands/UpdateCampaignsTest.php
+++ b/tests/Application/Commands/UpdateCampaignsTest.php
@@ -39,7 +39,6 @@ class UpdateCampaignsTest extends TestCase
         $campaignRepoProphecy->findCampaignsWhereFundsNeedToBeUpToDate()
             ->willReturn([$campaign])
             ->shouldBeCalledOnce();
-        $campaignRepoProphecy->updateFromSf($campaign)->shouldBeCalledOnce();
 
         $fundRepoProphecy = $this->prophesize(FundRepository::class);
         $fundRepoProphecy->pullForCampaign($campaign, $this->now)->shouldBeCalledOnce();
@@ -77,7 +76,6 @@ class UpdateCampaignsTest extends TestCase
         $campaignRepoProphecy->findCampaignsWhereFundsNeedToBeUpToDate()
             ->willReturn([$campaign])
             ->shouldBeCalledOnce();
-        $campaignRepoProphecy->updateFromSf($campaign)->shouldBeCalledOnce();
 
         $fundRepoProphecy = $this->prophesize(FundRepository::class);
         $fundRepoProphecy->pullForCampaign($campaign, $this->now)
@@ -122,7 +120,6 @@ class UpdateCampaignsTest extends TestCase
         $campaignRepoProphecy->findCampaignsWhereFundsNeedToBeUpToDate()
             ->willReturn([$campaign])
             ->shouldBeCalledOnce();
-        $campaignRepoProphecy->updateFromSf($campaign)->shouldBeCalledTimes(2);
 
         $fundRepoProphecy = $this->prophesize(FundRepository::class);
         $fundRepoProphecy->pullForCampaign($campaign, $this->now)
@@ -177,7 +174,6 @@ class UpdateCampaignsTest extends TestCase
         $campaignRepoProphecy->findCampaignsWhereFundsNeedToBeUpToDate()
             ->willReturn([$campaign])
             ->shouldBeCalledOnce();
-        $campaignRepoProphecy->updateFromSf($campaign)->shouldBeCalledTimes(2);
 
         $fundRepoMockBuilder = $this->getMockBuilder(FundRepository::class);
         $fundRepoMockBuilder->setConstructorArgs([$entityManagerProphecy->reveal(), new ClassMetadata(Campaign::class)]);
@@ -224,7 +220,6 @@ class UpdateCampaignsTest extends TestCase
         $campaignRepoProphecy->findAll()
             ->willReturn([$campaign])
             ->shouldBeCalledOnce();
-        $campaignRepoProphecy->updateFromSf($campaign)->shouldBeCalledOnce();
 
         $fundRepoProphecy = $this->prophesize(FundRepository::class);
         $fundRepoProphecy->pullForCampaign($campaign, $this->now)->shouldBeCalledOnce();


### PR DESCRIPTION
Reverts thebiggive/matchbot#1917

Might need a little more QA discussion but this ought to be safe enough to do soon.