### PR TITLE
MAT-488: Always use short reservation times for new donations

### DIFF
--- a/integrationTests/DonationRepositoryTest.php
+++ b/integrationTests/DonationRepositoryTest.php
@@ -122,10 +122,10 @@ class DonationRepositoryTest extends IntegrationTest
         $this->makeDonation($randomEmailAddress, $campaign, DonationStatus::Cancelled);
 
         $sut = $this->getService(DonationRepository::class);
-        $thirtyThreeMinsInFuture = (new \DateTimeImmutable('now'))->modify('+33 minute');
+        $sixMinsInFuture = (new \DateTimeImmutable('now'))->modify('+6 minute');
 
         // act
-        $expiredDonationsIDs = $sut->findWithExpiredMatching($thirtyThreeMinsInFuture);
+        $expiredDonationsIDs = $sut->findWithExpiredMatching($sixMinsInFuture);
         $expiredDonations = $sut->findBy(['uuid' => $expiredDonationsIDs]);
 
         // assert
@@ -196,6 +196,7 @@ class DonationRepositoryTest extends IntegrationTest
             campaign: $campaign,
             donorId: PersonId::nil()
         );
+        $oldPendingDonation->reserveFundsUntil(new \DateTimeImmutable()->add(new \DateInterval('PT5M')));
         if ($donationStatus === DonationStatus::Cancelled) {
             $oldPendingDonation->cancel();
         } else {

--- a/integrationTests/MatchFundsServiceTest.php
+++ b/integrationTests/MatchFundsServiceTest.php
@@ -115,7 +115,7 @@ class MatchFundsServiceTest extends IntegrationTest
             collected: true
         );
 
-        $this->donationService->enrollNewDonation($donation, attemptMatching: true, dispatchUpdateMessage: false, setReservationTime: true);
+        $this->donationService->enrollNewDonation($donation, attemptMatching: true, dispatchUpdateMessage: false);
 
         $fundsRemaining = $this->sut->getFundsRemainingForMetaCampaign($this->testMetaCampaign);
         $this->assertEquals(Money::fromPoundsGBP($expectedTotal), $fundsRemaining);
@@ -155,8 +155,8 @@ class MatchFundsServiceTest extends IntegrationTest
             collected: true
         );
 
-        $this->donationService->enrollNewDonation($donation1, attemptMatching: true, dispatchUpdateMessage: false, setReservationTime: true);
-        $this->donationService->enrollNewDonation($donation2, attemptMatching: true, dispatchUpdateMessage: false, setReservationTime: true);
+        $this->donationService->enrollNewDonation($donation1, attemptMatching: true, dispatchUpdateMessage: false);
+        $this->donationService->enrollNewDonation($donation2, attemptMatching: true, dispatchUpdateMessage: false);
 
         $fundsRemaining = $this->sut->getFundsRemainingForMetaCampaign($this->testMetaCampaign);
         $this->assertEquals(Money::fromPoundsGBP($expectedTotal), $fundsRemaining);

--- a/schema/Donation.sql
+++ b/schema/Donation.sql
@@ -78,6 +78,7 @@ CREATE TABLE `Donation` (
   KEY `pspCustomerId` (`pspCustomerId`),
   KEY `IDX_C893E3F66C1129CD` (`mandate_id`),
   KEY `collectedAt` (`collectedAt`),
+  KEY `fundsReservedUntil` (`fundsReservedUntil`),
   CONSTRAINT `FK_C893E3F66C1129CD` FOREIGN KEY (`mandate_id`) REFERENCES `RegularGivingMandate` (`id`),
   CONSTRAINT `FK_C893E3F6F639F774` FOREIGN KEY (`campaign_id`) REFERENCES `Campaign` (`id`)
 )

--- a/src/Application/Actions/Donations/Create.php
+++ b/src/Application/Actions/Donations/Create.php
@@ -78,8 +78,6 @@ class Create extends Action
 
         $body = (string) $request->getBody();
 
-        $setReservationTime = ($request->getQueryParams()['short-reservation'] ?? null) !== null;
-
         try {
             $donationData = $this->serializer->deserialize($body, DonationCreate::class, 'json');
         } catch (\TypeError | UnexpectedValueException | AssertionFailedException $exception) {
@@ -115,7 +113,6 @@ class Create extends Action
                 donationData: $donationData,
                 pspCustomerId: $pspCustomerId,
                 donorId: $donorId,
-                setReservationTime: $setReservationTime
             );
         } catch (RateLimitExceededException $e) {
             $retryDelaySeconds = ($e->getRetryAfter()->getTimestamp() - time());

--- a/src/Application/Commands/SetupTestMandate.php
+++ b/src/Application/Commands/SetupTestMandate.php
@@ -236,7 +236,7 @@ class SetupTestMandate extends LockingCommand
 
         $donation->preAuthorize($paymentDay);
 
-        $this->donationService->enrollNewDonation($donation, true, setReservationTime: true);
+        $this->donationService->enrollNewDonation($donation, true);
         $this->em->persist($donation);
     }
 }

