### PR TITLE
Update PHPStan to 2.2.0

### DIFF
--- a/app/dependencies.php
+++ b/app/dependencies.php
@@ -590,6 +590,7 @@ return function (ContainerBuilder $containerBuilder) {
 
 
             $connection = DBALDriverManager::getConnection(
+                // @phpstan-ignore argument.type (DBAL docblock doesn't explicitly allow the platform key but it works for now)
                 $c->get(Settings::class)->doctrine['connection'] +
                 [
                     'platform' => new \MatchBot\Application\CustomMysqlPlatform(),

--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,7 @@
         "phpspec/prophecy": "^1.19",
         "phpspec/prophecy-phpunit": "^v2.1.0",
         "phpstan/extension-installer": "^1.4",
-        "phpstan/phpstan": "^2.1.39",
+        "phpstan/phpstan": "^2.2.0",
         "phpstan/phpstan-beberlei-assert": "^2.0",
         "phpstan/phpstan-doctrine": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "79051626e2889e71908e44db2344cdd3",
+    "content-hash": "5bc0ac87dee00044e4087e7f7eaa52b3",
     "packages": [
         {
             "name": "async-aws/core",
@@ -9754,11 +9754,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.40",
+            "version": "2.2.1",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9b2c7aeb83a75d8680ea5e7c9b7fca88052b766b",
-                "reference": "9b2c7aeb83a75d8680ea5e7c9b7fca88052b766b",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/dea9c8f2d25cc849391042b71e429c1a4bf82660",
+                "reference": "dea9c8f2d25cc849391042b71e429c1a4bf82660",
                 "shasum": ""
             },
             "require": {
@@ -9780,6 +9780,17 @@
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
             "keywords": [
@@ -9803,7 +9814,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-02-23T15:04:35+00:00"
+            "time": "2026-05-28T14:44:12+00:00"
         },
         {
             "name": "phpstan/phpstan-beberlei-assert",

--- a/integrationTests/DonationMatchingTest.php
+++ b/integrationTests/DonationMatchingTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\Clock\MockClock;
 
 class DonationMatchingTest extends IntegrationTest
 {
+    // @phpstan-ignore property.onlyWritten (this seems to be untrue, it is read in e.g. testACrashedDonationDoesNOtReduceAvailableMatchFunds )
     private int $campaignFundingId;
     private CampaignFundingRepository $campaignFundingRepository;
     private Adapter $matchingAdapater;

--- a/integrationTests/IntegrationTest.php
+++ b/integrationTests/IntegrationTest.php
@@ -208,7 +208,7 @@ abstract class IntegrationTest extends TestCase
         };
 
         /** @var ApiClient $client */
-        $client = [
+        $client = [ // @phpstan-ignore varTag.nativeType
             'global' => $global,
             'mailer' => [
                 'baseUri' => 'dummy-mailer-base-uri',

--- a/src/Application/Actions/UpdatePaymentMethod.php
+++ b/src/Application/Actions/UpdatePaymentMethod.php
@@ -85,7 +85,7 @@ class UpdatePaymentMethod extends Action
             /**
              * @psalm-suppress MixedArgumentTypeCoercion - up to the FE to supply the right params in `$newBillingDetails`
              */
-            $this->stripeClient->paymentMethods->update($paymentMethodId, $newBillingDetails);
+            $this->stripeClient->paymentMethods->update($paymentMethodId, $newBillingDetails); // @phpstan-ignore argument.type
         } catch (ApiErrorException $e) {
             // Error message could be e.g. "Your card's security code is incorrect." in which case the donor
             // will not be able to update their card and can choose to delete it and add a new card for their

--- a/src/Application/Commands/MergeOpenApiDocs.php
+++ b/src/Application/Commands/MergeOpenApiDocs.php
@@ -108,8 +108,8 @@ class MergeOpenApiDocs extends Command
                             continue;
                         }
 
-                        if (!isset($result['paths'][$path][$method])) { // @phpstan-ignore offsetAccess.nonOffsetAccessible
-                            $result['paths'][$path][$method] = $methodData; // @phpstan-ignore offsetAccess.nonOffsetAccessible
+                        if (!isset($result['paths'][$path][$method])) {
+                            $result['paths'][$path][$method] = $methodData;
                         }
                     }
                 }
@@ -117,13 +117,15 @@ class MergeOpenApiDocs extends Command
         }
 
         // Special handling for components/schemas
+        // @phpstan-ignore offsetAccess.nonOffsetAccessible
         if (isset($attritributes['components']['schemas']) && is_array($attritributes['components']['schemas'])) {
             if (!isset($result['components'])) {
                 $result['components'] = [];
             }
 
+            // @phpstan-ignore offsetAccess.nonOffsetAccessible
             if (!isset($result['components']['schemas']) || !is_array($result['components']['schemas'])) {
-                $result['components']['schemas'] = [];
+                $result['components']['schemas'] = []; // @phpstan-ignore offsetAccess.nonOffsetAccessible
             }
 
             foreach ($attritributes['components']['schemas'] as $schema => $schemaData) {

--- a/src/Client/RyftClient.php
+++ b/src/Client/RyftClient.php
@@ -145,7 +145,7 @@ class RyftClient
         $responseContents = $response->getBody()->getContents();
 
         /** @var array{id: string, amount: int, platformFee: int, currency: string, status: string} $responseData */
-        $responseData = json_decode($responseContents, associative: true, depth: \JSON_THROW_ON_ERROR);
+        $responseData = json_decode($responseContents, associative: true, flags: \JSON_THROW_ON_ERROR);
 
         $this->log->info('Captured Ryft payment or ' . $responseData['amount'] . ' for payment session ' . $responseData['id']);
 

--- a/src/Domain/Campaign.php
+++ b/src/Domain/Campaign.php
@@ -629,7 +629,7 @@ class Campaign extends SalesforceReadProxy
      */
     public function getSalesforceData(): array
     {
-        return $this->salesforceData + ['charity' => $this->charity->getSalesforceData()];
+        return $this->salesforceData + ['charity' => $this->charity->getSalesforceData()]; // @phpstan-ignore return.type
     }
 
     /**

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -963,8 +963,6 @@ class Donation extends SalesforceWriteProxy
 
             $fundTypeOfThisWithdrawal = $fundingWithdrawal->getCampaignFunding()->getFund()->getFundType();
 
-            // I don't think the match.unhandled error from phpstan here can be right - we handle 12 cases: 3 cases of enum * 2 values of bool * 2 values of bool
-            // @phpstan-ignore match.unhandled
             $key = match ([$fundTypeOfThisWithdrawal, $this->donationStatus->isSuccessful(), $this->donationStatus === DonationStatus::PreAuthorized  ]) {
                 [FundType::ChampionFund, true, true] => throw new \LogicException("impossible status"),
                 [FundType::ChampionFund, true, false] => 'amountMatchedByChampionFunds',
@@ -1870,7 +1868,7 @@ class Donation extends SalesforceWriteProxy
         }
 
         /** @psalm-suppress InvalidReturnStatement - see note in docblock */
-        return $payload;
+        return $payload; // @phpstan-ignore return.type (see note in docblock)
     }
 
     public function isFullyMatched(): bool

--- a/src/Domain/DonationService.php
+++ b/src/Domain/DonationService.php
@@ -313,8 +313,8 @@ class DonationService
         $this->updateDonationFeesFromConfirmationTokenOrCard($donation, $confirmationToken, $card);
 
         if ($psp === PaymentServiceProvider::Ryft) {
-            \assert(isset($paymentSession));
-            \assert(isset($ryftAccountId));
+            \assert(isset($paymentSession)); // @phpstan-ignore isset.variable (psalm still needs this)
+            \assert(isset($ryftAccountId)); // @phpstan-ignore isset.variable (psalm still needs this)
             $donationWasPreviouslyCollected = $donation->getDonationStatus() === DonationStatus::Collected;
 
             $capture = $this->ryftClient->capturePayment(

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -142,7 +142,6 @@ class TestCase extends PHPUnitTestCase
 
 
     /**
-     * @psalm-suppress InvalidConstantAssignmentValue - can't work out quite what Psalm thinks is wrong here
      * @var SFCampaignApiResponse
      */
     public const array META_CAMPAIGN_FROM_SALESFORCE = [
@@ -153,7 +152,6 @@ class TestCase extends PHPUnitTestCase
         'video' => null,
         'hidden' => false,
         'quotes' => [],
-        'status' => 'Active',
         'endDate' => '2095-08-01T00:00:00.000Z',
         'logoUri' => null,
         'problem' => '',
@@ -198,7 +196,6 @@ class TestCase extends PHPUnitTestCase
         'budgetDetails' => [],
         'beneficiaries' => [],
         'parentTarget' => null,
-        'ryftAccountId' => null,
     ];
 
     /**


### PR DESCRIPTION
See https://phpstan.org/blog/phpstan-2-2-unsealed-array-shapes-safer-array-keys

Errors found by running new PHPStan on old code were as shown below:

```
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   app/dependencies.php
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  593    Parameter #1 $params of static method Doctrine\DBAL\DriverManager::getConnection() expects array{application_name?: string, charset?: string, dbname?: string, defaultTableOptions?: array<string, mixed>, driver?: 'ibm_db2'|'mysqli'|'oci8'|'pdo_mysql'|'pdo_oci'|'pdo_pgsql'|'pdo_
         sqlite'|'pdo_sqlsrv'|'pgsql'|'sqlite3'|'sqlsrv', driverClass?: class-string<Doctrine\DBAL\Driver>, driverOptions?: array<mixed>, host?: string, ...}, array{platform: MatchBot\Application\CustomMysqlPlatform, application_name?: string, charset?: string, dbname?: string, default
         TableOptions?: array<string, mixed>, driver?: 'ibm_db2'|'mysqli'|'oci8'|'pdo_mysql'|'pdo_oci'|'pdo_pgsql'|'pdo_sqlite'|'pdo_sqlsrv'|'pgsql'|'sqlite3'|'sqlsrv', driverClass?: class-string<Doctrine\DBAL\Driver>, driverOptions?: array<mixed>, ...} given.
         🪪  argument.type
         💡  Sealed array shape does not accept array with extra key 'platform'.
         ✏️  /var/www/html/app/dependencies.php:593
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

 ------ ----------------------------------------------------------------------------------------------------------
  Line   integrationTests/DonationMatchingTest.php
 ------ ----------------------------------------------------------------------------------------------------------
  18     Property MatchBot\IntegrationTests\DonationMatchingTest::$campaignFundingId is never read, only written.
         🪪  property.onlyWritten
         💡  See: https://phpstan.org/developing-extensions/always-read-written-properties
         ✏️  /var/www/html/integrationTests/DonationMatchingTest.php:18
 ------ ----------------------------------------------------------------------------------------------------------

 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   integrationTests/IntegrationTest.php
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  211    PHPDoc tag @var with type array{global: array{timeout: string}, salesforce: array{baseUri: string, baseUriCached: string}, mailer: array{baseUri: string, sendSecret: string}} is not subtype of native type array{global: mixed, mailer: array{baseUri: 'dummy-mailer-base…'},
         salesforce: array{baseUri: 'dummy-salesforce…'}}.
         🪪  varTag.nativeType
         ✏️  /var/www/html/integrationTests/IntegrationTest.php:211
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   src/Application/Actions/UpdatePaymentMethod.php
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  88     Parameter #2 $params of method Stripe\Service\PaymentMethodService::update() expects array{allow_redisplay?: string, billing_details?: array{address?: array{city?: string, country?: string, line1?: string, line2?: string, postal_code?: string, state?: string}|null, email?:
         string|null, name?: string|null, phone?: string|null, tax_id?: string}, card?: array{exp_month?: int, exp_year?: int, networks?: array{preferred?: string|null}}, expand?: array<string>, metadata?: array<string, string>|null, payto?: array{account_number?: string, bsb_number?:
         string, pay_id?: string}, us_bank_account?: array{account_holder_type?: string, account_type?: string}}|null, array<mixed, mixed> given.
         🪪  argument.type
         💡  Type #1 from the union: Sealed array shape can only accept a constant array. Extra keys are not allowed.
         ✏️  /var/www/html/src/Application/Actions/UpdatePaymentMethod.php:88
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

 ------ ------------------------------------------------------------------------------------
  Line   src/Application/Commands/MergeOpenApiDocs.php
 ------ ------------------------------------------------------------------------------------
  111    No error with identifier offsetAccess.nonOffsetAccessible is reported on line 111.
         🪪  ignore.unmatchedIdentifier (non-ignorable)
         ✏️  /var/www/html/src/Application/Commands/MergeOpenApiDocs.php:111
  112    No error with identifier offsetAccess.nonOffsetAccessible is reported on line 112.
         🪪  ignore.unmatchedIdentifier (non-ignorable)
         ✏️  /var/www/html/src/Application/Commands/MergeOpenApiDocs.php:112
  120    Cannot access offset 'schemas' on mixed.
         🪪  offsetAccess.nonOffsetAccessible
         ✏️  /var/www/html/src/Application/Commands/MergeOpenApiDocs.php:120
  125    Cannot access offset 'schemas' on mixed.
         🪪  offsetAccess.nonOffsetAccessible
         ✏️  /var/www/html/src/Application/Commands/MergeOpenApiDocs.php:125
  126    Cannot access offset 'schemas' on mixed.
         🪪  offsetAccess.nonOffsetAccessible
         ✏️  /var/www/html/src/Application/Commands/MergeOpenApiDocs.php:126
 ------ ------------------------------------------------------------------------------------

 ------ -------------------------------------------------------------------------------------------
  Line   src/Client/RyftClient.php
 ------ -------------------------------------------------------------------------------------------
  148    Constant JSON_THROW_ON_ERROR is not allowed for parameter $depth of function json_decode.
         🪪  argument.invalidConstant
         ✏️  /var/www/html/src/Client/RyftClient.php:148
 ------ -------------------------------------------------------------------------------------------

 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   src/Domain/Campaign.php
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  632    Method MatchBot\Domain\Campaign::getSalesforceData() should return array{charity: array{id: string, name: string, logoUri: string|null, phoneNumber: string|null, emailAddress: string|null, twitter: string|null, website: string|null, facebook: string|null, ...}|null, endDate:
         string|null, id: string, isMatched: bool, isPublished: bool, startDate: string|null, pinPosition?: int|null, championPagePinPosition?: int|null, ...} but returns non-empty-array<string, mixed>.
         🪪  return.type
         💡  Offset 'aims' (list<string>) does not accept type mixed: mixed is not a list.
         💡  Offset 'countries' (list<string>) does not accept type mixed: mixed is not a list.
         💡  Offset 'categories' (list<string>) does not accept type mixed: mixed is not a list.
         💡  Offset 'budgetDetails' (list<array{amount: float, description: string}>) does not accept type mixed: mixed is not a list.
         💡  Offset 'beneficiaries' (list<string>) does not accept type mixed: mixed is not a list.
         💡  Offset 'updates' (list<array{content: string, modifiedDate: string}>) does not accept type mixed: mixed is not a list.
         💡  Offset 'quotes' (list<array{person: string, quote: string}>) does not accept type mixed: mixed is not a list.
         💡  Offset 'additionalImages' (list<array{altText: string, rank: int, uri: string}>) does not accept type mixed: mixed is not a list.
         💡  Offset 'additionalImageUris' (list<array{order: int, uri: string}>) does not accept type mixed: mixed is not a list.
         💡  Sealed array shape can only accept a constant array. Extra keys are not allowed.
         ✏️  /var/www/html/src/Domain/Campaign.php:632
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   src/Domain/Donation.php
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------
  968    No error with identifier match.unhandled is reported on line 968.
         🪪  ignore.unmatchedIdentifier (non-ignorable)
         ✏️  /var/www/html/src/Domain/Donation.php:968
  1873   Method MatchBot\Domain\Donation::createStripePaymentIntentPayload() should return array{amount: int, currency: string} but returns non-empty-array<string, mixed>.
         🪪  return.type
         💡  Sealed array shape can only accept a constant array. Extra keys are not allowed.
         ✏️  /var/www/html/src/Domain/Donation.php:1873
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------

 ------ ------------------------------------------------------------------------
  Line   src/Domain/DonationService.php
 ------ ------------------------------------------------------------------------
  316    Variable $paymentSession in isset() always exists and is not nullable.
         🪪  isset.variable
         ✏️  /var/www/html/src/Domain/DonationService.php:316
  317    Variable $ryftAccountId in isset() always exists and is not nullable.
         🪪  isset.variable
         ✏️  /var/www/html/src/Domain/DonationService.php:317
 ------ ------------------------------------------------------------------------

 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   tests/TestCase.php
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  148    Constant MatchBot\Tests\TestCase::META_CAMPAIGN_FROM_SALESFORCE (array<string, array<int<0, max>|string, array<string, float|int|string>|string|null>|bool|float|int|string|null>) does not accept value array{id: 'a05xxxxxxxxxxxxxxx', isMetaCampaign: true, isPublished: true, tit
         le: 'This is a meta…', video: null, hidden: false, quotes: array{}, status: 'Active', ...}.
         🪪  classConstant.value
         💡  Sealed array shape does not accept array with extra key 'status'.
         💡  Sealed array shape does not accept array with extra key 'ryftAccountId'.
         ✏️  /var/www/html/tests/TestCase.php:148
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

 [ERROR] Found 16 errors
 ```