### PR TITLE
MAT-489 Fix our workaround for a Stripe payment method change bug

### DIFF
--- a/src/Client/LiveStripeClient.php
+++ b/src/Client/LiveStripeClient.php
@@ -141,6 +141,11 @@ class LiveStripeClient implements Stripe
         );
     }
 
+    #[\Override]
+    public function retrievePendingPaymentMethod(StripePaymentMethodId $methodId): PaymentMethod
+    {
+        return $this->stripeClient->paymentMethods->retrieve($methodId->stripePaymentMethodId);
+    }
 
     #[\Override]
     public function detatchPaymentMethod(StripePaymentMethodId $paymentMethodId): void

--- a/src/Client/Stripe.php
+++ b/src/Client/Stripe.php
@@ -78,11 +78,15 @@ interface Stripe
     public function createSetupIntent(StripeCustomerId $stripeCustomerId): SetupIntent;
 
     /**
+     * Gets a specific Customer's Payment Method which must be attached. Generally for saved methods.
+     * @link https://docs.stripe.com/api/payment_methods/customer
      * @throws InvalidRequestException
      */
     public function retrievePaymentMethod(StripeCustomerId $customerId, StripePaymentMethodId $methodId): PaymentMethod;
 
     /**
+     * Gets a Payment Method that is not necessarily attached to a Customer yet.
+     * @link https://docs.stripe.com/api/payment_methods/retrieve
      * @throws ApiErrorException
      */
     public function retrievePendingPaymentMethod(StripePaymentMethodId $methodId): PaymentMethod;

--- a/src/Client/Stripe.php
+++ b/src/Client/Stripe.php
@@ -85,6 +85,11 @@ interface Stripe
     /**
      * @throws ApiErrorException
      */
+    public function retrievePendingPaymentMethod(StripePaymentMethodId $methodId): PaymentMethod;
+
+    /**
+     * @throws ApiErrorException
+     */
     public function detatchPaymentMethod(StripePaymentMethodId $paymentMethodId): void;
 
     /**

--- a/src/Client/StubStripeClient.php
+++ b/src/Client/StubStripeClient.php
@@ -137,6 +137,12 @@ class StubStripeClient implements Stripe
     }
 
     #[\Override]
+    public function retrievePendingPaymentMethod(StripePaymentMethodId $methodId): PaymentMethod
+    {
+        throw new \Exception("Retrieve Pending Payment Method not implemented in stub - not currently used in load tests");
+    }
+
+    #[\Override]
     public function detatchPaymentMethod(StripePaymentMethodId $paymentMethodId): void
     {
         throw new \Exception("Detatch Payment Method not implemented in stub - not currently used in load tests");

--- a/src/Domain/DonationService.php
+++ b/src/Domain/DonationService.php
@@ -275,7 +275,7 @@ class DonationService
         $confirmationToken = $this->stripe->retrieveConfirmationToken($tokenId);
         $psp = $donation->paymentServiceProvider();
         Assertion::notNull($psp, 'Donation must have a payment service provider');
-        if ($psp == PaymentServiceProvider::Stripe) {
+        if ($psp === PaymentServiceProvider::Stripe) {
             Assertion::notNull($tokenId);
 
             /**
@@ -344,13 +344,14 @@ class DonationService
         // following line has no mutation coverage but I think its fine to delete anyway given new assertion above.
         $donation->checkPreAuthDateAllowsCollectionAt($this->clock->now());
 
-        if ($psp == PaymentServiceProvider::Stripe) {
+        if ($psp === PaymentServiceProvider::Stripe) {
             \assert(isset($paymentMethodPreview));
             $paymentIntent = $this->stripe->retrievePaymentIntent($paymentIntentId);
 
             // Check if PaymentIntent has a payment_method of a different type
             /** @var string|null $paymentMethodId */
             $paymentMethodId = $paymentIntent->payment_method ?? null;
+
             if ($paymentMethodId !== null) {
                 $paymentIntent = $this->updatePaymentMethodFromStripe(
                     donation: $donation,
@@ -1108,7 +1109,10 @@ class DonationService
     }
 
     /**
-     * @throws CouldNotRetrievePaymentMethod
+     * For use only with saved methods, because they'll only be attached to Customers reliably in that case and
+     * we use https://docs.stripe.com/api/payment_methods/customer
+     *
+     * @throws CouldNotRetrievePaymentMethod if e.g. the method ID doesn't meet the condition above.
      */
     private function updateDonationFeesFromPaymentMethodId(Donation $donation, StripePaymentMethodId $paymentMethodId): void
     {
@@ -1214,13 +1218,12 @@ class DonationService
 
         $paymentMethod = null;
         try {
-            $paymentMethod = $this->stripe->retrievePaymentMethod(
-                $donation->getPspCustomerId() ?? throw new \LogicException('Missing customer ID'),
+            $paymentMethod = $this->stripe->retrievePendingPaymentMethod(
                 StripePaymentMethodId::of($paymentMethodId),
             );
-        } catch (ApiErrorException $exception) { // e.g. a 404 from a detached-by-Stripe.js method is an InvalidRequestException.
-            $this->logger->info(sprintf(
-                'Donation UUID %s: Could not retrieve probably detached payment method %s: %s',
+        } catch (ApiErrorException $exception) {
+            $this->logger->error(sprintf(
+                'Donation UUID %s: Could not retrieve payment method %s: %s',
                 $donation->getUuid(),
                 $paymentMethodId,
                 $exception->getMessage()

--- a/tests/Domain/DonationServiceTest.php
+++ b/tests/Domain/DonationServiceTest.php
@@ -469,8 +469,7 @@ class DonationServiceTest extends TestCase
         $currentPaymentMethod->type = $currentPaymentMethodType;
 
         // When we confirm the donation
-        $this->stripeProphecy->retrievePaymentMethod(
-            StripeCustomerId::of('cus_someCustomerID'),
+        $this->stripeProphecy->retrievePendingPaymentMethod(
             StripePaymentMethodId::of('pm_paymentmethodid')
         )->willReturn($currentPaymentMethod);
         $this->entityManagerProphecy->flush()->shouldBeCalled();


### PR DESCRIPTION
We think that this can happen if a donor starts with Pay By Bank; abandons the next_action; and switches to card while saying yes to saving it for future.

Our existing logic to clear the payment_method proactively on type change was broken (probably) because we were never successfully reading the existing payment method's type in cases where it is too new to be attached to the Customer.