### PR TITLE
MAT-153 Reapply accidentally reverted fix to WHERE logic; 

### DIFF
--- a/src/Domain/DoctrineDonationRepository.php
+++ b/src/Domain/DoctrineDonationRepository.php
@@ -196,7 +196,6 @@ DQL);
             ->andWhere('c.isMatched = true')
             ->andWhere('c.endDate < :now')
             ->andWhere('c.endDate > :campaignClosedSince')
-            ->andWhere('fw.releasedAt is null')
             ->groupBy('d.id')
             ->having(
                 '(SUM(CASE WHEN fw.releasedAt is null THEN fw.amount ELSE 0 END) IS NULL


### PR DESCRIPTION
Broke retrospective matching for donations that had release matching

See https://github.com/thebiggive/matchbot/pull/1855#discussion_r2878599603 where we discussed and fixed, and https://github.com/thebiggive/matchbot/commit/948027b015ee0c3933b13ed4fe3067c453a7bb44 where I think it was put back in error