### PR TITLE
BG2-3354: WIP - return counts of campaigns per location with search results for UK

### DIFF
--- a/integrationTests/CampaignRepositoryTest.php
+++ b/integrationTests/CampaignRepositoryTest.php
@@ -86,7 +86,7 @@ class CampaignRepositoryTest extends IntegrationTest
                 'categories' => 'Food',
             ],
             term: 'Porridge',
-        );
+        )->campaigns;
 
         // assert
         $this->assertCount(1, $result);
@@ -111,7 +111,7 @@ class CampaignRepositoryTest extends IntegrationTest
                 'invalid-field!' => 'value'
             ],
             term: null,
-        );
+        )->campaigns;
     }
 
     /**
@@ -138,7 +138,7 @@ class CampaignRepositoryTest extends IntegrationTest
             fundSlug: null,
             jsonMatchInListConditions: [],
             term: $query,
-        );
+        )->campaigns;
 
         $newSearchNames = array_map(fn(Campaign $campaign) => [$campaign->getCharity()->getName(), $campaign->getCampaignName()], $resultsWithNewSearch);
 
@@ -180,7 +180,7 @@ class CampaignRepositoryTest extends IntegrationTest
             fundSlug: null,
             jsonMatchInListConditions: [],
             term: null,
-        );
+        )->campaigns;
 
         $returnCampaignNames = array_map(
             static fn(Campaign $campaign) => $campaign->getCampaignName(),

--- a/integrationTests/SearchByLocationTest.php
+++ b/integrationTests/SearchByLocationTest.php
@@ -124,7 +124,7 @@ class SearchByLocationTest extends IntegrationTest
             fundSlug: null,
             jsonMatchInListConditions: [],
             term: null,
-        );
+        )->campaigns;
 
         $returnCampaignNames = array_map(
             static fn(Campaign $campaign) => $campaign->getCampaignName(),

--- a/src/Application/Actions/Campaigns/Search.php
+++ b/src/Application/Actions/Campaigns/Search.php
@@ -113,7 +113,7 @@ class Search extends Action
 
         try {
             /** @psalm-suppress ArgumentTypeCoercion */
-            $campaigns = $this->campaignRepository->search(
+            $searchResult = $this->campaignRepository->search(
                 sortField: $sortField, // @mago-expect analysis:possibly-invalid-argument (search function will throw safely if given invalid arg)
                 sortDirection: $sortDirection,
                 offset: (int)($params['offset'] ?? 0),
@@ -138,12 +138,15 @@ class Search extends Action
          *
          * @var list<array<string, mixed>>
          */
-        $campaignSummaries = \array_filter($campaigns->campaigns, static fn(Campaign $c) => !$c->isSfDataMissing())
+        $campaignSummaries = \array_filter($searchResult->campaigns, static fn(Campaign $c) => !$c->isSfDataMissing())
                 |> \array_values(...)
                 |> (fn(array $campaignsWithSfData): array => \array_map($this->campaignService->renderCampaignSummary(...), $campaignsWithSfData));
 
         return new JsonResponse(
-            ['campaignSummaries' => $campaignSummaries],
+            [
+                'campaignSummaries' => $campaignSummaries,
+                'locationCounts' => $searchResult->locationCounts,
+            ],
             200
         );
     }

--- a/src/Application/Actions/Campaigns/Search.php
+++ b/src/Application/Actions/Campaigns/Search.php
@@ -135,11 +135,16 @@ class Search extends Action
          *
          * Have to then pass through array_values to make sure it produces a JSON array as needed by FE not a JSON
          * object - any missing keys (other than at the end of the list) will make PHP output it as an object.
+         *
+         * @var list<array<string, mixed>>
          */
-        return
-            \array_filter($campaigns, static fn(Campaign $c) => ! $c->isSfDataMissing())
-            |> \array_values(...)
-            |> (fn(array $campaignsWithSfData) => \array_map($this->campaignService->renderCampaignSummary(...), $campaignsWithSfData))
-            |> (fn(array $campaignSummaries) => new JsonResponse(['campaignSummaries' => $campaignSummaries], 200));
+        $campaignSummaries = \array_filter($campaigns->campaigns, static fn(Campaign $c) => !$c->isSfDataMissing())
+                |> \array_values(...)
+                |> (fn(array $campaignsWithSfData): array => \array_map($this->campaignService->renderCampaignSummary(...), $campaignsWithSfData));
+
+        return new JsonResponse(
+            ['campaignSummaries' => $campaignSummaries],
+            200
+        );
     }
 }

--- a/src/Application/Actions/Sitemap.php
+++ b/src/Application/Actions/Sitemap.php
@@ -50,7 +50,7 @@ class Sitemap extends Action
             fundSlug: null,
             jsonMatchInListConditions: [],
             term:null,
-        );
+        )->campaigns;
 
         foreach ($campaigns as $campaign) {
             $endsInFuture = $campaign->getEndDate() > $this->clock->now();

--- a/src/Domain/CampaignRepository.php
+++ b/src/Domain/CampaignRepository.php
@@ -789,6 +789,46 @@ class CampaignRepository extends SalesforceReadProxyRepository
             forInternalUpdate: $forInternalUpdate,
         );
 
