### PR TITLE
MAT-480, MAT-481 Remove temporary hard-coded ignore

### DIFF
--- a/src/Application/Commands/UpdateCampaignDonationStats.php
+++ b/src/Application/Commands/UpdateCampaignDonationStats.php
@@ -113,14 +113,7 @@ class UpdateCampaignDonationStats extends LockingCommand
             );
         } catch (AssertionFailedException $exception) {
             $errorMessage = "Error updating statistics for campaign ID {$campaignId} ({$campaign->getSalesforceId()}): {$exception->getMessage()}";
-            if ($campaignId !== 31646) {
-                // @todo resolve issue and remove hard-coded campaign ID conditional.
-                // known issue with possible small over-matching on this campaign.
-                // MAT-481
-                $this->logger->error($errorMessage);
-            } else {
-                $this->logger->warning($errorMessage);
-            }
+            $this->logger->error($errorMessage);
             $output->writeln("<error>$errorMessage</error>");
             return false; // Not re-throwing for now so that we can get a complete list of campaigns with issues in one go.
         }


### PR DESCRIPTION
Our usual logic for ignoring overmatches from past bugs should have this covered.