### PR TITLE
MAT-483: Stop using Metacampaign status and mastercampaign status fields

### DIFF
--- a/src/Application/Commands/CreateFictionalData.php
+++ b/src/Application/Commands/CreateFictionalData.php
@@ -410,8 +410,6 @@ class CreateFictionalData extends Command
             salesforceId: Salesforce18Id::ofMetaCampaign(TestCase::randomString()),
             title: "Local test MetaCampaign", // feel free to replace if you have a more creative idea
             currency: Currency::GBP,
-            status: 'Active',
-            masterCampaignStatus: MetaCampaign::STATUS_VIEW_CAMPAIGN,
             hidden: false,
             summary: 'These campaigns exist in the local Matchbot Database, they are not real and not currently expected to exist in any Salesforce org',
             bannerURI: new Uri($bannerURI),

--- a/src/Domain/MetaCampaign.php
+++ b/src/Domain/MetaCampaign.php
@@ -26,8 +26,6 @@ class MetaCampaign extends SalesforceReadProxy
 {
     use TimestampsTrait;
 
-    public const string STATUS_VIEW_CAMPAIGN = 'View campaign';
-
     /** Metacampaigns from before this date may not have accurate data so should not be indexed */
     public const string INDEX_FROM = '2019-12-01T00:00:00z';
 
@@ -47,16 +45,19 @@ class MetaCampaign extends SalesforceReadProxy
 
     /**
      * @var string|null Copy of Campaign_Status__c in Salesforce
+     * @deprecated as we don't want to rely on this property, and in fact in prod DB for this table
+     * it's all null apart from four 'Expired'
      */
     #[ORM\Column(nullable: true)]
-    private ?string $status;
+    private ?string $status = null;
 
 
     /**
      * @var string|null Copy of Master_Campaign_Status__c in Salesforce
+     * @deprecated - no longer needed, may delete for next deploy.
      */
     #[ORM\Column(nullable: true)]
-    private ?string $masterCampaignStatus;
+    private ?string $masterCampaignStatus = null;
 
     #[ORM\Column()]
     private bool $hidden;
@@ -127,8 +128,6 @@ class MetaCampaign extends SalesforceReadProxy
         Salesforce18Id $salesforceId,
         string $title,
         Currency $currency,
-        string $status,
-        string $masterCampaignStatus,
         bool $hidden,
         ?string $summary,
         ?UriInterface $bannerURI,
@@ -147,8 +146,6 @@ class MetaCampaign extends SalesforceReadProxy
         $this->setSalesforceId($salesforceId->value);
         $this->title = $title;
         $this->currency = $currency;
-        $this->status = $status;
-        $this->masterCampaignStatus = $masterCampaignStatus;
         $this->hidden = $hidden;
         $this->summary = $summary;
         $this->bannerURI = $bannerURI?->__toString();
@@ -177,8 +174,6 @@ class MetaCampaign extends SalesforceReadProxy
             salesforceId: Salesforce18Id::ofMetaCampaign($data['id']),
             title: '',
             currency: Currency::GBP,
-            status: '',
-            masterCampaignStatus: '',
             hidden: false,
             summary: '',
             bannerURI: null,
@@ -211,10 +206,6 @@ class MetaCampaign extends SalesforceReadProxy
         $endDate = $data['endDate'];
         $title = $data['title'];
 
-        // status may be null for now.
-        $status = $data['campaignStatus'] ?? null;
-        $masterCampaignStatus = $data['masterCampaignStatus'] ?? null;
-
         Assertion::notNull($startDate);
         Assertion::notNull($endDate);
         Assertion::notNull($title);
@@ -228,8 +219,6 @@ class MetaCampaign extends SalesforceReadProxy
         }
         Assertion::numeric($totalAdjustment);
 
-        $this->status = $status;
-        $this->masterCampaignStatus = $masterCampaignStatus;
         $this->bannerURI = \is_string($bannerUri) ? (new Uri($bannerUri))->__toString() : null;
         $this->isRegularGiving = $isRegularGiving;
         $this->title = $title;
@@ -273,10 +262,6 @@ class MetaCampaign extends SalesforceReadProxy
 
     public function getStatusAt(\DateTimeImmutable $date): ?string
     {
-        if ($this->masterCampaignStatus !== self::STATUS_VIEW_CAMPAIGN) {
-            return $this->status;
-        }
-
         if ($date < $this->startDate) {
             return 'Preview';
         }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -573,8 +573,6 @@ class TestCase extends PHPUnitTestCase
             salesforceId: IntegrationTest::randomSalesForce18Id(MetaCampaign::class),
             title: 'not relevant ' . TestCase::randomHex(),
             currency: Currency::GBP,
-            status: 'Active',
-            masterCampaignStatus: MetaCampaign::STATUS_VIEW_CAMPAIGN,
             hidden: false,
             summary: 'not relevant',
             bannerURI: null,


### PR DESCRIPTION
Better to calculate status entirely in matchbot & frontend based on other fields