### PR TITLE
Fix incorrect enum/string comparison in donation Confirm

### DIFF
--- a/src/Application/Actions/Donations/Confirm.php
+++ b/src/Application/Actions/Donations/Confirm.php
@@ -112,7 +112,7 @@ class Confirm extends Action
             throw new NotFoundException();
         }
 
-        if ((!is_string($confirmationTokenId) || trim($confirmationTokenId) === '') && $psp === 'stripe') {
+        if ((!is_string($confirmationTokenId) || trim($confirmationTokenId) === '') && $psp === PaymentServiceProvider::Stripe) {
             $donationUUID = $donation->getId();
             $this->logger->warning(
                 <<<EOF
@@ -187,7 +187,7 @@ EOF
         }
 
         $paymentIntentId = $donation->getTransactionId();
-        if ($psp === 'stripe') {
+        if ($psp === PaymentServiceProvider::Stripe) {
             Assertion::notNull($paymentIntentId);
         }
 


### PR DESCRIPTION
Without this fix, the incorrect comparison lets 'stripe' mode donations with no confirmation token get further than intended, causing a noisy error log.