--- a/src/Domain/DoctrineDonationRepository.php
+++ b/src/Domain/DoctrineDonationRepository.php
@@ -31,24 +31,13 @@ class DoctrineDonationRepository extends SalesforceProxyRepository implements Do
     #[\Override]
     public function findWithExpiredMatching(\DateTimeImmutable $now): array
     {
-        // and we only need to expire donations that were create AFTER this point, because if they were created at
-        // before it we would have already expired them in a previous run.
-        $expireAfter = $now->sub(new \DateInterval('PT1H'));
-
-        if ((int) $now->format('i') % 30 === 0) {
-            // once every 30 minutes, try expiring any older donations just in case they were missed, but it shouldn't
-            // really be necassary unless this stopped running for some reason.
-            $expireAfter = new \DateTimeImmutable('2025-08-05T00:00:00z');
-        }
-
         $query = $this->getEntityManager()->createQuery(<<<'DQL'
             SELECT d.uuid FROM MatchBot\Domain\Donation d
 
             -- Only select donations with 1+ FWs. We don't need any further info about the FWs.
             INNER JOIN d.fundingWithdrawals fw
             WHERE d.donationStatus IN (:expireWithStatuses)
-            AND (d.fundsReservedUntil is null OR d.fundsReservedUntil < :now)
-            AND d.createdAt > :expireAfter
+            AND d.fundsReservedUntil < :now
 
             -- First of a regular giving series is Pending during 3DS. If we ever make the timeout for
             -- that longer than the timeout for matching, we still want to ensure matching can't be
@@ -59,8 +48,7 @@ class DoctrineDonationRepository extends SalesforceProxyRepository implements Do
             DQL
         )
             ->setParameter('expireWithStatuses', [DonationStatus::Pending->value, DonationStatus::Cancelled->value])
-            ->setParameter('now', $now)
-            ->setParameter('expireAfter', $expireAfter);
+            ->setParameter('now', $now);
 
         // As this is used by the only regular task working with donations,
         // `ExpireMatchFunds`, it makes more sense to opt it out of result caching

--- a/src/Domain/DoctrineDonationRepository.php
+++ b/src/Domain/DoctrineDonationRepository.php
@@ -31,9 +31,6 @@ class DoctrineDonationRepository extends SalesforceProxyRepository implements Do
     #[\Override]
     public function findWithExpiredMatching(\DateTimeImmutable $now): array
     {
-        // we only expire donations that were created before this point.
-        $expireBefore = $now->sub(Donation::expiryInterval());
-
         // and we only need to expire donations that were create AFTER this point, because if they were created at
         // before it we would have already expired them in a previous run.
         $expireAfter = $now->sub(new \DateInterval('PT1H'));
@@ -50,7 +47,7 @@ class DoctrineDonationRepository extends SalesforceProxyRepository implements Do
             -- Only select donations with 1+ FWs. We don't need any further info about the FWs.
             INNER JOIN d.fundingWithdrawals fw
             WHERE d.donationStatus IN (:expireWithStatuses)
-            AND (d.createdAt < :expireBefore OR d.fundsReservedUntil is null OR d.fundsReservedUntil < :now)
+            AND (d.fundsReservedUntil is null OR d.fundsReservedUntil < :now)
             AND d.createdAt > :expireAfter
 
             -- First of a regular giving series is Pending during 3DS. If we ever make the timeout for
@@ -62,7 +59,6 @@ class DoctrineDonationRepository extends SalesforceProxyRepository implements Do
             DQL
         )
             ->setParameter('expireWithStatuses', [DonationStatus::Pending->value, DonationStatus::Cancelled->value])
-            ->setParameter('expireBefore', $expireBefore)
             ->setParameter('now', $now)
             ->setParameter('expireAfter', $expireAfter);
 

--- a/src/Domain/DoctrineDonationRepository.php
+++ b/src/Domain/DoctrineDonationRepository.php
@@ -50,7 +50,7 @@ class DoctrineDonationRepository extends SalesforceProxyRepository implements Do
             -- Only select donations with 1+ FWs. We don't need any further info about the FWs.
             INNER JOIN d.fundingWithdrawals fw
             WHERE d.donationStatus IN (:expireWithStatuses)
-            AND (d.createdAt < :expireBefore OR (d.fundsReservedUntil is not null AND d.fundsReservedUntil < :now))
+            AND (d.createdAt < :expireBefore OR d.fundsReservedUntil is null OR d.fundsReservedUntil < :now)
             AND d.createdAt > :expireAfter
 
             -- First of a regular giving series is Pending during 3DS. If we ever make the timeout for

--- a/src/Domain/Donation.php
+++ b/src/Domain/Donation.php
@@ -38,6 +38,7 @@ use function sprintf;
 #[ORM\Index(name: 'salesforcePushStatus', columns: ['salesforcePushStatus'])]
 #[ORM\Index(name: 'pspCustomerId', columns: ['pspCustomerId'])]
 #[ORM\Index(name: 'collectedAt', columns: ['collectedAt'])]
+#[ORM\Index(name: 'fundsReservedUntil', columns: ['fundsReservedUntil'])]
 #[ORM\Entity(repositoryClass: DoctrineDonationRepository::class)]
 #[ORM\HasLifecycleCallbacks]
 class Donation extends SalesforceWriteProxy

--- a/src/Domain/DonationService.php
+++ b/src/Domain/DonationService.php
@@ -133,16 +133,16 @@ class DonationService
      * @throws \MatchBot\Client\NotFoundException
      * @throws DbErrorPreventedMatch
      */
-    public function createDonation(DonationCreate $donationData, string $pspCustomerId, PersonId $donorId, bool $setReservationTime): Donation
+    public function createDonation(DonationCreate $donationData, string $pspCustomerId, PersonId $donorId): Donation
     {
         try {
-            return $this->doCreateDonation($pspCustomerId, $donationData, $donorId, setReservationTime: $setReservationTime);
+            return $this->doCreateDonation($pspCustomerId, $donationData, $donorId);
         } catch (RetryableException $exception) {
             /**
              * See notes on {@see self::enrollNewDonation} for EM side effect details.
              */
             $this->logger->warning("Error creating donation, will retry: " . $exception->getMessage());
-            return $this->doCreateDonation($pspCustomerId, $donationData, $donorId, setReservationTime: $setReservationTime);
+            return $this->doCreateDonation($pspCustomerId, $donationData, $donorId);
         }
     }
 
@@ -470,8 +470,6 @@ class DonationService
      * @param bool $attemptMatching Whether to use match funds. Match funds will be withdrawn based on
      *                              availability or donation amount, which ever is smaller.
      *
-     * @param bool $setReservationTime Whether to explicitly set how long to reserve funds for, expecting the client
-     *                                 to request an extension if required. Will always be true in future.
      * @throws CampaignNotOpen
      * @throws CharityAccountLacksNeededCapaiblities
      * @throws CouldNotMakeStripePaymentIntent
@@ -481,7 +479,7 @@ class DonationService
      * @throws WrongCampaignType
      * @throws NotFoundException
      */
-    public function enrollNewDonation(Donation $donation, bool $attemptMatching, bool $dispatchUpdateMessage = true, bool $setReservationTime = true): void
+    public function enrollNewDonation(Donation $donation, bool $attemptMatching, bool $dispatchUpdateMessage = true): void
     {
         $campaign = $donation->getCampaign();
 
@@ -511,9 +509,7 @@ class DonationService
 
         $fiveMinutes = new \DateInterval('PT5M');
 
-        if ($setReservationTime) {
-            $donation->reserveFundsUntil($this->clock->now()->add($fiveMinutes));
-        }
+        $donation->reserveFundsUntil($this->clock->now()->add($fiveMinutes));
 
         $this->entityManager->commit();
 
@@ -1060,9 +1056,6 @@ class DonationService
      * @param string $pspCustomerId
      * @param DonationCreate $donationData
      * @param PersonId $donorId
-     * @param bool $setReservationTime Whether to explicitly set how long to reserve funds for, expecting the client
-     *                                  to request an extension if required. Will always be true in future.
-     *
      * @return Donation
      * @throws CampaignNotOpen
      * @throws CharityAccountLacksNeededCapaiblities
@@ -1074,7 +1067,7 @@ class DonationService
      * @throws StripeAccountIdNotSetForAccount
      * @throws WrongCampaignType
      */
-    public function doCreateDonation(string $pspCustomerId, DonationCreate $donationData, PersonId $donorId, bool $setReservationTime): Donation
+    public function doCreateDonation(string $pspCustomerId, DonationCreate $donationData, PersonId $donorId): Donation
     {
         $this->creationRateLimiterFactory->create(key: $pspCustomerId)->consume()->ensureAccepted();
 
@@ -1099,7 +1092,7 @@ class DonationService
             throw new CampaignNotOpen("Campaign {$donation->getCampaign()->getSalesforceId()} is not open");
         }
 
-        $this->enrollNewDonation($donation, attemptMatching: true, setReservationTime: $setReservationTime);
+        $this->enrollNewDonation($donation, attemptMatching: true);
 
         return $donation;
     }

--- a/src/Domain/RegularGivingService.php
+++ b/src/Domain/RegularGivingService.php
@@ -380,7 +380,6 @@ readonly class RegularGivingService
                 donation: $donation,
                 attemptMatching: $mandate->isMatched(),
                 dispatchUpdateMessage: false,
-                setReservationTime: true
             );
             if (!$donation->isFullyMatched() && $mandate->isMatched()) {
                 /** @psalm-suppress RedundantCondition - not redundant for PHPStan */

--- a/src/Migrations/Version20260807155511.php
+++ b/src/Migrations/Version20260807155511.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatchBot\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260807155511 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add index for Donation.fundsReservedUntil as its used in a WHERE clause';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE INDEX fundsReservedUntil ON Donation (fundsReservedUntil)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX fundsReservedUntil ON Donation');
+    }
+}

