### PR TITLE
MAT-483: Remove remaining usages of CampaignStatus field from SF

### DIFF
--- a/integrationTests/CampaignRepositoryTest.php
+++ b/integrationTests/CampaignRepositoryTest.php
@@ -9,6 +9,7 @@ use MatchBot\Domain\ApplicationStatus;
 use MatchBot\Domain\Campaign;
 use MatchBot\Domain\CampaignRepository;
 use MatchBot\Domain\CampaignStatistics;
+use MatchBot\Domain\CampaignStatus;
 use MatchBot\Domain\Charity;
 use MatchBot\Domain\CharityResponseToOffer;
 use MatchBot\Domain\Money;
@@ -133,12 +134,15 @@ class CampaignRepositoryTest extends IntegrationTest
 
         $charity = TestCase::someCharity();
 
-        foreach (['Expired', 'Active', 'Preview'] as $status) {
+        foreach ([CampaignStatus::Expired, CampaignStatus::Active, CampaignStatus::Preview] as $status) {
             $campaign = $this->createCampaign(
                 charity: $charity,
-                name: 'Campaign ' . $status,
+                name: 'Campaign ' . $status->value,
                 status: $status,
                 withUniqueSalesforceId: true,
+                metaCampaignSlug: 'some-slug',
+                relatedApplicationStatus: ApplicationStatus::Approved,
+                relatedApplicationCharityResponseToOffer: CharityResponseToOffer::Accepted
             );
             $stats = CampaignStatistics::zeroPlaceholder($campaign, new \DateTimeImmutable('now'));
             $em->persist($campaign);
@@ -151,7 +155,7 @@ class CampaignRepositoryTest extends IntegrationTest
             sortDirection: 'desc',
             offset: 0,
             limit: 6,
-            metaCampaignSlug: null,
+            metaCampaignSlug: 'some-slug',
             fundSlug: null,
             jsonMatchInListConditions: [],
             term: null,

--- a/integrationTests/IntegrationTest.php
+++ b/integrationTests/IntegrationTest.php
@@ -11,8 +11,11 @@ use MatchBot\Application\Assertion;
 use MatchBot\Application\Messenger\DonationUpserted;
 use MatchBot\Application\Settings;
 use MatchBot\Client\Mandate as MandateSFClient;
+use MatchBot\Domain\ApplicationStatus;
 use MatchBot\Domain\Campaign;
+use MatchBot\Domain\CampaignStatus;
 use MatchBot\Domain\Charity;
+use MatchBot\Domain\CharityResponseToOffer;
 use MatchBot\Domain\DoctrineDonationRepository;
 use MatchBot\Domain\DonationRepository;
 use MatchBot\Domain\FundType;
@@ -493,37 +496,43 @@ abstract class IntegrationTest extends TestCase
         return $fakeStripeClient;
     }
 
-    /**
-     * @param 'Active'|'Expired'|'Preview' $status
-     */
     protected function createCampaign(
         ?Charity $charity = null,
         string $name = 'Campaign Name',
         string $summary = 'Campaign Summary',
-        string $status = 'Active',
+        CampaignStatus $status = CampaignStatus::Active,
         bool $withUniqueSalesforceId = false,
+        ?string $metaCampaignSlug = null,
+        ?ApplicationStatus $relatedApplicationStatus = null,
+        ?CharityResponseToOffer $relatedApplicationCharityResponseToOffer = null
     ): Campaign {
         $salesforceId = $withUniqueSalesforceId
             ? Salesforce18Id::ofCampaign(self::randomString())
             : Salesforce18Id::ofCampaign('campaignId12345678');
 
+        [$startDate, $endDate] = match ($status) {
+            CampaignStatus::Preview => [new \DateTimeImmutable('now')->add(new \DateInterval('P2D')), new \DateTimeImmutable('now')->add(new \DateInterval('P3D'))],
+            CampaignStatus::Active => [new \DateTimeImmutable('now')->sub(new \DateInterval('P1D')), new \DateTimeImmutable('now')->add(new \DateInterval('P1D'))],
+            CampaignStatus::Expired => [new \DateTimeImmutable('now')->sub(new \DateInterval('P3D')),  new \DateTimeImmutable('now')->sub(new \DateInterval('P2D'))],
+        };
+
         return new Campaign(
             $salesforceId,
-            metaCampaignSlug: null,
+            metaCampaignSlug: $metaCampaignSlug,
             charity: $charity ?? \MatchBot\Tests\TestCase::someCharity(),
-            startDate: new \DateTimeImmutable('now'),
-            endDate: (new \DateTimeImmutable('now'))->modify('+1 minute'),
+            startDate: $startDate,
+            endDate: $endDate,
             isMatched: true,
             ready: true,
-            status: $status,
+            status: $status->value,
             name: $name,
             summary: $summary,
             currencyCode: 'GBP',
             isRegularGiving: false,
             pinPosition: null,
             championPagePinPosition: null,
-            relatedApplicationStatus: null,
-            relatedApplicationCharityResponseToOffer: null,
+            relatedApplicationStatus: $relatedApplicationStatus,
+            relatedApplicationCharityResponseToOffer: $relatedApplicationCharityResponseToOffer,
             regularGivingCollectionEnd: null,
             totalFundraisingTarget: Money::zero(),
             thankYouMessage: null,

--- a/src/Domain/Campaign.php
+++ b/src/Domain/Campaign.php
@@ -69,7 +69,8 @@ class Campaign extends SalesforceReadProxy
      *
      * Default null because campaigns not recently updated in matchbot have not pulled this field from SF.
      *
-     * Currently only used in database queries, hoping to remove all usages.
+     * @deprecated - there should now be no usages of this. In the next deploy we should be able to remove it from the
+     * DB. Note that {@see self::getStatus } does not use this field.
      */
     #[ORM\Column(length: 64, nullable: true, options: ['default' => null])]
     private ?string $status = null; // @phpstan-ignore doctrine.columnType

--- a/src/Domain/CampaignRepository.php
+++ b/src/Domain/CampaignRepository.php
@@ -389,7 +389,7 @@ class CampaignRepository extends SalesforceReadProxyRepository
              campaign.charity = :charity
              AND campaign.isPublished = true
              AND (statistics.donationSum.amountInPence > 0 OR campaign.endDate > :at OR campaign.endDate IS NULL)
-             ORDER BY campaign.status ASC, campaign.endDate ASC 
+             ORDER BY statistics.approxStatus ASC, campaign.endDate ASC 
             DQL
         );
 
@@ -567,7 +567,7 @@ class CampaignRepository extends SalesforceReadProxyRepository
             $qb->andWhere($qb->expr()->gt('campaign.endDate', ':now'));
             $qb->setParameter('now', $this->clock->now());
         } else {
-            $qb->andWhere('campaign.status IS NOT NULL'); // <- marked usage
+            $qb->andWhere('campaign.isPublished = true');
         }
 
         $qb->andWhere(<<<DQL
@@ -644,7 +644,7 @@ class CampaignRepository extends SalesforceReadProxyRepository
         array|null $idsOrderedByRelavence
     ): void {
         // Active, Expired, Preview in that order; status sort takes highest precedence.
-        $qb->addOrderBy('campaign.status', 'asc');
+        $qb->addOrderBy('campaignStatistics.approxStatus', 'asc');
 
         if ($applyPinSort) {
             $qb->addOrderBy('pinPosition', 'asc');

--- a/src/Domain/CampaignRepository.php
+++ b/src/Domain/CampaignRepository.php
@@ -383,13 +383,19 @@ class CampaignRepository extends SalesforceReadProxyRepository
     {
         $query = $this->getEntityManager()->createQuery(
             <<<'DQL'
-            SELECT campaign FROM MatchBot\Domain\Campaign campaign
+            SELECT campaign,
+            CASE
+                WHEN statistics.approxStatus = 'Active' THEN 0 
+                WHEN statistics.approxStatus = 'Expired' THEN 1
+                WHEN statistics.approxStatus = 'Preview' THEN 2
+                ELSE 2 END AS HIDDEN approxStatusRank
+            FROM MatchBot\Domain\Campaign campaign
             JOIN campaign.campaignStatistics statistics
             WHERE 
              campaign.charity = :charity
              AND campaign.isPublished = true
              AND (statistics.donationSum.amountInPence > 0 OR campaign.endDate > :at OR campaign.endDate IS NULL)
-             ORDER BY statistics.approxStatus ASC, campaign.endDate ASC 
+             ORDER BY approxStatusRank ASC, campaign.endDate ASC
             DQL
         );
 
@@ -643,8 +649,7 @@ class CampaignRepository extends SalesforceReadProxyRepository
         string $sortDirection,
         array|null $idsOrderedByRelavence
     ): void {
-        // Active, Expired, Preview in that order; status sort takes highest precedence.
-        $qb->addOrderBy('campaignStatistics.approxStatus', 'asc');
+        $qb->addOrderBy('approxStatusRank', 'asc');
 
         if ($applyPinSort) {
             $qb->addOrderBy('pinPosition', 'asc');
@@ -702,7 +707,12 @@ class CampaignRepository extends SalesforceReadProxyRepository
 
         $qb->select(<<<SELECT
               campaign,
-              COALESCE(campaign.pinPosition, 999999999) AS HIDDEN pinPosition
+              COALESCE(campaign.pinPosition, 999999999) AS HIDDEN pinPosition,
+              CASE
+                WHEN campaignStatistics.approxStatus = 'Active' THEN 0
+                WHEN campaignStatistics.approxStatus = 'Expired' THEN 1
+                WHEN campaignStatistics.approxStatus = 'Preview' THEN 2
+                ELSE 2 END AS HIDDEN approxStatusRank
             SELECT)
             ->from(Campaign::class, 'campaign')
             ->join('campaign.charity', 'charity')


### PR DESCRIPTION
Replaced with the campaignStatistics.pproxStatus which is not derived from any 'status' field in SF