### PR TITLE
Switch Stripe charge event lock errors HTTP code to 409

### DIFF
--- a/src/Application/Actions/Hooks/StripePaymentsUpdate.php
+++ b/src/Application/Actions/Hooks/StripePaymentsUpdate.php
@@ -128,7 +128,7 @@ class StripePaymentsUpdate extends Stripe
             } catch (LockWaitTimeoutException $exception) {
                 $this->logger->warning(sprintf('charge.succeeded: Failed to acquire lock on donation with Payment Intent ID %s', $intentId));
                 $this->entityManager->rollback();
-                return $this->respond($response, new ActionPayload(503));
+                return $this->respond($response, new ActionPayload(409));
             }
         } else {
             $donation = null;
@@ -201,7 +201,7 @@ class StripePaymentsUpdate extends Stripe
             } catch (LockWaitTimeoutException $exception) {
                 $this->logger->warning(sprintf('charge.updated: Failed to acquire lock on donation with Payment Intent ID %s', $intentId));
                 $this->entityManager->rollback();
-                return $this->respond($response, new ActionPayload(503));
+                return $this->respond($response, new ActionPayload(409));
             }
         } else {
             $donation = null;


### PR DESCRIPTION
Trying to keep the behaviour we want in other respects – halt processing and let Stripe know there was an error so their systems retry the event delivery – while avoiding noise in our alarms which treat any 5xx as unexpected.