### PR TITLE
DON-1192: Store ryft payment session ID on donation for reference

### DIFF
--- a/integrationTests/DonationPersistenceTest.php
+++ b/integrationTests/DonationPersistenceTest.php
@@ -103,6 +103,7 @@ class DonationPersistenceTest extends IntegrationTest
             'paymentCard_country' => null,
             'expectedMatchAmount_amountInPence' => 0,
             'expectedMatchAmount_currency' => 'GBP',
+            'ryftPaymentSessionId' => null,
             'updatedAt' => '1970-01-01',
             'createdAt' => '1970-01-01'
         ];

--- a/schema/Donation.sql
+++ b/schema/Donation.sql
@@ -61,6 +61,7 @@ CREATE TABLE `Donation` (
   `paymentCard_country` varchar(255) DEFAULT NULL,
   `expectedMatchAmount_amountInPence` bigint NOT NULL,
   `expectedMatchAmount_currency` varchar(3) NOT NULL,
+  `ryftPaymentSessionId` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `UNIQ_C893E3F6D17F50A6` (`uuid`),
   UNIQUE KEY `UNIQ_C893E3F6C2F43114` (`transactionId`),

--- a/src/Application/Actions/Donations/Create.php
+++ b/src/Application/Actions/Donations/Create.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MatchBot\Application\Actions\Donations;
 
 use Doctrine\DBAL\Exception\ServerException as DBALServerException;
+use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Exception\ORMException;
 use MatchBot\Application\Actions\Action;
 use MatchBot\Application\Actions\ActionError;
@@ -48,6 +49,7 @@ class Create extends Action
         private Stripe $stripe,
         private RyftClient $ryftClient,
         Settings $settings,
+        private EntityManager $em,
     ) {
         parent::__construct($logger);
         $this->enableNoReservationsMode = $settings->enableNoReservationsMode;
@@ -212,10 +214,13 @@ class Create extends Action
         if ($donation->getPsp() === 'ryft') {
             $ryftAccountId = $donation->getCampaign()->getCharity()->getRyftAccountId();
             Assertion::notNull($ryftAccountId, 'Ryft account ID cannot be null for ryft payment method');
-            $ryftClientSecret = $this->ryftClient->createPaymentSession(
+            ['id' => $ryftPaymentSessionID, 'clientSecret' => $ryftClientSecret] = $this->ryftClient->createPaymentSession(
                 $ryftAccountId,
                 Money::fromPence($donation->getAmountForCharityFractional(), $donation->currency()),
             );
+
+            $donation->setRyftPaymentSessionId($ryftPaymentSessionID);
+            $this->em->flush();
         } else {
             $ryftClientSecret = null;
         }

--- a/src/Client/RyftClient.php
+++ b/src/Client/RyftClient.php
@@ -10,6 +10,7 @@ use MatchBot\Application\Assertion;
 use MatchBot\Application\Environment;
 use MatchBot\Domain\Money;
 use MatchBot\Domain\RyftAccountId;
+use MatchBot\Domain\RyftPaymentSessionId;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -37,11 +38,14 @@ class RyftClient
 
     /**
      * @param RyftAccountId $ryftAccountId Ryft sub-account ID of the charity that will receive the payment
-     * @return string client secret
+     *
+     *
+     * @return array{id: RyftPaymentSessionId, clientSecret: string} . Note that the Client Secret must not
+     * be logged or saved - it is only for sending to the client.
      *
      * See https://api-reference.ryftpay.com/#tag/Payments/operation/paymentSessionCreate
      */
-    public function createPaymentSession(RyftAccountId $ryftAccountId, Money $amount): string
+    public function createPaymentSession(RyftAccountId $ryftAccountId, Money $amount): array
     {
         $request = new Request(
             method: 'POST',
@@ -61,20 +65,18 @@ class RyftClient
 
         $responseContents = $response->getBody()->getContents();
 
-        $this->log->info($responseContents);
-
-        /*
-         * 2026-04-01T15:40:22.243849016Z [2026-04-01T15:40:22.243429+00:00] matchbot.INFO: {"id":"ps_01KN4V7VRAGFBGHGRXDZBVTPFM","amount":270,"currency":"GBP","paymentType":"Standard","entryMode":"Online","enabledPaymentMethods":["Card"],"returnUrl":"https://donate.biggive.org","status":"PendingPayment","refundedAmount":0,"clientSecret":"ps_01KN4V7VRAGFBGHGRXDZBVTPFM_secret_0a31276f-1e46-40b0-8bdb-75742249d0b4","statementDescriptor":{"descriptor":"Big Give","city":"Manchester"},"authorizationType":"FinalAuth","captureFlow":"Automatic","createdTimestamp":1775058022,"lastUpdatedTimestamp":1775058022} [] {"commit":"fde1a7d","uid":"9425ebd","memory_peak_usage":"4 MB"}
-
-         */
-
         $response = json_decode($responseContents, true, \JSON_THROW_ON_ERROR);
         Assertion::isArray($response);
         $clientSecret = $response['clientSecret'];
+        $id = $response['id'];
 
         \assert(\is_string($clientSecret));
+        \assert(\is_string($id));
 
-        return $clientSecret;
+        return [
+            'id' => RyftPaymentSessionId::of($id),
+            'clientSecret' => $clientSecret
+        ];
     }
 
     /**

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -425,6 +425,10 @@ class Donation extends SalesforceWriteProxy
     #[ORM\Column(nullable: true, name: 'paymentCard_country')]
     private ?CountryAlpha2 $paymentCardCountry;
 
+    /** @psalm-suppress UnusedProperty - for now just recorded for internal reference */
+    #[ORM\Column(nullable: true)]
+    private ?string $ryftPaymentSessionId = null;
+
     /**
      * @param string|null $billingPostcode
      * @psalm-param numeric-string $amount
@@ -2158,5 +2162,10 @@ class Donation extends SalesforceWriteProxy
     public function paymentServiceProvider(): ?PaymentServiceProvider
     {
         return PaymentServiceProvider::tryFrom($this->psp);
+    }
+
+    public function setRyftPaymentSessionId(RyftPaymentSessionId $id): void
+    {
+        $this->ryftPaymentSessionId = $id->id;
     }
 }

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -708,6 +708,7 @@ class Donation extends SalesforceWriteProxy
             'tipAmount' => (float) $this->getTipAmount(),
             'tipGiftAid' => $this->hasTipGiftAid(),
             'transactionId' => $this->getTransactionId(),
+            'referenceCode' => $this->getReferenceCode(),
             'updatedTime' => $this->getUpdatedDate()->format(DateTimeInterface::ATOM),
         ];
 
@@ -995,6 +996,12 @@ class Donation extends SalesforceWriteProxy
     public function getTransactionId(): ?string
     {
         return $this->transactionId;
+    }
+
+    /** Code to be given to donor so they can quote it back to us to identify the donation. */
+    public function getReferenceCode(): string
+    {
+        return $this->transactionId ?? $this->uuid->toString();
     }
 
 

--- a/src/Domain/DonationNotifier.php
+++ b/src/Domain/DonationNotifier.php
@@ -93,7 +93,8 @@ class DonationNotifier
             'totalChargedAmount' => (float) $donation->getTotalPaidByDonor(),
 
             'totalCharityValueAmount' => (float) $donation->totalCharityValueAmount(),
-            'transactionId' => $donation->getTransactionId(),
+            'transactionId' => $donation->getReferenceCode(), // @todo switch mailer to use referenceCode and delete this after line below is in prod
+            'referenceCode' => $donation->getReferenceCode(),
             'charityLogoUri' => $charity->getLogoUri()?->__toString(),
             'charityWebsite' => $charity->getWebsiteUri()?->__toString(),
 

--- a/src/Domain/DonationService.php
+++ b/src/Domain/DonationService.php
@@ -1246,7 +1246,7 @@ class DonationService
         }
     }
 
-    public function notifyDonationSuccesIfRequired(Donation $donation, bool $donationWasPreviouslyCollected): void
+    private function notifyDonationSuccesIfRequired(Donation $donation, bool $donationWasPreviouslyCollected): void
     {
         $showAccountExistsForEmail = $this->donorAccountRepository->accountExistsMatchingEmailWithDonation($donation);
 

--- a/src/Domain/RyftPaymentSessionId.php
+++ b/src/Domain/RyftPaymentSessionId.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace MatchBot\Domain;
+
+use MatchBot\Application\Assertion;
+
+readonly class RyftPaymentSessionId
+{
+    private function __construct(public string $id)
+    {
+        Assertion::regex(
+            $this->id,
+            '/^ps_[0-7][0-9A-HJKMNP-TV-Z]{25}/',
+            'Value "%s" does not match regex for ryft payment session'
+        );
+    }
+
+    public static function of(string $id): self
+    {
+        return new self($id);
+    }
+}

--- a/src/Domain/RyftPaymentSessionId.php
+++ b/src/Domain/RyftPaymentSessionId.php
@@ -15,6 +15,10 @@ readonly class RyftPaymentSessionId
         );
     }
 
