### PR TITLE
MAT-497 Remove * from Campaign search terms

### DIFF
--- a/integrationTests/CampaignRepositoryTest.php
+++ b/integrationTests/CampaignRepositoryTest.php
@@ -122,7 +122,7 @@ class CampaignRepositoryTest extends IntegrationTest
      *
      * @return void
      */
-    public function testSearchQueriesAgainstResults(string $query, array $expectedResultsWithNewSearch)
+    public function testSearchQueriesAgainstResults(string $query, array $expectedResultsWithNewSearch): void
     {
         $sut = $this->getService(CampaignRepository::class);
 
@@ -300,6 +300,10 @@ class CampaignRepositoryTest extends IntegrationTest
     public function searchQueriesAgainstResultsProvider(): array
     {
         return [
+            [
+                '*',
+                [], // No results but verify it doesn't crash.
+            ],
             [
                 'Porridge and Juice',
                 [['Charity Name', 'Campaign Two is for Porridge and Juice']],

--- a/src/Domain/CampaignRepository.php
+++ b/src/Domain/CampaignRepository.php
@@ -600,6 +600,11 @@ class CampaignRepository extends SalesforceReadProxyRepository
             // Charity.normalisedName
             $termWithoutApostrophes = preg_replace("/['`‘’]+/u", '', $term);
 
+            // MySQL FTS parser throws a syntax error if term has only asterisks.
+            // (They're also not wildcards with NATURAL LANGUAGE MODE.)
+            \assert($termWithoutApostrophes !== null);
+            $termWithoutApostrophes = str_replace('*', ' ', $termWithoutApostrophes);
+
             /** @var list<int> $ids */
             $ids = $this->getEntityManager()->getConnection()->fetchFirstColumn(
                 'SELECT Campaign.id,


### PR DESCRIPTION
This would not have been working well as a user-defined wildcard anyway and could lead to crashes.

Problem identification & the main code fix itself (excluding `\assert` & comment wording) is from passing logs to Copilot / Gemini.