### PR TITLE
BG2-3357: Add DB index hoping to speed up slow query

### DIFF
--- a/schema/Donation.sql
+++ b/schema/Donation.sql
@@ -77,6 +77,7 @@ CREATE TABLE `Donation` (
   KEY `updated_date_and_status` (`updatedAt`,`donationStatus`),
   KEY `pspCustomerId` (`pspCustomerId`),
   KEY `IDX_C893E3F66C1129CD` (`mandate_id`),
+  KEY `collectedAt` (`collectedAt`),
   CONSTRAINT `FK_C893E3F66C1129CD` FOREIGN KEY (`mandate_id`) REFERENCES `RegularGivingMandate` (`id`),
   CONSTRAINT `FK_C893E3F6F639F774` FOREIGN KEY (`campaign_id`) REFERENCES `Campaign` (`id`)
 )

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -37,6 +37,7 @@ use function sprintf;
 #[ORM\Index(name: 'updated_date_and_status', columns: ['updatedAt', 'donationStatus'])]
 #[ORM\Index(name: 'salesforcePushStatus', columns: ['salesforcePushStatus'])]
 #[ORM\Index(name: 'pspCustomerId', columns: ['pspCustomerId'])]
+#[ORM\Index(name: 'collectedAt', columns: ['collectedAt'])]
 #[ORM\Entity(repositoryClass: DoctrineDonationRepository::class)]
 #[ORM\HasLifecycleCallbacks]
 class Donation extends SalesforceWriteProxy

--- a/src/Migrations/Version20260806111212.php
+++ b/src/Migrations/Version20260806111212.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260806111212 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add index for Donation.collectedAt';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE INDEX collectedAt ON Donation (collectedAt)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX collectedAt ON Donation');
+    }
+}


### PR DESCRIPTION
This index should be used when running the query in DoctrineDonationRepository::countDonationsCollectedInMinuteTo that runs every minute and we've seen taking up to six seconds in regtest environment