### PR TITLE
BG2-3130: Fix missing banner displays

### DIFF
--- a/src/Domain/CampaignService.php
+++ b/src/Domain/CampaignService.php
@@ -113,7 +113,8 @@ class CampaignService
             'categories' => $sfCampaignData['categories'],
             'locations' => $campaign->getLocationsForApi(),
             'championName' => $sfCampaignData['championName'],
-            'imageUri' => $sfCampaignData['bannerUri'] ?? null,
+            'imageUri' => $sfCampaignData['bannerUri'] ?? $sfCampaignData['banner']['uri'] ?? null, // <- deprecated - FE should switch to using 'banner' instead once this is in prod..
+            'banner' => ['uri' => $sfCampaignData['banner']['uri'] ?? $sfCampaignData['bannerUri'] ?? null, 'alt_text' => $sfCampaignData['banner']['alt_text'] ?? null],
             'target' => $this->campaignTarget($campaign, $metaCampaign)->toMajorUnitFloat(),
             'parentUsesSharedFunds' => $metaCampaign && $metaCampaign->usesSharedFunds(),
             'parentRef' => $metaCampaign?->getSlug()->slug,

--- a/src/Domain/MetaCampaign.php
+++ b/src/Domain/MetaCampaign.php
@@ -190,7 +190,7 @@ class MetaCampaign extends SalesforceReadProxy
     {
         Assertion::true($data['isMetaCampaign'] ?? true);
 
-        $bannerUri = $data['bannerUri'] ?? null;
+        $bannerUri = $data['banner']['uri'] ?? $data['bannerUri'] ?? null;
         $isRegularGiving = $data['isRegularGiving'] ?? null;
         Assertion::boolean($isRegularGiving);
 


### PR DESCRIPTION
As discussed today on Slack, seeing that some new campaigns are not showing any banners in their summary cards, despite having banners that do show up on their detail pages.