+    /**
+     * @param string $id - for instance 'ps_01FCTS1XMKH9FF43CAFA4CXT3P'
+     * @return self
+     */
     public static function of(string $id): self
     {
         return new self($id);

--- a/src/Migrations/Version20260520135332.php
+++ b/src/Migrations/Version20260520135332.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260520135332 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add column Donation.ryftPaymentSessionId';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE Donation ADD ryftPaymentSessionId VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE Donation DROP ryftPaymentSessionId');
+    }
+}

--- a/tests/Application/Actions/Donations/CreateTest.php
+++ b/tests/Application/Actions/Donations/CreateTest.php
@@ -12,6 +12,7 @@ use MatchBot\Application\Environment;
 use MatchBot\Application\Matching\Allocator;
 use MatchBot\Application\Messenger\DonationUpserted;
 use Doctrine\ORM\EntityManagerInterface;
+use MatchBot\Client\RyftClient;
 use MatchBot\Client\Stripe;
 use MatchBot\Domain\Campaign;
 use MatchBot\Domain\CampaignFunding;
@@ -26,6 +27,8 @@ use MatchBot\Domain\FundingWithdrawal;
 use MatchBot\Domain\FundRepository;
 use MatchBot\Domain\FundType;
 use MatchBot\Domain\PaymentMethodType;