--- a/tests/Domain/DonationServiceTest.php
+++ b/tests/Domain/DonationServiceTest.php
@@ -127,7 +127,7 @@ class DonationServiceTest extends TestCase
 
         $this->expectException(CharityAccountLacksNeededCapaiblities::class);
 
-        $this->sut->createDonation($donationCreate, self::CUSTOMER_ID, PersonId::nil(), true);
+        $this->sut->createDonation($donationCreate, self::CUSTOMER_ID, PersonId::nil());
     }
 
     public function testInitialPersistRunsOutOfRetries(): void
@@ -148,7 +148,7 @@ class DonationServiceTest extends TestCase
             ->willReturn($this->prophesize(\Stripe\PaymentIntent::class)->reveal());
 
         try {
-            $this->sut->createDonation($donationCreate, self::CUSTOMER_ID, PersonId::nil(), true);
+            $this->sut->createDonation($donationCreate, self::CUSTOMER_ID, PersonId::nil());
             $this->fail('Should have thrown LockWaitTimeoutException');
         } catch (LockWaitTimeoutException) {
             // pass – in app context, final exception will be surfaced as an error to Slack etc.

--- a/tests/Domain/RegularGivingServiceTest.php
+++ b/tests/Domain/RegularGivingServiceTest.php
@@ -112,7 +112,7 @@ class RegularGivingServiceTest extends TestCase
         $this->campaignFunding = $this->createStub(CampaignFunding::class);
 
         $testCase = $this;
-        $this->donationServiceProphecy->enrollNewDonation(Argument::type(Donation::class), true, false, true)
+        $this->donationServiceProphecy->enrollNewDonation(Argument::type(Donation::class), true, false)
             ->will(/**
              * @param Donation[] $args
              */
@@ -347,7 +347,7 @@ class RegularGivingServiceTest extends TestCase
         $testCase = $this;
         /** @var Donation[] $donations */
         $donations = [];
-        $this->donationServiceProphecy->enrollNewDonation(Argument::type(Donation::class), true, false, true)
+        $this->donationServiceProphecy->enrollNewDonation(Argument::type(Donation::class), true, false)
             ->will(/**
              * @param Donation[] $args
              */
@@ -551,7 +551,7 @@ class RegularGivingServiceTest extends TestCase
         $this->donorAccount->setHomeAddressLine1('Existing address');
 
         $regularGivingService = $this->makeSut(new \DateTimeImmutable('2024-11-29T05:59:59 GMT'));
-        $this->donationServiceProphecy->enrollNewDonation(Argument::type(Donation::class), true, false, true)->willThrow(CampaignNotOpen::class);
+        $this->donationServiceProphecy->enrollNewDonation(Argument::type(Donation::class), true, false)->willThrow(CampaignNotOpen::class);
         $this->donationServiceProphecy->cancel(Argument::type(Donation::class))->shouldBeCalled();
 
         try {


### PR DESCRIPTION
This was optional previously just to account for donations from old versions of donate frontend, but as those versions of donate-frontend have been out of prod for hours those donations will have had their matching expire by now anyway.