### PR TITLE
Fix matchbot generating warning on missing campaign banner

### DIFF
--- a/src/Client/Campaign.php
+++ b/src/Client/Campaign.php
@@ -53,7 +53,7 @@ use MatchBot\Domain\MetaCampaignSlug;
  *     aims: list<string>,
  *     problem: ?string,
  *     solution: ?string,
- *     bannerUri: ?string,
+ *     bannerUri?: ?string,
  *     banner?: array{uri: string, alt_text: ?string}|null,
  *     amountRaised: float,
  *     summary: string,

--- a/src/Domain/CampaignService.php
+++ b/src/Domain/CampaignService.php
@@ -113,7 +113,7 @@ class CampaignService
             'categories' => $sfCampaignData['categories'],
             'locations' => $campaign->getLocationsForApi(),
             'championName' => $sfCampaignData['championName'],
-            'imageUri' => $sfCampaignData['bannerUri'],
+            'imageUri' => $sfCampaignData['bannerUri'] ?? null,
             'target' => $this->campaignTarget($campaign, $metaCampaign)->toMajorUnitFloat(),
             'parentUsesSharedFunds' => $metaCampaign && $metaCampaign->usesSharedFunds(),
             'parentRef' => $metaCampaign?->getSlug()->slug,

--- a/src/Domain/MetaCampaign.php
+++ b/src/Domain/MetaCampaign.php
@@ -190,7 +190,7 @@ class MetaCampaign extends SalesforceReadProxy
     {
         Assertion::true($data['isMetaCampaign'] ?? true);
 
-        $bannerUri = $data['bannerUri'];
+        $bannerUri = $data['bannerUri'] ?? null;
         $isRegularGiving = $data['isRegularGiving'] ?? null;
         Assertion::boolean($isRegularGiving);
 


### PR DESCRIPTION
May be the cause of reported empty metacampaign page in staging