+use MatchBot\Domain\PaymentServiceProvider;
+use MatchBot\Domain\RyftPaymentSessionId;
 use MatchBot\Domain\Salesforce18Id;
 use MatchBot\Domain\StripeCustomerId;
 use MatchBot\Tests\TestCase;
@@ -81,6 +84,9 @@ class CreateTest extends TestCase
 
     /** @var ObjectProphecy<EntityManagerInterface>  */
     private ObjectProphecy $entityManagerProphecy;
+
+    /** @var ObjectProphecy<RyftClient>  */
+    private ObjectProphecy $ryftClientProphecy;
 
     #[\Override]
     public function setUp(): void
@@ -147,11 +153,14 @@ class CreateTest extends TestCase
         $this->entityManagerProphecy->getUnitOfWork()->willReturn($emptyUow->reveal());
         $this->diContainer()->set(EntityManagerInterface::class, $this->entityManagerProphecy->reveal());
 
+        $this->ryftClientProphecy = $this->prophesize(RyftClient::class);
+
         $this->diContainer()->set(CampaignRepository::class, $this->campaignRepositoryProphecy->reveal());
         $this->diContainer()->set(DonorAccountRepository::class, $this->createStub(DonorAccountRepository::class));
         $this->diContainer()->set(FundRepository::class, $this->prophesize(FundRepository::class)->reveal());
         $this->donationRepoProphecy = $this->prophesize(DonationRepository::class);
         $this->diContainer()->set(DonationRepository::class, $this->donationRepoProphecy->reveal());
+        $this->diContainer()->set(RyftClient::class, $this->ryftClientProphecy->reveal());
 
         $this->allocatorProphecy = $this->prophesize(Allocator::class);
         $this->diContainer()->set(Allocator::class, $this->allocatorProphecy->reveal());
