### PR TITLE
BG2-3342: Exclude non-application charity campaigns missing funds from lists

### DIFF
--- a/src/Domain/Campaign.php
+++ b/src/Domain/Campaign.php
@@ -67,7 +67,9 @@ class Campaign extends SalesforceReadProxy
     protected string $currencyCode;
 
     /**
-     * Has this campaign been published to the public? Currently, corrosponds to a status of any of 'Preview, 'Active', or 'Expired' in SF.
+     * Has this campaign been published to the public? Currently corresponds to a status of any of 'Preview, 'Active', or 'Expired' in SF.
+     * However, not all campaigns with isPublished=true should actually be listed publicly - specifically we exclude
+     * campaigns that are set to be match-funded but currently have zero match funds.
      */
     #[ORM\Column]
     private(set) bool $isPublished;

--- a/src/Domain/CampaignRepository.php
+++ b/src/Domain/CampaignRepository.php
@@ -26,7 +26,7 @@ use function trim;
 class CampaignRepository extends SalesforceReadProxyRepository
 {
     private ClockInterface $clock;  // @phpstan-ignore property.uninitialized
-    private string $appStatusWhereClause = <<<DQL
+    private string $statusAndFundingWhereClause = <<<DQL
         (
             (campaign.metaCampaignSlug IS NULL AND (campaign.isMatched = 0 OR campaignStatistics.matchFundsTotal.amountInPence > 0))
             OR
@@ -382,7 +382,7 @@ class CampaignRepository extends SalesforceReadProxyRepository
              campaign.charity = :charity
              AND campaign.isPublished = true
              AND (campaignStatistics.donationSum.amountInPence > 0 OR campaign.endDate > :at OR campaign.endDate IS NULL)
-             AND {$this->appStatusWhereClause}
+             AND {$this->statusAndFundingWhereClause}
              ORDER BY approxStatusRank ASC, campaign.endDate ASC
             DQL
         );
@@ -404,7 +404,7 @@ class CampaignRepository extends SalesforceReadProxyRepository
             FROM MatchBot\Domain\Campaign campaign
             WHERE campaign.metaCampaignSlug = :slug
             AND campaign.isPublished = true
-            AND {$this->appStatusWhereClause}
+            AND {$this->statusAndFundingWhereClause}
         DQL
         );
 
@@ -563,7 +563,7 @@ class CampaignRepository extends SalesforceReadProxyRepository
             $qb->setParameter('now', $this->clock->now());
         }
 
-        $qb->andWhere($this->appStatusWhereClause);
+        $qb->andWhere($this->statusAndFundingWhereClause);
 
         if ($metaCampaignSlug !== null) {
             $qb->andWhere($qb->expr()->eq('campaign.metaCampaignSlug', ':metaCampaignSlug'));

--- a/src/Domain/CampaignRepository.php
+++ b/src/Domain/CampaignRepository.php
@@ -381,6 +381,7 @@ class CampaignRepository extends SalesforceReadProxyRepository
              AND campaign.isPublished = true
              AND (statistics.donationSum.amountInPence > 0 OR campaign.endDate > :at OR campaign.endDate IS NULL)
              AND {$this->appStatusWhereClause}
+             AND (campaign.metaCampaignSlug IS NOT null OR campaign.isMatched = 0 OR statistics.matchFundsTotal.amountInPence > 0)
              ORDER BY approxStatusRank ASC, campaign.endDate ASC
             DQL
         );

