### PR TITLE
MAT-496: Log PHP warnings & notices as errors but don't disrupt outpu…

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -40,8 +40,10 @@ $errorHandler = new HttpErrorHandler(
     $request,
 );
 
+$logger = $appContainer->get(LoggerInterface::class);
+
 // Create Shutdown Handler
-$shutdownHandler = new ShutdownHandler($request, $errorHandler, $displayErrorDetails);
+$shutdownHandler = new ShutdownHandler($request, $errorHandler, $displayErrorDetails, $logger);
 register_shutdown_function($shutdownHandler);
 
 // Add Routing Middleware

--- a/src/Application/Actions/Campaigns/Search.php
+++ b/src/Application/Actions/Campaigns/Search.php
@@ -6,6 +6,7 @@ use BcMath\Number;
 use Laminas\Diactoros\Response\JsonResponse;
 use MatchBot\Application\Actions\Action;
 use MatchBot\Application\Assertion;
+use MatchBot\Application\Environment;
 use MatchBot\Client\FindThatPostcode;
 use MatchBot\Client\PointOutsideUK;
 use MatchBot\Domain\Campaign;
@@ -69,6 +70,15 @@ class Search extends Action
         Assertion::string($sortDirection);
         Assertion::string($sortField);
         Assertion::nullOrString($term);
+
+        if (! Environment::current()->isProduction() && is_string($term) && \str_contains($term, 'issue-warning-please')) {
+            // send a search query including issue-warning-please to see how we handle PHP warnings. You can include other
+            // terms as well to make it match a campaign.
+            \trigger_error(
+                message: 'Testing how we handle warnings, you asked to issue-warning-please',
+                error_level: \E_USER_WARNING
+            );
+        }
 
         if (!\in_array($sortDirection, ['asc', 'desc'], true)) {
             throw new HttpBadRequestException($request, 'Unrecognised sort direction');

--- a/src/Application/Handlers/ShutdownHandler.php
+++ b/src/Application/Handlers/ShutdownHandler.php
@@ -6,6 +6,7 @@ namespace MatchBot\Application\Handlers;
 
 use JetBrains\PhpStorm\Pure;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Log\LoggerInterface;
 use Slim\Exception\HttpInternalServerErrorException;
 use Slim\ResponseEmitter;
 
@@ -15,7 +16,8 @@ class ShutdownHandler
     public function __construct(
         private Request $request,
         private HttpErrorHandler $errorHandler,
-        private bool $displayErrorDetails
+        private bool $displayErrorDetails,
+        private LoggerInterface $log,
     ) {
     }
 
@@ -28,42 +30,73 @@ class ShutdownHandler
             $errorLine = $error['line'];
             $errorMessage = $error['message'];
             $errorType = $error['type'];
-            $message = 'An error while processing your request. Please try again later.';
 
-            if ($this->displayErrorDetails) {
-                switch ($errorType) {
-                    case E_USER_ERROR:
-                        $message = "FATAL ERROR: {$errorMessage}. ";
-                        $message .= " on line {$errorLine} in file {$errorFile}.";
-                        break;
+            switch ($errorType) {
+                // I think in practice we may never hit these first two as
+                // they interrupt control flow so we don't get here, but included for completeness.
+                case E_USER_ERROR:
+                    $message = "FATAL USER ERROR: {$errorMessage}. ";
+                    $message .= " on line {$errorLine} in file {$errorFile}.";
+                    break;
 
-                    case E_USER_WARNING:
-                        $message = "WARNING: {$errorMessage}";
-                        break;
+                case E_ERROR:
+                    $message = "FATAL ERROR: {$errorMessage}. ";
+                    $message .= " on line {$errorLine} in file {$errorFile}.";
+                    break;
 
-                    case E_USER_NOTICE:
-                        $message = "NOTICE: {$errorMessage}";
-                        break;
+                case E_USER_WARNING:
+                    $message = "USER WARNING: {$errorMessage}";
+                    break;
 
-                    default:
-                        $message = "ERROR: {$errorMessage}";
-                        $message .= " on line {$errorLine} in file {$errorFile}.";
-                        break;
-                }
+                case E_WARNING:
+                    $message = "WARNING: {$errorMessage}";
+                    break;
+
+                case E_NOTICE:
+                    $message = "NOTICE: {$errorMessage}";
+                    break;
+
+                case E_USER_NOTICE:
+                    $message = "USER NOTICE: {$errorMessage}";
+                    break;
+
+                default:
+                    $message = "ERROR: {$errorMessage}";
+                    $message .= " on line {$errorLine} in file {$errorFile}.";
+                    break;
             }
 
-            // Skip emitting a shutdown response from native warnings on non-dev envs, since events like Redis
+            // Skip emitting a shutdown response or alarm from these connection warnings, since events like Redis
             // connection failures cause these. These are already logged and if error-like output is emitted
             // alongside `/ping`'s more helpful output, its response body is left malformatted.
-            $isServiceResolutionWarning = (
+            if (
+                (
                 $errorType === E_WARNING &&
                 str_contains($message, 'getaddrinfo failed: Name or service not known')
-            );
-            if ($isServiceResolutionWarning) {
+                )
+            ) {
                 return;
             }
 
-            $exception = new HttpInternalServerErrorException($this->request, $message);
+            // maybe just a warning or PHP notice but we log it as an error since it could indicate important
+            // info missing from the output, e.g. because we tried to read a field that didn't exist in data sent from
+            // SF or FE. If this proves too noisy we might have to change this to just logging as warnings.
+            $this->log->error($errorMessage);
+
+            if (\in_array(needle: $errorType, haystack: [\E_USER_WARNING, \E_WARNING, \E_NOTICE, \E_USER_NOTICE], strict: true)) {
+                // the output is probably better than nothing - if it wasn't, we would have had an error
+                // so we return here to avoid issuing output that will break JSON parsing by the frontend.
+
+                // A possible enhancement in future might be to include details of the error in a header or an additional
+                // key added to the JSON response so that frontend can choose to display it.
+
+                return;
+            }
+
+            $exception = new HttpInternalServerErrorException(
+                $this->request,
+                $this->displayErrorDetails ? $message : 'An error while processing your request. Please try again later.'
+            );
             $response = $this->errorHandler->__invoke(
                 $this->request,
                 $exception,

--- a/src/Domain/CampaignService.php
+++ b/src/Domain/CampaignService.php
@@ -92,6 +92,10 @@ class CampaignService
         $slug = $campaign->getMetaCampaignSlug();
         $metaCampaign = $slug ? $this->metaCampaignRepository->getBySlug($slug) : null;
 
+        if ($campaign->getCampaignName() === 'Save Barney\'s Keyboard 1') {
+            \trigger_error('Testing how we handle warnings', \E_USER_WARNING);
+        }
+
         return [
             'charity' => [
                 'id' => $campaign->getCharity()->getSalesforceId(),


### PR DESCRIPTION
…t to frontend

This is a reversal of the current system which outputs these to frontend, breaking JSON parsing, but does not log them.