### PR TITLE
MAT-493 Support requesting command runs through CI, with consumers reading from the queue and running them

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,18 @@ orbs:
   jira: circleci/jira@2.2.0
   slack: circleci/slack@5.1.1
 
+parameters:
+  run_command:
+    type: boolean
+    default: false
+  command_environment:
+    type: enum
+    enum: ["regression", "staging", "production"]
+    default: "regression"
+  command_string:
+    type: string
+    default: "matchbot:tick"
+
 jobs:
   test: # Also lints first
     # Working directory must match docker-compose mount / Docker `COPY` for real Doctrine proxy
@@ -156,7 +168,52 @@ jobs:
 
       - store_artifacts:
           path: reports
+  publish-command:
+    parameters:
+      environment:
+        type: string
+      command_string:
+        type: string
+    docker:
+      - image: cimg/aws:2026.07.1
+    steps:
+      - aws-cli/setup:
+          aws_access_key_id: AWS_ACCESS_KEY_ID
+          aws_secret_access_key: AWS_SECRET_ACCESS_KEY
+      - run:
+          name: Publish Command to SQS
+          command: |
+            ENV="<< parameters.environment >>"
+            COMMAND="<< parameters.command_string >>"
+            COMMAND_LEN=${#COMMAND}
+
+            # High-priority queue has no suffix after `matchbot` apart from the `.fifo` which
+            # all first-in-first-out queues have.
+            # Name is defined in infrastructure repo but a real example is: tbg-staging-eu-west-1-matchbot.fifo
+            QUEUE_URL="https://sqs.${AWS_REGION}.amazonaws.com/${AWS_ACCOUNT_ID}/tbg-${ENV}-${AWS_REGION}-matchbot.fifo"
+
+            DEDUP_ID=$(date +%s)-$RANDOM
+
+            # Symfony Messenger PhpSerializer wraps the serialized PHP object in a JSON payload for SQS.
+            BODY="O:46:\"MatchBot\Application\Messenger\CommandRequest\":1:{s:7:\"command\";s:${COMMAND_LEN}:\"${COMMAND}\";}"
+            MESSAGE="{\"body\": \"$BODY\", \"headers\": {\"type\": \"MatchBot\\\\Application\\\\Messenger\\\\CommandRequest\"}}"
+
+            aws sqs send-message \
+              --queue-url "$QUEUE_URL" \
+              --message-body "$MESSAGE" \
+              --message-group-id "matchbot-cli" \
+              --message-deduplication-id "$DEDUP_ID"
+
 workflows:
+  run-command:
+    when: << pipeline.parameters.run_command >>
+    jobs:
+      - publish-command:
+          context:
+            - ecs-deploys
+          environment: << pipeline.parameters.command_environment >>
+          command_string: << pipeline.parameters.command_string >>
+
   build:
     jobs:
       - test:

--- a/app/dependencies.php
+++ b/app/dependencies.php
@@ -20,9 +20,11 @@ use MatchBot\Application\Auth;
 use MatchBot\Application\Auth\IdentityTokenService;
 use MatchBot\Application\Environment;
 use MatchBot\Application\Matching;
+use MatchBot\Application\Messenger\CommandRequest;
 use MatchBot\Application\Messenger\DonationMatchingShouldBeChecked;
 use MatchBot\Application\Messenger\DonationUpserted;
 use MatchBot\Application\Messenger\FundTotalUpdated;
+use MatchBot\Application\Messenger\Handler\CommandRequestHandler;
 use MatchBot\Application\Messenger\Handler\DonationMatchCheckHandler;
 use MatchBot\Application\Messenger\Handler\DonationUpsertedHandler;
 use MatchBot\Application\Messenger\Handler\FundTotalUpdatedHandler;
@@ -405,6 +407,7 @@ return function (ContainerBuilder $containerBuilder) {
                     // Outbound, priority, for MatchBot worker; SQS queue in Production.
                     // `CharityUpdated` does call out to Salesforce, to read data, but it's rarer and
                     // occasionally more time-sensitive than the group below which push data.
+                    CommandRequest::class => [Transports::TRANSPORT_HIGH_PRIORITY],
                     DonationMatchingShouldBeChecked::class => [Transports::TRANSPORT_HIGH_PRIORITY],
 
                     // Outbound, payout processing and Salesforce pushes (lower priority). For MatchBot worker; SQS
@@ -429,6 +432,7 @@ return function (ContainerBuilder $containerBuilder) {
             $handleMiddleware = new HandleMessageMiddleware(new HandlersLocator(
                 /** We lazy-load the handlers from the container to avoid circular dependencies. */
                 [
+                    CommandRequest::class => [fn($msg) => $c->get(CommandRequestHandler::class)($msg)],
                     DonationMatchingShouldBeChecked::class => [fn($msg) => $c->get(DonationMatchCheckHandler::class)($msg)],
                     Messages\Donation::class => [fn($msg) => $c->get(GiftAidResultHandler::class)($msg)],
                     Messages\Person::class => [fn($msg) => $c->get(PersonHandler::class)($msg)],

--- a/app/dependencies.php
+++ b/app/dependencies.php
@@ -432,7 +432,7 @@ return function (ContainerBuilder $containerBuilder) {
             $handleMiddleware = new HandleMessageMiddleware(new HandlersLocator(
                 /** We lazy-load the handlers from the container to avoid circular dependencies. */
                 [
-                    CommandRequest::class => [fn($msg) => $c->get(CommandRequestHandler::class)($msg)],
+                    CommandRequest::class => [fn(CommandRequest $msg) => $c->get(CommandRequestHandler::class)($msg)],
                     DonationMatchingShouldBeChecked::class => [fn($msg) => $c->get(DonationMatchCheckHandler::class)($msg)],
                     Messages\Donation::class => [fn($msg) => $c->get(GiftAidResultHandler::class)($msg)],
                     Messages\Person::class => [fn($msg) => $c->get(PersonHandler::class)($msg)],

--- a/integrationTests/RunConsoleCommandTest.php
+++ b/integrationTests/RunConsoleCommandTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace MatchBot\IntegrationTests;
+
+use MatchBot\Application\Commands\CallFrequentTasks;
+use MatchBot\Application\Commands\CancelStaleDonationFundTips;
+use MatchBot\Application\Commands\DeleteOldTestFunds;
+use MatchBot\Application\Commands\ExpireMatchFunds;
+use MatchBot\Application\Commands\ExpirePendingMandates;
+use MatchBot\Application\Commands\SendStatistics;
+use MatchBot\Application\Commands\UpdateApproxCampaignStatus;
+use MatchBot\Application\Commands\UpdateCampaignDonationStats;
+use MatchBot\Application\Commands\HandleOutOfSyncFunds;
+use MatchBot\Application\Messenger\CommandRequest;
+use MatchBot\Application\Messenger\Handler\CommandRequestHandler;
+use MatchBot\Tests\Application\Commands\AlwaysAvailableLockStore;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Exception\CommandNotFoundException;
+use Symfony\Component\Lock\LockFactory;
+use Prophecy\Argument;
+use Aws\CloudWatch\CloudWatchClient;
+use MatchBot\Application\Environment;
+use MatchBot\Domain\DonationRepository;
+use Symfony\Component\Clock\NativeClock;
+
+class RunConsoleCommandTest extends IntegrationTest
+{
+    public function testItRunsSupportedCommandAndFailsOnUnknown(): void
+    {
+        $lockFactory = new LockFactory(new AlwaysAvailableLockStore());
+        $app = $this->buildMinimalApp($lockFactory);
+
+        $tickCommand = new CallFrequentTasks();
+        $tickCommand->setApplication($app);
+        $tickCommand->setLockFactory($lockFactory);
+        $app->add($tickCommand);
+
+        $handler = new CommandRequestHandler($app);
+
+        // 1. Check supported command runs ok
+        $handler(new CommandRequest('matchbot:tick'));
+        // Continuing means it didn't throw. Explicit `assertTrue()` falls foul of phpstan rules.
+
+        // 2. Check supported command with argument runs ok
+        $handler(new CommandRequest('matchbot:handle-out-of-sync-funds check'));
+        // Continuing means it didn't throw. Explicit `assertTrue()` falls foul of phpstan rules.
+
+        // 3. Check unknown string fails and bails out
+        $this->expectException(CommandNotFoundException::class);
+        $this->expectExceptionMessage('Command "unknown-command" is not defined.');
+
+        $handler(new CommandRequest('unknown-command'));
+    }
+
+    private function buildMinimalApp(LockFactory $lockFactory): Application
+    {
+        $app = new Application();
+
+        $commands = [
+            new SendStatistics(
+                new NativeClock(),
+                $this->getMockCloudWatchClient(),
+                $this->getService(DonationRepository::class),
+                $this->getService(Environment::class),
+            ),
+            $this->getService(DeleteOldTestFunds::class),
+            $this->getService(ExpireMatchFunds::class),
+            $this->getService(CancelStaleDonationFundTips::class),
+            $this->getService(ExpirePendingMandates::class),
+            $this->getService(UpdateCampaignDonationStats::class),
+            $this->getService(UpdateApproxCampaignStatus::class),
+            $this->getService(HandleOutOfSyncFunds::class),
+        ];
+
+        foreach ($commands as $command) {
+            $command->setLockFactory($lockFactory);
+            $app->add($command);
+        }
+
+        return $app;
+    }
+
+    private function getMockCloudWatchClient(): CloudWatchClient
+    {
+        $cloudWatchClientProphecy = $this->prophesize(CloudWatchClient::class);
+        $cloudWatchClientProphecy->putMetricData(Argument::type('array'))->shouldBeCalled();
+
+        return $cloudWatchClientProphecy->reveal();
+    }
+}

--- a/integrationTests/RunConsoleCommandTest.php
+++ b/integrationTests/RunConsoleCommandTest.php
@@ -14,6 +14,8 @@ use MatchBot\Application\Commands\HandleOutOfSyncFunds;
 use MatchBot\Application\Messenger\CommandRequest;
 use MatchBot\Application\Messenger\Handler\CommandRequestHandler;
 use MatchBot\Tests\Application\Commands\AlwaysAvailableLockStore;
+use MatchBot\Tests\TestLogger;
+use Psr\Log\NullLogger;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
 use Symfony\Component\Lock\LockFactory;
@@ -22,6 +24,7 @@ use Aws\CloudWatch\CloudWatchClient;
 use MatchBot\Application\Environment;
 use MatchBot\Domain\DonationRepository;
 use Symfony\Component\Clock\NativeClock;
+use Symfony\Component\Notifier\ChatterInterface;
 
 class RunConsoleCommandTest extends IntegrationTest
 {
@@ -35,7 +38,12 @@ class RunConsoleCommandTest extends IntegrationTest
         $tickCommand->setLockFactory($lockFactory);
         $app->add($tickCommand);
 
-        $handler = new CommandRequestHandler($app);
+        $handler = new CommandRequestHandler(
+            consoleApplication: $app,
+            chatter: $this->createStub(ChatterInterface::class),
+            environment: Environment::Test,
+            logger: new NullLogger()
+        );
 
         // 1. Check supported command runs ok
         $handler(new CommandRequest('matchbot:tick'));

--- a/src/Application/Messenger/CommandRequest.php
+++ b/src/Application/Messenger/CommandRequest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace MatchBot\Application\Messenger;
+
+/**
+ * A queued request to invoke the Console app with the given command (and any arguments).
+ */
+class CommandRequest
+{
+    public function __construct(public string $command)
+    {
+    }
+}

--- a/src/Application/Messenger/Handler/CommandRequestHandler.php
+++ b/src/Application/Messenger/Handler/CommandRequestHandler.php
@@ -2,10 +2,18 @@
 
 namespace MatchBot\Application\Messenger\Handler;
 
+use MatchBot\Application\Environment;
 use MatchBot\Application\Messenger\CommandRequest;
+use Psr\Log\LoggerInterface;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Notifier\Bridge\Slack\Block\SlackHeaderBlock;
+use Symfony\Component\Notifier\Bridge\Slack\Block\SlackSectionBlock;
+use Symfony\Component\Notifier\Bridge\Slack\SlackOptions;
+use Symfony\Component\Notifier\ChatterInterface;
+use Symfony\Component\Notifier\Message\ChatMessage;
 
 /**
  * Takes the command string from a {@see CommandRequest} and gets Console to run it.
@@ -15,6 +23,9 @@ readonly class CommandRequestHandler
 {
     public function __construct(
         private \Symfony\Component\Console\Application $consoleApplication,
+        private readonly ChatterInterface $chatter,
+        private readonly Environment $environment,
+        private LoggerInterface $logger,
     ) {
     }
 
@@ -23,17 +34,54 @@ readonly class CommandRequestHandler
         $this->consoleApplication->setAutoExit(false);
         $this->consoleApplication->setCatchExceptions(false);
 
+        // No stamps because CircleCI handles the publish, so invent a UUID to uniquely identify
+        // the task when it ends.
+        $commandRunUuid = Uuid::uuid4()->toString();
+        $startedLog = sprintf(
+            '%s starting with ID %s for command %s',
+            __CLASS__,
+            $commandRunUuid,
+            $message->command,
+        );
+        $this->logger->info($startedLog);
+        $this->sendToSlack($startedLog);
+
         $exitCode = $this->consoleApplication->run(
             new StringInput($message->command),
             new ConsoleOutput()
         );
 
         if ($exitCode !== 0) {
-            throw new \RuntimeException(sprintf(
-                'Command "%s" failed with exit code %d.',
-                $message->command,
+            // Exception handler will also relay this one to Slack, to the env's alarms channel.
+            $this->logger->error(sprintf(
+                'Command run %s failed with exit code %d.',
+                $commandRunUuid,
                 $exitCode
             ));
         }
+
+        $statusAdjective = $exitCode === 0 ? ' successfully' : ' with errors (see alarm)';
+        $finishedLog = sprintf(
+            '%s finished %s with ID %s',
+            __CLASS__,
+            $statusAdjective,
+            $commandRunUuid,
+        );
+        $this->logger->info($finishedLog);
+        $this->sendToSlack($finishedLog);
+    }
+
+    private function sendToSlack(string $details): void
+    {
+        if ($this->environment === Environment::Test) {
+            return;
+        }
+
+        $chatMessage = new ChatMessage('Manual command run');
+        $options = (new SlackOptions())
+            ->block(new SlackHeaderBlock(sprintf('[%s] %s', $this->environment->name, 'Manual command run')))
+            ->block(new SlackSectionBlock()->text($details));
+        $chatMessage->options($options);
+        $this->chatter->send($chatMessage);
     }
 }

--- a/src/Application/Messenger/Handler/CommandRequestHandler.php
+++ b/src/Application/Messenger/Handler/CommandRequestHandler.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace MatchBot\Application\Messenger\Handler;
+
+use MatchBot\Application\Messenger\CommandRequest;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * Takes the command string from a {@see CommandRequest} and gets Console to run it.
+ */
+#[AsMessageHandler]
+readonly class CommandRequestHandler
+{
+    public function __construct(
+        private \Symfony\Component\Console\Application $consoleApplication,
+    ) {
+    }
+
+    public function __invoke(CommandRequest $message): void
+    {
+        $this->consoleApplication->setAutoExit(false);
+        $this->consoleApplication->setCatchExceptions(false);
+
+        $exitCode = $this->consoleApplication->run(
+            new StringInput($message->command),
+            new ConsoleOutput()
+        );
+
+        if ($exitCode !== 0) {
+            throw new \RuntimeException(sprintf(
+                'Command "%s" failed with exit code %d.',
+                $message->command,
+                $exitCode
+            ));
+        }
+    }
+}

--- a/src/Application/Messenger/MandateUpserted.php
+++ b/src/Application/Messenger/MandateUpserted.php
@@ -3,7 +3,6 @@
 namespace MatchBot\Application\Messenger;
 
 use MatchBot\Application\Assertion;
-use MatchBot\Domain\Donation;
 use MatchBot\Domain\DonorAccount;
 use MatchBot\Domain\RegularGivingMandate;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\MessageGroupAwareInterface;

--- a/src/Domain/CampaignService.php
+++ b/src/Domain/CampaignService.php
@@ -3,8 +3,6 @@
 namespace MatchBot\Domain;
 
 use Assert\AssertionFailedException;
-use Assert\InvalidArgumentException;
-use Assert\LazyAssertionException;
 use Doctrine\ORM\EntityManagerInterface;
 use MatchBot\Application\Assertion;
 use MatchBot\Application\Commands\UpdateCampaignDonationStats;


### PR DESCRIPTION
Mostly from collab with Copilot + Gemini 3.1 Pro.

Not quite ready to run live. `circleci` AWS user (or role) will need permission before we can actually publish to SQS directly like this, and our internal docs are still to update. But probably good to get a next review at this stage.

As it stands, observability would be through checking CloudWatch Logs somewhat proactively, e.g.
1. tail logs for the running relevant MB consumer service's tasks, or
2. search in CloudWatch Logs Insights for the specific command you invoked, to more quickly find the particular task and timestamp