### PR TITLE
DON-1192: Remove duplicate capture of Ryft payment

### DIFF
--- a/src/Domain/DonationService.php
+++ b/src/Domain/DonationService.php
@@ -377,17 +377,6 @@ class DonationService
             );
 
             $this->throwIfUnsuccessful($updatedIntent);
-        } else {
-            // @phpstan-ignore-next-line - (phpstan reasonably wants us to use match to check this statically)
-            \assert($psp === PaymentServiceProvider::Ryft, 'Unexpected payment service provider');
-            \assert(isset($paymentSession));
-            \assert(isset($ryftAccountId));
-
-            $this->ryftClient->capturePayment(
-                $ryftAccountId,
-                $paymentSession,
-                Money::fromPence($donation->getAmountToDeductFractional(), $donation->currency()),
-            );
         }
 
         return $updatedIntent ?? null;


### PR DESCRIPTION
Not sure exactly how or why there were two calls to ryftClient::capturePayment in this function.