--- a/src/Domain/CampaignRepository.php
+++ b/src/Domain/CampaignRepository.php
@@ -28,8 +28,10 @@ class CampaignRepository extends SalesforceReadProxyRepository
     private ClockInterface $clock;  // @phpstan-ignore property.uninitialized
     private string $appStatusWhereClause = <<<DQL
         (
-            campaign.metaCampaignSlug IS NULL OR
+            (campaign.metaCampaignSlug IS NULL AND (campaign.isMatched = 0 OR campaignStatistics.matchFundsTotal.amountInPence > 0))
+            OR
             (
+                campaign.metaCampaignSlug IS NOT NULL AND
                 campaign.relatedApplicationStatus = 'Approved' AND
                 campaign.relatedApplicationCharityResponseToOffer = 'Accepted'
             )
@@ -370,18 +372,17 @@ class CampaignRepository extends SalesforceReadProxyRepository
             <<<DQL
             SELECT campaign,
             CASE
-                WHEN statistics.approxStatus = 'Active' THEN 0 
-                WHEN statistics.approxStatus = 'Expired' THEN 1
-                WHEN statistics.approxStatus = 'Preview' THEN 2
+                WHEN campaignStatistics.approxStatus = 'Active' THEN 0
+                WHEN campaignStatistics.approxStatus = 'Expired' THEN 1
+                WHEN campaignStatistics.approxStatus = 'Preview' THEN 2
                 ELSE 2 END AS HIDDEN approxStatusRank
             FROM MatchBot\Domain\Campaign campaign
-            JOIN campaign.campaignStatistics statistics
+            JOIN campaign.campaignStatistics campaignStatistics
             WHERE 
              campaign.charity = :charity
              AND campaign.isPublished = true
-             AND (statistics.donationSum.amountInPence > 0 OR campaign.endDate > :at OR campaign.endDate IS NULL)
+             AND (campaignStatistics.donationSum.amountInPence > 0 OR campaign.endDate > :at OR campaign.endDate IS NULL)
              AND {$this->appStatusWhereClause}
-             AND (campaign.metaCampaignSlug IS NOT null OR campaign.isMatched = 0 OR statistics.matchFundsTotal.amountInPence > 0)
              ORDER BY approxStatusRank ASC, campaign.endDate ASC
             DQL
         );

--- a/src/Domain/CampaignStatistics.php
+++ b/src/Domain/CampaignStatistics.php
@@ -66,7 +66,7 @@ class CampaignStatistics
     #[ORM\Embedded(columnPrefix: 'match_funds_used_')]
     private Money $matchFundsUsed;
 
-    /** Total of match funds still available ot use for donations to this campaign. Should be equal to
+    /** Total of match funds still available to use for donations to this campaign. Should be equal to
      * matchFundsTotal - matchFundsUsed.
      */
     #[ORM\Embedded(columnPrefix: 'match_funds_remaining_')]

--- a/src/Domain/CampaignStatistics.php
+++ b/src/Domain/CampaignStatistics.php
@@ -55,20 +55,25 @@ class CampaignStatistics
     #[ORM\Embedded(columnPrefix: 'donation_sum_')]
     private Money $donationSum;
 
-    /** Set on construct only for now */
+    /*
+     * Total of all match funds allocated to the campaign, shared or not, including funds
+     * that have already been matched to a donation as well as available funds.
+     **/
     #[ORM\Embedded(columnPrefix: 'match_funds_total_')]
     private Money $matchFundsTotal;
 
-    /** Set on construct and updated when donations change. */
+    /** Total of match funds that have been withdrawn for donations to this campaign. */
     #[ORM\Embedded(columnPrefix: 'match_funds_used_')]
     private Money $matchFundsUsed;
 
-    /** Set on construct and updated when donations change. */
+    /** Total of match funds still available ot use for donations to this campaign. Should be equal to
+     * matchFundsTotal - matchFundsUsed.
+     */
     #[ORM\Embedded(columnPrefix: 'match_funds_remaining_')]
     private Money $matchFundsRemaining;
 
     /**
-     * Set on construct and when donations change. Uses {@see Campaign::$totalFundraisingTarget} on each update.
+     * Uses {@see Campaign::$totalFundraisingTarget} on each update.
      * It's set to zero of the Campaign currency when the target is met, which also leads search to exclude the
      * Campaign when sorting by distance ascending.
      */


### PR DESCRIPTION
I think this covers everywhere that matchbot would present the campaign in a list for discovery: Search, explore, sitemap, and the charity page.

The charity themselves will still have access to the page via a link from their portal, and may or may not choose to share it.