### PR TITLE
BG2-3145 Stop sending Stripe per-donation descriptors

### DIFF
--- a/src/Domain/Charity.php
+++ b/src/Domain/Charity.php
@@ -358,6 +358,11 @@ class Charity extends SalesforceReadProxy
         $this->emailAddress = $emailAddress?->email;
     }
 
+    /**
+     * This is now our approximation of the statement descriptor Salesforce sets at account level.
+     * It's only directly used to tell donors what to look out for rather than sent to Stripe
+     * per-donation which didn't work as we wanted pre-BG2-3145.
+     */
     public function getStatementDescriptor(): string
     {
         $maximumLength = 22; // https://stripe.com/docs/payments/payment-intents#dynamic-statement-descriptor

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -1851,8 +1851,6 @@ class Donation extends SalesforceWriteProxy
                 'stripeFeeRechargeVat' => $this->getCharityFeeVat(),
                 'tipAmount' => $this->getTipAmount(),
             ],
-            'statement_descriptor' => $this->getCampaign()->getCharity()->getStatementDescriptor(),
-            'statement_descriptor_suffix' => $this->getCampaign()->getCharity()->getStatementDescriptor(),
             // See https://stripe.com/docs/connect/destination-charges#application-fee
             'application_fee_amount' => $this->getAmountToDeductFractional(),
             'transfer_data' => [

--- a/tests/Application/Actions/Donations/CreateTest.php
+++ b/tests/Application/Actions/Donations/CreateTest.php
@@ -121,8 +121,6 @@ class CreateTest extends TestCase
                 'stripeFeeRechargeVat' => '0.08',
                 'tipAmount' => '1.11',
             ],
-            'statement_descriptor' => 'Big Give Create test c',
-            'statement_descriptor_suffix' => 'Big Give Create test c',
             'application_fee_amount' => 157,
             'on_behalf_of' => 'unitTest_stripeAccount_123',
             'transfer_data' => [
@@ -401,8 +399,6 @@ class CreateTest extends TestCase
                 'stripeFeeRechargeVat' => '0.08',
                 'tipAmount' => '1.11',
             ],
-            'statement_descriptor' => 'Big Give Create test c',
-            'statement_descriptor_suffix' => 'Big Give Create test c',
             'application_fee_amount' => 157,
             'on_behalf_of' => 'unitTest_newStripeAccount_456',
             'transfer_data' => [
@@ -510,8 +506,6 @@ class CreateTest extends TestCase
                 'stripeFeeRechargeVat' => '0.08',
                 'tipAmount' => '1.11',
             ],
-            'statement_descriptor' => 'Big Give Create test c',
-            'statement_descriptor_suffix' => 'Big Give Create test c',
             'application_fee_amount' => 157,
             'transfer_data' => [
                 'destination' => 'unitTest_stripeAccount_123',
@@ -606,8 +600,6 @@ class CreateTest extends TestCase
                 'stripeFeeRechargeVat' => '0.08',
                 'tipAmount' => '1.11',
             ],
-            'statement_descriptor' => 'Big Give Create test c',
-            'statement_descriptor_suffix' => 'Big Give Create test c',
             'application_fee_amount' => 157,
             'on_behalf_of' => 'unitTest_stripeAccount_123',
             'transfer_data' => [


### PR DESCRIPTION
These can only be combined with account defaults which isn't what we want to give donors the clearest refs we can.