@@ -836,6 +845,66 @@ class CreateTest extends TestCase
     }
 
     /**
+     * Use unmatched campaign in previous test but also omit all donor-supplied
+     * detail except donation and tip amount, to test new 2-step Create setup.
+     */
+    public function testSuccessWithMinimalDataAndCharityOnRyft(): void
+    {
+        $this->entityManagerProphecy->beginTransaction()->shouldBeCalled();
+        $this->entityManagerProphecy->commit()->shouldBeCalled();
+
+        $donation = $this->getTestDonation(true, false, true, psp: PaymentServiceProvider::Ryft);
+        $app = $this->getAppWithCommonPersistenceDeps(
+            donationPersisted: true,
+            donationPushed: true,
+            donationMatched: false,
+            donation: $donation,
+            skipEmExpectations: true,
+        );
+        $this->setupFakeDonationProvider($donation);
+        $this->entityManagerProphecy->persist($donation)->shouldBeCalled();
+        $this->entityManagerProphecy->flush()->shouldBeCalled();
+
+        $this->ryftClientProphecy->createPaymentSession(Argument::cetera())->shouldBeCalled()
+            ->willReturn([
+                'id' => RyftPaymentSessionId::of('ps_01FCTS1XMKH9FF43CAFA4CXT3P'),
+                'clientSecret' => 'some-secret',
+            ]);
+
+        $this->diContainer()->set(Stripe::class, $this->stripeProphecy->reveal());
+
+        $data = $this->encode($donation);
+        $request = $this->createRequest('POST', Identity::TEST_PERSON_NEW_DONATION_ENDPOINT, $data);
+        $response = $app->handle($this->addDummyPersonAuth($request));
+
+        $payload = (string) $response->getBody();
+
+        $this->assertJson($payload);
+        $this->assertSame(201, $response->getStatusCode());
+
+        /** @var array<string, string|numeric|boolean|array<array-key, mixed>> $payloadArray */
+        $payloadArray = json_decode($payload, true);
+
+        $this->assertIsString($payloadArray['jwt']);
+        $this->assertNotEmpty($payloadArray['jwt']);
+        $this->assertIsArray($payloadArray['donation']);
+        $this->assertNotEmpty($payloadArray['donation']['createdTime']);
+        $this->assertFalse($payloadArray['donation']['giftAid']);
+        $this->assertNull($payloadArray['donation']['optInCharityEmail']);
+        $this->assertNull($payloadArray['donation']['optInChampionEmail']);
+        $this->assertNull($payloadArray['donation']['optInTbgEmail']);
+        $this->assertSame(0.38, $payloadArray['donation']['charityFee']); // 1.5% + 20p.
+        $this->assertSame(0.08, $payloadArray['donation']['charityFeeVat']);
+        $this->assertSame('GB', $payloadArray['donation']['countryCode']);
+        $this->assertSame(12, $payloadArray['donation']['donationAmount']);
+        $this->assertSame(self::DONATION_UUID, $payloadArray['donation']['donationId']);
+        $this->assertSame(0, $payloadArray['donation']['matchReservedAmount']);
+        $this->assertSame(1.11, $payloadArray['donation']['tipAmount']);
+        $this->assertSame('567CharitySFID', $payloadArray['donation']['charityId']);
+        $this->assertSame('123CAmPAIGNID12345', $payloadArray['donation']['projectId']);
+    }
+
+    /**
      * Persist itself failing with a non-retryable exception should mean we give up immediately.
      */
     public function testErrorWhenDbPersistCallFails(): void
@@ -964,11 +1033,22 @@ class CreateTest extends TestCase
         bool $campaignMatched,
         bool $minimalSetupData = false,
         string $currencyCode = 'GBP',
+        PaymentServiceProvider $psp = PaymentServiceProvider::Stripe,
     ): Donation {
-        $charity = \MatchBot\Tests\TestCase::someCharity();
+
+        $charity = \MatchBot\Tests\TestCase::someCharity(psp: $psp);
+
+        switch ($psp) {
+            case PaymentServiceProvider::Stripe:
+                $charity->setStripeAccountId('unitTest_stripeAccount_123');
+                break;
+            case PaymentServiceProvider::Ryft:
+                // no-op
+                break;
+        }
         $charity->setSalesforceId('567CharitySFID');
         $charity->setName('Create test charity');
-        $charity->setStripeAccountId('unitTest_stripeAccount_123');
+
 
         $campaign = TestCase::someCampaign(sfId: Salesforce18Id::ofCampaign('123CAmPAIGNID12345'), charity: $charity);
         $campaign->setName('123CampaignName');
@@ -981,7 +1061,7 @@ class CreateTest extends TestCase
         }
         $this->campaign = $campaign;
 
-        $donation = TestCase::someDonation(amount: '12.00', currencyCode: $currencyCode);
+        $donation = TestCase::someDonation(amount: '12.00', currencyCode: $currencyCode, psp: $psp);
         $donation->setCampaign(TestCase::getMinimalCampaign());
 
         if (!$minimalSetupData) {

--- a/tests/Domain/DonationNotifierTest.php
+++ b/tests/Domain/DonationNotifierTest.php
@@ -74,6 +74,7 @@ class DonationNotifierTest extends TestCase
 
                     'charityPhoneNumber' => '0191 498 0000',
                     'charityEmailAddress' => 'charity@charitiesareus.com',
+                    'referenceCode' => 'some-transaction-id',
                 ]
             ],
             [$emailCommand->templateKey, $emailCommand->emailAddress->email, $emailCommand->params]

