### PR TITLE
Fix `matchbot:pull-meta-campaign-from-sf` for pulling meta-campaigns from Salesforce on-demand

### DIFF
--- a/src/Application/Commands/PullMetaCampaignFromSF.php
+++ b/src/Application/Commands/PullMetaCampaignFromSF.php
@@ -23,9 +23,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 #[AsCommand(
     name: 'matchbot:pull-meta-campaign-from-sf',
-    description: 'Pulls a meta campaign (or at least all its related individual campaigns) from Salesforce into the
-     matchbot db. Should improve performance and reduce chance of any db contention particularly if run shortly before 
-     campaign start time'
+    description: 'Pulls already-known children of meta-campaign from Salesforce into the matchbot DB.'
 )]
 class PullMetaCampaignFromSF extends LockingCommand
 {
@@ -48,7 +46,7 @@ class PullMetaCampaignFromSF extends LockingCommand
     public function pullCharityCampaigns(MetaCampaignSlug $metaCampaginSlug, OutputInterface $output): void
     {
         ['newFetchCount' => $newFetchCount, 'updatedCount' => $updatedCount, 'campaigns' => $campaigns] =
-            $this->campaignRepository->fetchAllForMetaCampaign($metaCampaginSlug);
+            $this->campaignRepository->fetchAlreadyKnownChildrenForMetaCampaign($metaCampaginSlug);
 
         $total = $newFetchCount + $updatedCount;
 

--- a/src/Client/Campaign.php
+++ b/src/Client/Campaign.php
@@ -179,49 +179,6 @@ class Campaign extends Common
         return $campaignResponse;
     }
 
-    /**
-     * Returns a list of all campaigns associated with the meta-campagin with the given slug.
-     *
-     * @psalm-suppress MoreSpecificReturnType
-     * @psalm-suppress LessSpecificReturnStatement
-     * @return list<array>
-     */
-    public function findCampaignsForMetaCampaign(MetaCampaignSlug $metaCampaignSlug, int $limit = 100): array
-    {
-        $campaigns = [];
-        $encodedSlug = urlencode($metaCampaignSlug->slug);
-
-        $offset = 0;
-        $pageSize = 100;
-        $foundEmptyPage = false;
-        while ($offset < $limit) {
-            $uri = $this->getUri(
-                "{$this->baseUriCached()}?parentSlug=$encodedSlug&limit=$pageSize&offset=$offset",
-                true
-            );
-            $response = $this->getHttpClient()->get($uri);
-
-            $decoded = json_decode((string)$response->getBody(), true);
-
-            Assertion::isArray($decoded);
-            if ($decoded === []) {
-                $foundEmptyPage = true;
-                break;
-            }
-
-            $campaigns = [...$campaigns, ...$decoded];
-            $offset += $pageSize;
-        }
-
-        if (! $foundEmptyPage) {
-            throw new \Exception(
-                "Did not find empty page in campaign search results, too many campaigns in metacampaign?"
-            );
-        }
-
-        return $campaigns;
-    }
-
     private function baseUri(): string
     {
         return $this->sfApiBaseUrl . '/campaigns/services/apexrest/v1.0/campaigns';

--- a/src/Domain/CampaignRepository.php
+++ b/src/Domain/CampaignRepository.php
@@ -121,13 +121,21 @@ class CampaignRepository extends SalesforceReadProxyRepository
  *@throws NotFoundException
      *
      */
-    public function fetchAllForMetaCampaign(MetaCampaignSlug $metaCampaginSlug): array
+    public function fetchAlreadyKnownChildrenForMetaCampaign(MetaCampaignSlug $metaCampaignSlug): array
     {
-        /** @var list<array{id: string}> $campaignList */
-        $campaignList = $this->getClient()->findCampaignsForMetaCampaign($metaCampaginSlug, limit: 10_000);
+        $campaignList = $this->search(
+            sortField: 'amountRaised',
+            sortDirection: 'asc',
+            offset: 0,
+            limit: 10_000,
+            metaCampaignSlug: $metaCampaignSlug->slug,
+            fundSlug: null,
+            jsonMatchInListConditions: [],
+            term: null,
+        );
 
-        $campaignIds = array_map(function (array $campaign) {
-            return Salesforce18Id::ofCampaign($campaign['id']);
+        $campaignIds = array_map(function (Campaign $campaign) {
+            return Salesforce18Id::ofCampaign($campaign->getSalesforceId());
         }, $campaignList);
 
         $newFetchCount = 0;


### PR DESCRIPTION
And reduce scope to known campaigns since Salesforce now pushes new ones reliably