### PR TITLE
MAT-483: Set all campaign statistics to 'Preview' not empty

### DIFF
--- a/src/Migrations/Version20260427153629.php
+++ b/src/Migrations/Version20260427153629.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260427153629 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Set all campaign stats approx statuses to non-empty to stop enum doctrine errors';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(sql: "UPDATE CampaignStatistics SET approxStatus = 'Preview' where approxStatus = ''");
+    }
+
+    public function down(Schema $schema): void
+    {
+        // no going back.
+    }
+}


### PR DESCRIPTION
Empty string was set by default on creating the column but is not a member of the enum so causes errors