--- a/tests/Domain/DonationTest.php
+++ b/tests/Domain/DonationTest.php
@@ -229,7 +229,7 @@ class DonationTest extends TestCase
 
     public function testToSfAPIModel(): void
     {
-        $donation = self::someDonation(amount: '10', tipAmount: '1', collected: true);
+        $donation = self::someDonation(amount: '10', tipAmount: '1', collected: true, transactionId: 'some-transaction-id');
 
         $donation->recordPayout('po_some_payout_id', new \DateTimeImmutable('2025-05-21T02:17:46+01:00'));
 
@@ -273,13 +273,14 @@ class DonationTest extends TestCase
                 'tipGiftAid' => null,
                 'tipRefundAmount' => null,
                 'totalPaid' => 11.0,
-                'transactionId' => null,
+                'transactionId' => 'some-transaction-id',
                 'updatedTime' => $donation->getUpdatedDate()->format('c'),
                 'stripePayoutId' => 'po_some_payout_id',
                 'paidOutAt' => '2025-05-21T02:17:46+01:00',
                 'payoutSuccessful' => true,
                 'isOffSession' => false,
                 'isOrganisationDonor' => true,
+                'referenceCode' => 'some-transaction-id',
             ],
             $donation->toSFApiModel()
         );

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -474,6 +474,7 @@ class TestCase extends PHPUnitTestCase
         bool $collected = false,
         ?string $transferId = null,
         ?int $mandateSequenceNumber = null,
+        ?string $transactionId = null,
     ): Donation {
 
         $donation = new Donation(
@@ -501,6 +502,9 @@ class TestCase extends PHPUnitTestCase
         );
 
         $donation->setUuid($uuid ?? Uuid::uuid4());
+        if (\is_string($transactionId)) {
+            $donation->setTransactionId($transactionId);
+        }
 
         if ($collected) {
             self::collectDonation(

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -27,6 +27,7 @@ use MatchBot\Domain\PaymentMethodType;
 use MatchBot\Domain\PaymentServiceProvider;
 use MatchBot\Domain\RegularGivingMandate;
 use MatchBot\Domain\PersonId;
+use MatchBot\Domain\RyftAccountId;
 use MatchBot\Domain\Salesforce18Id;
 use MatchBot\IntegrationTests\IntegrationTest;
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
@@ -383,13 +384,14 @@ class TestCase extends PHPUnitTestCase
         string $name = 'Charity Name',
         ?string $phoneNumber = null,
         ?EmailAddress $emailAddress = null,
+        PaymentServiceProvider $psp = PaymentServiceProvider::Stripe,
     ): Charity {
         return new Charity(
             salesforceId: $salesforceId->value ?? ('123CharityId' . self::randomHex(3)),
             charityName: $name,
-            stripeAccountId: $stripeAccountId ?? "stripe-account-id-" . self::randomHex(),
-            ryftAccountId: null,
-            psp: PaymentServiceProvider::Stripe,
+            stripeAccountId: $psp === PaymentServiceProvider::Stripe ? ($stripeAccountId ?? "stripe-account-id-" . self::randomHex()) : null,
+            ryftAccountId: $psp === PaymentServiceProvider::Ryft ? RyftAccountId::of("ac_aaaaaaaa-bbbb-aaaa-bbbb-aaaaaaaaaaaa") : null,
+            psp: $psp,
             hmrcReferenceNumber: 'H' . self::randomHex(3),
             giftAidOnboardingStatus: 'Onboarded',
             regulator: 'CCEW',
@@ -475,6 +477,7 @@ class TestCase extends PHPUnitTestCase
         ?string $transferId = null,
         ?int $mandateSequenceNumber = null,
         ?string $transactionId = null,
+        PaymentServiceProvider $psp = \MatchBot\Domain\PaymentServiceProvider::Stripe,
     ): Donation {
 
         $donation = new Donation(
@@ -485,7 +488,7 @@ class TestCase extends PHPUnitTestCase
             charityComms: null,
             championComms: null,
             pspCustomerId: null,
-            psp: \MatchBot\Domain\PaymentServiceProvider::Stripe,
+            psp: $psp,
             optInTbgEmail: null,
             donorName: $donorName,
             emailAddress: $emailAddress,


### PR DESCRIPTION
For now just for manual reference via DB, but may be used more in future.