### PR TITLE
SO-78: Stop attempting to send countries from SF through to FE

### DIFF
--- a/src/Application/Commands/CreateFictionalData.php
+++ b/src/Application/Commands/CreateFictionalData.php
@@ -280,7 +280,6 @@ class CreateFictionalData extends Command
             'solution' => 'do the saving',
             // in prod bannerUri is available in multiple sizes with a `width` param added by FE. Picsum will always send the image at 1700px wide.
             'bannerUri' => "https://picsum.photos/seed/$randomSeed/1700/500",
-            'countries' => [0 => 'United Kingdom'],
             'locations' => [['countryName' => 'United Kingdom', 'regionCode' => null]],
             'isMatched' => $isMatched,
             'parentRef' => $metaCampaign?->getSlug()?->slug,

--- a/src/Application/HttpModels/Campaign.php
+++ b/src/Application/HttpModels/Campaign.php
@@ -30,7 +30,6 @@ readonly class Campaign
      * @param list<string> $beneficiaries
      * @param list<array{amount: float, description: string}> $budgetDetails
      * @param list<string> $categories
-     * @param list<string> $countries
      * @param array<int, array{countryName: ?string, regionCode: ?string}> $locations array is simplest way to match type; ArrayCollection is not covariant.
      * @param list<array{person: string, quote: string}> $quotes
      * @param list<array{content: string, modifiedDate: string}> $updates
@@ -153,13 +152,6 @@ readonly class Campaign
             ref: "#/components/schemas/Charity"
         )]
         public Charity $charity,
-        #[OA\Property(
-            property: "countries",
-            description: "List of countries where the campaign operates",
-            type: "array",
-            items: new OA\Items(type: "string", example: "United Kingdom")
-        )]
-        public array $countries,
         #[OA\Property(
             property: "currencyCode",
             description: "Currency code for the campaign",

--- a/src/Client/Campaign.php
+++ b/src/Client/Campaign.php
@@ -57,7 +57,6 @@ use MatchBot\Domain\MetaCampaignSlug;
  *     banner?: array{uri: string, alt_text: ?string}|null,
  *     amountRaised: float,
  *     summary: string,
- *     countries: list<string>,
  *     locations: list<array{countryName: ?string, regionCode: ?string}>,
  *     categories: list<string>,
  *     budgetDetails: list<array{amount: float, description: string}>,

--- a/src/Domain/CampaignService.php
+++ b/src/Domain/CampaignService.php
@@ -249,7 +249,6 @@ class CampaignService
             championOptInStatement: $sfCampaignData['championOptInStatement'],
             championRef: $sfCampaignData['championRef'],
             charity: $charityHttpModel,
-            countries: $sfCampaignData['countries'], // @todo-SO-78 remove
             currencyCode: $campaign->getCurrencyCode() ?? '',
             donationCount: $this->donationRepository->countCompleteDonationsToCampaign($campaign),
             endDate: $this->formatDate($campaign->getEndDate()),

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -76,7 +76,6 @@ class TestCase extends PHPUnitTestCase
         'updates' => [],
         'solution' => 'do the saving',
         'bannerUri' => null,
-        'countries' => [0 => 'United Kingdom'],
         'locations' => [['countryName' => 'United Kingdom', 'regionCode' => null]],
         'isMatched' => true,
         'parentRef' => null,
@@ -162,7 +161,6 @@ class TestCase extends PHPUnitTestCase
         'bannerUri' => null,
         // These properties aren't actually used on MetaCampaign but it's only tests affected and
         // quicker to continue importing a shared type for now.
-        'countries' => [0 => 'United Kingdom',],
         'locations' => [['countryName' => 'United Kingdom', 'regionCode' => null]],
         'isMatched' => true,
         'parentRef' => null,


### PR DESCRIPTION
This is causing type errors in staging as SF is no longer supplying a countries key - countries are now part of 'locations'. FE develop is already not expecting to see countries - FE main does still need countries so we need to update FE main before merging this.