+        if ($country === 'United Kingdom' && ! Environment::current()->isProduction()) {
+            // also fetch a count of how many relevent campaigns have
+            // locations each major part of the UK.
+//
+//            $locationCountQueryBuilder = $this->getEntityManager()->createQuery(
+//                <<<DQL
+//                    SELECT COUNT(cl), cl.regionCode FROM MatchBot\Domain\CampaignLocation cl
+//                    WHERE cl.campaign IN (
+//                        SELECT -- here we would need to repliacte the search logic of filterForSearch but keeping all that twice seems very risky.
+//                        -- I don't think we can just call it as-is even if we start using a querybuilder here since we're trying to get a list of
+//                        -- locations not a list of campaings.
+//                        -- Possibly we could keep it as a function that generates a string and include it in both queries.
+//                    )
+//                    GROUP BY cl.regionCode
+//                DQL
+//            );
+
+//            $locationCounts = $locationCountQueryBuilder->getResult();
+
+            // fpr now just returning dummy counts to allow developing the FE display and validating the HTTP API.
+            $locationCounts = [
+                /*
+                 * Leaving these and the other Eight major divisons of England out for now, although
+                 * potentially we could include them as if at the top level of UK since some of them have comparable
+                 * populations to the other entire nations.
+                 *
+                'E12000008' => 1000, // South East England
+                'E12000009' => 1001, // South West England
+                'E12000002' => 1002, // North West England
+                */
+                'E92000001' => 1003, // England
+                'S92000003' => 1004, // Scotland
+                'W92000004' => 1005, // Wales
+                'N92000002' => 1006 // Northern Ireland
+
+            ];
+        } else {
+            $locationCounts = [];
+        }
+
         $this->sortForSearch(
             qb: $qb,
             applyPinSort: $jsonMatchInListConditions === [],
@@ -804,7 +844,7 @@ class CampaignRepository extends SalesforceReadProxyRepository
         /** @var list<Campaign> $result */
         $result = $query->getResult();
 
-        return new CampaignSearchResult($result);
+        return new CampaignSearchResult(campaigns: $result, locationCounts: $locationCounts);
     }
 
     public static function getRegulatorHMRCIdentifier(string $regulatorName): ?string

--- a/src/Domain/CampaignRepository.php
+++ b/src/Domain/CampaignRepository.php
@@ -145,7 +145,7 @@ class CampaignRepository extends SalesforceReadProxyRepository
             jsonMatchInListConditions: [],
             term: null,
             forInternalUpdate: true, // Don't skip non-isPublished ones etc.
-        );
+        )->campaigns;
 
         $campaignIds = array_map(function (Campaign $campaign) {
             return Salesforce18Id::ofCampaign($campaign->getSalesforceId());
@@ -722,7 +722,6 @@ class CampaignRepository extends SalesforceReadProxyRepository
      * @psalm-suppress DocblockTypeContradiction
      * @mago-expect lint:excessive-parameter-list - consider reducing parameter list
      *
-     * @return list<Campaign>
      */
     public function search(
         string $sortField,
@@ -736,7 +735,7 @@ class CampaignRepository extends SalesforceReadProxyRepository
         ?string $country = null,
         ?array $regions = [],
         bool $forInternalUpdate = false,
-    ): array {
+    ): CampaignSearchResult {
         $qb = $this->getEntityManager()->createQueryBuilder();
 
         $safeSortField = match ($sortField) {
@@ -805,7 +804,7 @@ class CampaignRepository extends SalesforceReadProxyRepository
         /** @var list<Campaign> $result */
         $result = $query->getResult();
 
-        return $result;
+        return new CampaignSearchResult($result);
     }
 
     public static function getRegulatorHMRCIdentifier(string $regulatorName): ?string

--- a/src/Domain/CampaignSearchResult.php
+++ b/src/Domain/CampaignSearchResult.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace MatchBot\Domain;
+
+/**
+ * Currently just a wrapper around a list of campaigns, but intended to expand to include statistics on the result
+ * (without considering the limit), that can be displayed alongside the list of campaigns. E.g. on the map of the UK.
+ */
+readonly class CampaignSearchResult
+{
+    /**
+     * @param list<Campaign> $campaigns
+     */
+    public function __construct(public array $campaigns)
+    {
+    }
+}

--- a/src/Domain/CampaignSearchResult.php
+++ b/src/Domain/CampaignSearchResult.php
@@ -9,9 +9,12 @@ namespace MatchBot\Domain;
 readonly class CampaignSearchResult
 {
     /**
-     * @param list<Campaign> $campaigns
+     * @param list<Campaign> $campaigns List of campaigns in this page of search results.
+     *
+     * @param array<string, int> $locationCounts Count of how many campaigns have impact in
+     * each given region within the UK, for map display.
      */
-    public function __construct(public array $campaigns)
+    public function __construct(public array $campaigns, public array $locationCounts = [])
     {
     }
 }

--- a/tests/Application/Actions/SitemapTest.php
+++ b/tests/Application/Actions/SitemapTest.php
@@ -7,6 +7,7 @@ use Laminas\Diactoros\Response;
 use MatchBot\Application\Actions\Sitemap;
 use MatchBot\Application\Environment;
 use MatchBot\Domain\CampaignRepository;
+use MatchBot\Domain\CampaignSearchResult;
 use MatchBot\Domain\MetaCampaignRepository;
 use MatchBot\Domain\MetaCampaignSlug;
 use MatchBot\Domain\Salesforce18Id;
@@ -33,9 +34,9 @@ class SitemapTest extends TestCase
             null,
             [],
             null,
-        )->willReturn([
+        )->willReturn(new CampaignSearchResult(campaigns: [
             self::someCampaign(sfId: Salesforce18Id::ofCampaign('000000000000000000')),
-        ]);
+        ]));
 
         $metaCampaignRepositoryProphecy->allToIncludeInSitemap($now)->willReturn([
             $this->someMetaCampaign(false, false, slug: MetaCampaignSlug::of('this-is-the-metacampaign-slug')),


### PR DESCRIPTION
This should allow adding further properties to the object for statistics about the result as a whole - like the count of how many matching campaigns there are in in total and in each geographical region.